### PR TITLE
Changes next() to cb() in example and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ var User = Waterline.Collection.extend({
       if(err) return next(err);
 
       self.password = password;
-      next();
+      cb();
     });
   },
 

--- a/example/models/User.js
+++ b/example/models/User.js
@@ -81,11 +81,11 @@ var User = Waterline.Model.extend({
 
   beforeCreate: function(values, cb) {
     encrypt(values.password, function(err, password) {
-      if(err) return next(err);
+      if(err) return cb(err);
 
       delete values.password;
       values.secure_password = password;
-      next();
+      cb();
     });
   }
 


### PR DESCRIPTION
Hey,

I was playing around with SailsJS and trying to get the beforeSave/beforeCreate callbacks to work and they kept erroring on `next()`. After a little bit of snooping I found it is suppose to be `cb()` so to prevent other peoples confusion I have fixed up the two areas.
