### PR TITLE
Fixed issue where keys matching column names were being deleted.

### DIFF
--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -136,9 +136,10 @@ Transformation.prototype.unserialize = function(attributes) {
   // Loop through the attributes and change them
   Object.keys(this._transformations).forEach(function(key) {
     var transformed = self._transformations[key];
-
-    values[key] = attributes[transformed];
-    delete values[transformed];
+    if (transformed !== key) {
+      values[key] = attributes[transformed];
+      delete values[transformed];
+    }
   });
 
   return values;

--- a/test/unit/core/core.transformations.js
+++ b/test/unit/core/core.transformations.js
@@ -115,6 +115,9 @@ describe('Core Transformations', function() {
         name: 'string',
         username: {
           columnName: 'login'
+        },
+        password: {
+          columnName: 'password'
         }
       };
 
@@ -125,6 +128,12 @@ describe('Core Transformations', function() {
       var values = transformer.unserialize({ login: 'foo' });
       assert(values.username);
       assert(values.username === 'foo');
+    });
+    
+    it('shouldnt delete password key when it matches the column name', function() {
+      var values = transformer.unserialize({ password: 'bar' });
+      assert(values.password);
+      assert(values.password === 'bar');
     });
   });
 


### PR DESCRIPTION
I ran into an issue using waterline with postgres where if I specified a column name for an attribute on a model where the column name was equal to the key of the attribute, the column would be excluded from the query.  I could have removed the columnName to work around it but it would be nicer if it just worked as you'd expect. 

See the example in the core.transformations test below.

Thanks,

Colin
