### PR TITLE
Fix uppercase type casting issues

### DIFF
--- a/lib/waterline/core/typeCast.js
+++ b/lib/waterline/core/typeCast.js
@@ -38,6 +38,7 @@ Cast.prototype.initialize = function(attributes) {
   Object.keys(attributes).forEach(function(key) {
 
     var type = attributes[key].type ? attributes[key].type : attributes[key];
+    if(typeof type === 'string') type = type.toLowerCase();
 
     // Check if type is in the supported list, if not it's probally
     // a validation type so set it as a string

--- a/test/unit/core/core.cast.js
+++ b/test/unit/core/core.cast.js
@@ -30,6 +30,35 @@ describe('Core Type Casting', function() {
       assert(typeof values.age === 'number');
       assert(values.age === 27);
     });
-
   });
+
+  describe('.cast() with model attributes and uppercase types', function() {
+    var person;
+
+    before(function() {
+      var Person = Core.extend({
+        attributes: {
+          name: {
+            type: 'STRING'
+          },
+          age: {
+            type: 'INTEGER'
+          }
+        }
+      });
+
+      person = new Person();
+    });
+
+    it('should cast values to proper types', function() {
+      var values = person._cast.run({ name: '27', age: '27' });
+
+      assert(typeof values.name === 'string');
+      assert(values.name === '27');
+
+      assert(typeof values.age === 'number');
+      assert(values.age === 27);
+    });
+  });
+
 });


### PR DESCRIPTION
Normalize all types to their lowercase counterpart, this should fix casting problems when initializing schema attributes with uppercase types. This change should close issue #42.

Something to look into would be filtering out all function attributes before they are iterated over by schema/validation/cast objects, but I might not be understanding how model functions are accommodated.
