### PR TITLE
Added information about sorting in the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,21 @@ Based on your Collection attributes you also have dynamic finders. So given a `n
   - nameEndsWith
   - nameContains
 
+
+## Sorting
+
+Sorting is performed in the deferred object query method `sort`. Simply specify an attribute name for natural (ascending) sort, or specify an `asc` or `desc` flag for ascending or descending orders respectively.
+
+```javascript
+User.find()
+.sort('roleId asc')
+.sort('createdAt desc')
+.exec(function(err, users) {
+  // Do stuff here
+});
+```
+
+
 ## Validations
 
 Validations are handled by [Anchor](https://github.com/balderdashy/anchor) which is based off of [Node Validate](https://github.com/chriso/node-validator) and supports most of the properties in node-validate. For a full list of validations see: [Anchor Validations](https://github.com/balderdashy/anchor/blob/master/lib/rules.js).


### PR DESCRIPTION
I have been using Sails.js for a personal project, and I was having trouble finding out how to manipulate the sorting order used by the `.sort()` function.

Eventually I found out that the keywords `asc` and `desc` were used, by looking through the source code. I thought it'd be a good idea to include this bit of info in the readme, just in case.
