### PR TITLE
Ignore size attribute to validate.

### DIFF
--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -53,7 +53,7 @@ Validator.prototype.initialize = function(attrs, types) {
     var attrsVal = attrs[attr];
 
     for(var prop in attrsVal) {
-      if(/^(defaultsTo|primaryKey|autoIncrement|unique|index|columnName)$/.test(prop)) continue;
+      if(/^(defaultsTo|primaryKey|autoIncrement|unique|index|columnName|size)$/.test(prop)) continue;
 
       // use the Anchor `in` method for enums
       if(prop === 'enum') {


### PR DESCRIPTION
Size is not a valid anchor rule.
