### PR TITLE
Fix typo in normalize

### DIFF
--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -34,7 +34,7 @@ var normalize = module.exports = {
       delete criteria.where;
       delete criteria.limit;
       delete criteria.skip;
-      delete criteria.skip;
+      delete criteria.sort;
       criteria = {
         where: criteria
       };


### PR DESCRIPTION
Was glancing over the code, and figured I would get my +-1 line into the code base.

Removed the second delete on `criteria.skip` and replaced with `criteria.sort`. All tests still passing.
