### PR TITLE
Instead of rebuilding validation errors received from anchor, pass them along to preserve more information about errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.jshintrc
+.editorconfig

--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -122,14 +122,7 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
     // If No Error return
     if(!err) return cb();
 
-    // Build an Error Object
-    errors[validation] = [];
-
-    err.forEach(function(obj) {
-      if(obj.property) delete obj.property;
-      errors[validation].push({ rule: obj.rule, message: obj.message });
-    });
-
+    errors[validation] = err;
     return cb();
   }
 


### PR DESCRIPTION
Since waterline rebuilds validation errors received from anchor, it loses some very important information such as parameters to validation.
For example, if you want to make a custom error message like "password must be at least {{minLength}} characters long", then you need min parameter to the minLength validator.
These parameters to each validations are available until waterline's validation.js removes them.
These are very crucial information to build user friendly error messages.

I think the best thing to do is to pass along the validation errors from anchor.
If the errors are not formatted correctly, then fix them in the anchor, not waterline.
