### PR TITLE
Add size to an object attribute.

### DIFF
--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -106,6 +106,11 @@ Schema.prototype.objectAttribute = function(value) {
       case 'enum':
         attr.enum = value[key];
         break;
+
+      // Set schema[attribute].size
+      case 'size':
+        attr.size = value[key];
+        break;
     }
   }
 


### PR DESCRIPTION
String type usually needs a size parameter, for example, in MySQL,
string type is converted to VARCHAR(n). Size parameter defines the value of
n.
