### PR TITLE
Populate: Pass alias attribute

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -65,6 +65,7 @@ Deferred.prototype.populate = function(keyName) {
     child: attr.references,
     childKey: attr.on,
     select: true,
+    alias:keyName,
     removeParentKey: parentKey.model ? true : false
   };
 


### PR DESCRIPTION
I think, that populate should be passing aliases to joins. Aliases should be equal to model attribute name not the related model name.

Example:

Model User

``` javascript
{
"attribute_name":{"model":"Group"}
}

User.populate('attribute_name')
```

Returns

``` javascript
{"group":{data..}}
```

Should return

``` javascript
{"attribute_name":{data..}}
```

Hope you get me.. You'll find sails-mysql part over [here](https://github.com/just-paja/sails-mysql/compare/balderdashy:associations...associations).

I woul like this to be more like .. asking for opinion than a pull request. So, what do you think?
