### PR TITLE
Correct utils.normalize to always properly format the WHERE parameter

### DIFF
--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -27,22 +27,40 @@ var normalize = module.exports = {
     // Return string to indicate an error
     if(!_.isObject(criteria)) throw new Error('Invalid options/criteria :: ' + criteria);
 
-    // If criteria doesn't seem to contain operational keys, assume all the keys are criteria
-    if(!criteria.where && !criteria.limit && !criteria.skip
-       && !criteria.sort && !criteria.sum && !criteria.average
-       && !criteria.groupBy && !criteria.min && !criteria.max) {
-
-      // Delete any residuals and then use the remaining keys as attributes in a criteria query
-      delete criteria.where;
+    // Restructure criteria to format WHERE if it was not already defined
+    if (!criteria.where) {
       delete criteria.limit;
       delete criteria.skip;
       delete criteria.sort;
-      criteria = {
-        where: criteria
-      };
+      delete criteria.sum;
+      delete criteria.average;
+      delete criteria.groupBy;
+      delete criteria.min;
+      delete criteria.max;
+      if (_.keys(criteria).length !== 0) {
+        criteria = {
+          where: criteria
+        };
+      }
+      if (_.isObject(origCriteria)) {
+        if (origCriteria.limit)
+          criteria.limit = origCriteria.limit;
+        if (origCriteria.skip)
+          criteria.skip = origCriteria.skip;
+        if (origCriteria.sort)
+          criteria.sort = origCriteria.sort;
+        if (origCriteria.sum)
+          criteria.sum = origCriteria.sum;
+        if (origCriteria.average)
+          criteria.average = origCriteria.average;
+        if (origCriteria.groupBy)
+          criteria.groupBy = origCriteria.groupBy;
+        if (origCriteria.min)
+          criteria.min = origCriteria.min;
+        if (origCriteria.max)
+          criteria.max = origCriteria.max;
+      }
     }
-    // If where is null, turn it into an object
-    else if(_.isNull(criteria.where)) criteria.where = {};
 
     // If WHERE is {}, always change it back to null
     if(criteria.where && _.keys(criteria.where).length === 0) {


### PR DESCRIPTION
utils.normalize did not properly format the WHERE parameter if any of the other options were specified since this caused the formatting of the WHERE parameter to be skipped.  For example, if you specified the find options as shown here:

Accounts.find({ type: "free", sort: "id ASC" }, fn);

The WHERE parameter { type: "free" } was not created and the query returned all of the account records.  This change corrects the issue.
