### PR TITLE
Fix cache lookup for find queries without joins

### DIFF
--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -88,7 +88,7 @@ module.exports = {
       // If no joins are used grab the only item from the cache and pass to the returnResults
       // function.
       if(!criteria.joins) {
-        values = values[Object.keys(values)[0]];
+        values = values[self.identity];
         return returnResults(values);
       }
 


### PR DESCRIPTION
The previous implementation fell apart when `operations.run` returned the whole cache (desired behavior?). Using always the first collection's identity caused empty results for all `find` queries on all other collections.

If using the identity here is not feasible, this should solve it, too:
`values = _.find(values, function(item){ return item.length > 0 });` 
