### PR TITLE
Add .select method to deffered and pass it as criteria

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -57,6 +57,13 @@ Deferred.prototype.limit = function(limit) {
   return this;
 };
 
+
+Deferred.prototype.select = function() {
+  this._criteria.select = Array.prototype.slice.call(arguments);
+
+  return this;
+};
+
 /**
  * Add a Skip clause to the criteria object
  *

--- a/test/unit/query/query.find.js
+++ b/test/unit/query/query.find.js
@@ -53,6 +53,7 @@ describe('Collection Query', function() {
 
     it('should allow a query to be built using deferreds', function(done) {
       query.find()
+      .select('id', 'name')
       .where({ name: 'Foo Bar' })
       .where({ id: { '>': 1 } })
       .limit(1)


### PR DESCRIPTION
I made this method to allow call .select in a find object to allow select which field would be retrieved. Each adapter must implement the select feature by its own which is passed in criteria. If not implement in adapter the method won't do anything.