### PR TITLE
Added pagination to deferred

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -71,6 +71,32 @@ Deferred.prototype.skip = function(skip) {
 };
 
 /**
+ * Add a Paginate clause to the criteria object
+ *
+ * This is syntatical sugar that calls skip and
+ * limit from a single function.
+ *
+ * @param {Object} page and limit
+ * @return this
+ */
+Deferred.prototype.paginate = function(options) {
+  if(options == undefined) var options = {page: 0, limit: 0};
+  
+  var page  = options.page  || 0,
+      limit = options.limit || 0,
+      skip  = 0;
+
+  if (page > 0 && limit == 0) skip = page - 1;
+  if (page > 0 && limit > 0)  skip = (page * limit) - limit;
+
+  this
+  .skip(skip)
+  .limit(limit);
+
+  return this;
+};
+
+/**
  * Add a groupBy clause to the criteria object
  *
  * @param {Array|Arguments} Keys to group by

--- a/test/unit/query/query.find.js
+++ b/test/unit/query/query.find.js
@@ -73,5 +73,82 @@ describe('Collection Query', function() {
       });
     });
 
+    describe('.paginate()', function() {
+      it('should not set skip and limit by default', function(done) {
+        query.find()
+        .paginate()
+        .exec(function(err, results) {
+          assert(!err);
+          assert(Array.isArray(results));
+
+          assert(results[0].skip == undefined);
+          assert(results[0].limit == undefined);
+
+          done();
+        });
+      });
+
+      it('should not set skip from page 0', function(done) {
+        query.find()
+        .paginate({page: 1})
+        .exec(function(err, results) {
+          assert(results[0].skip == undefined);
+
+          done();
+        });
+      });
+
+      it('should not set skip from page 1', function(done) {
+        query.find()
+        .paginate({page: 1})
+        .exec(function(err, results) {
+          assert(results[0].skip == undefined);
+
+          done();
+        });
+      });
+
+      it('should set skip to 1', function(done) {
+        query.find()
+        .paginate({page: 2})
+        .exec(function(err, results) {
+          assert(results[0].skip == 1);
+
+          done();
+        });
+      });
+
+      it('should set limit to 1', function(done) {
+        query.find()
+        .paginate({limit: 1})
+        .exec(function(err, results) {
+          assert(results[0].limit == 1);
+
+          done();
+        });
+      });
+
+      it('should set skip to 10 and limit to 10', function(done) {
+        query.find()
+        .paginate({page: 2, limit: 10})
+        .exec(function(err, results) {
+          assert(results[0].skip  == 10);
+          assert(results[0].limit == 10);
+
+          done();
+        });
+      });
+
+      it('should set skip to 20 and limit to 10', function(done) {
+        query.find()
+        .paginate({page: 3, limit: 10})
+        .exec(function(err, results) {
+          assert(results[0].skip  == 20);
+          assert(results[0].limit == 10);
+
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This is syntactical sugar that makes use of `Deferred.skip()` and `Deferred.limit()`, along with some pagination logic, to make it easier do pagination with waterline.

I added 11 test cases for you to look over. The use case is basically:

``` javascript
User.find().paginate({limit: 10});
// Returns the first 10 users

User.find().paginate({page: 1, limit: 10});
// Returns the first 10 users

User.find().paginate({page: 2, limit: 10});
// Returns the next 10 users

User.find().paginate();
// Returns all the users as if no pagination was done

User.find().paginate({page: 1});
// Returns all the users skipping none

User.find().paginate({page: 2});
// Returns all the users skipping the first one
```

I'm finding myself using pagination logic a lot with waterline (and sails). This work was done as an optional interface to dry up that work. I'm completely up to changing the semantics (for example using skip instead of page), just let you me know what you need.

Cheers!
