### PR TITLE
Fix error handling in Deferred's promise functions

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -239,22 +239,21 @@ Deferred.prototype.done = function(cb) {
  * Executes a Query, and returns a promise
  */
 
-Deferred.prototype.then = function(cb, ec) {
+Deferred.prototype.toPromise = function() {
   var deferred = Q.defer();
 
-  this.exec(function(err, result) {
-    if(err) {
-      if(typeof ec === 'function') {
-        deferred.resolve(ec(err));
-      } else {
-        deferred.reject(err);
-      }
-    } else {
-      cb ? deferred.resolve(cb(result)) : deferred.resolve(result);
-    }
-  });
+  this.exec(deferred.makeNodeResolver());
 
   return deferred.promise;
+};
+
+/**
+ * Executes a Query, and returns a promise that applies cb/ec to the
+ * result/error.
+ */
+
+Deferred.prototype.then = function(cb, ec) {
+  return this.toPromise().then(cb, ec);
 };
 
 /**
@@ -262,22 +261,7 @@ Deferred.prototype.then = function(cb, ec) {
  */
 
 Deferred.prototype.spread = function(cb) {
-  var deferred = Q.defer();
-
-  this.exec(function(err, result) {
-    if(err) {
-        deferred.reject(err);
-    } else {
-
-      if(!(result instanceof Array)) {
-        cb ? deferred.resolve(cb(result)) : deferred.resolve(result);
-      } else {
-        cb ? deferred.resolve(cb.apply(cb, result)) : deferred.resolve(result);
-      }
-    }
-  });
-
-  return deferred.promise;
+  return this.toPromise().spread(cb);
 };
 
 /**
@@ -285,16 +269,6 @@ Deferred.prototype.spread = function(cb) {
  */
 
 Deferred.prototype.fail = function(cb) {
-  var deferred = Q.defer();
-
-  this.exec(function(err, result) {
-    if(err) {
-      cb ? deferred.resolve(cb(err)) : deferred.reject(err);
-    } else {
-      deferred.resolve(result);
-    }
-  });
-
-  return deferred.promise;
+  return this.toPromise().fail(cb);
 };
 

--- a/test/unit/query/query.promises.js
+++ b/test/unit/query/query.promises.js
@@ -49,5 +49,25 @@ describe('Collection Promise', function () {
         done(err);
       });
     });
+
+    it('should reject the promise if the then handler fails', function (done) {
+      var promise = query.find({}).then(function (obj) {
+        throw new Error("Error in promise handler");
+      }).then(function (unexpected) {
+        done(new Error("Unexpected success"));
+      }).fail(function (expected) {
+        done();
+      })
+    });
+
+    it('should reject the promise if the spread handler fails', function (done) {
+      var promise = query.find({}).spread(function (obj) {
+        throw new Error("Error in promise handler");
+      }).then(function (unexpected) {
+        done(new Error("Unexpected success"));
+      }).fail(function (expected) {
+        done();
+      })
+    });
   });
 });


### PR DESCRIPTION
With Q promises, if the then(), fail() or spread() handlers throw an
exception, the promise is rejected. The wrapper functions in Deferred,
however, were simply throwing those exceptions on up.

Rather than try to duplicate those functions in waterline, this patch
adds a toPromise() method to Deferred which simply executes the query
and creates a Q Promise with the result. Then then(), fail() and
spread() functions are then just wrappers calling those methods on the
Promise.
