### PR TITLE
Add feature from issue #228

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -53,7 +53,9 @@ module.exports = {
       // Set Default Values if available
       for(var key in self.attributes) {
         if(record[key] === undefined && self.attributes[key].hasOwnProperty('defaultsTo')) {
-          record[key] = _.clone(self.attributes[key].defaultsTo);
+          var defaultObj = self.attributes[key].defaultsTo;
+          var defaultValue = typeof defaultObj === 'function' ? defaultObj(record) : defaultObj;
+          record[key] = _.clone(defaultValue);
         }
       }
 
@@ -210,7 +212,9 @@ module.exports = {
       // Set Default Values if available
       for(var key in self.attributes) {
         if(record[key] === undefined && self.attributes[key].hasOwnProperty('defaultsTo')) {
-          record[key] = _.clone(self.attributes[key].defaultsTo);
+          var defaultObj = self.attributes[key].defaultsTo;
+          var defaultValue = typeof defaultObj === 'function' ? defaultObj(record) : defaultObj;
+          record[key] = _.clone(defaultValue);
         }
       }
 

--- a/lib/waterline/query/dql.js
+++ b/lib/waterline/query/dql.js
@@ -53,7 +53,9 @@ module.exports = {
     // Set Default Values if available
     for(var key in this.attributes) {
       if(values[key] === undefined && this.attributes[key].hasOwnProperty('defaultsTo')) {
-        values[key] = _.clone(this.attributes[key].defaultsTo);
+        var defaultObj = this.attributes[key].defaultsTo;
+        var defaultValue = typeof defaultObj === 'function' ? defaultObj(values) : defaultObj;
+        values[key] = _.clone(defaultValue);
       }
     }
 

--- a/test/unit/query/query.create.js
+++ b/test/unit/query/query.create.js
@@ -15,6 +15,18 @@ describe('Collection Query', function() {
           identity: 'user',
           adapter: 'foo',
           attributes: {
+            first:{
+              type: 'string',
+              defaultsTo: 'Foo'
+            },
+            second: {
+              type: 'string',
+              defaultsTo: 'Bar'
+            },
+            full: {
+              type: 'string',
+              defaultsTo: function(self){ return self.first + " " + self.second}
+            },
             name: {
               type: 'string',
               defaultsTo: 'Foo Bar'
@@ -35,6 +47,13 @@ describe('Collection Query', function() {
       it('should set default values', function(done) {
         query.create({}, function(err, status) {
           assert(status.name === 'Foo Bar');
+          done();
+        });
+      });
+
+      it('should set default values when function', function(done) {
+        query.create({}, function(err, status) {
+          assert(status.full === 'Foo Bar');
           done();
         });
       });

--- a/test/unit/query/query.createEach.js
+++ b/test/unit/query/query.createEach.js
@@ -15,6 +15,18 @@ describe('Collection Query', function() {
           identity: 'user',
           adapter: 'foo',
           attributes: {
+            first:{
+              type: 'string',
+              defaultsTo: 'Foo'
+            },
+            second: {
+              type: 'string',
+              defaultsTo: 'Bar'
+            },
+            full: {
+              type: 'string',
+              defaultsTo: function(self){ return self.first + " " + self.second}
+            },
             name: {
               type: 'string',
               defaultsTo: 'Foo Bar'
@@ -56,6 +68,15 @@ describe('Collection Query', function() {
           assert(Array.isArray(values));
           assert(values[0].name === 'Foo Bar');
           assert(values[1].name === 'Foo Bar');
+          done();
+        });
+      });
+
+      it('should add default values to each record when function', function(done) {
+        query.createEach([{},{}], function(err, values) {
+          assert(Array.isArray(values));
+          assert(values[0].full === 'Foo Bar');
+          assert(values[1].full === 'Foo Bar');
           done();
         });
       });


### PR DESCRIPTION
Add feature from issue #228: defaultsTo can be a function  that runs on creation, in order to use as default random values, composite values and current time related values (new Date()), for instance.

Example:

```
...
attributes: {
  first:{
    type: 'string',
    defaultsTo: 'Foo'
  },
  second: {
    type: 'string',
    defaultsTo: 'Bar'
  },
  full: {
    type: 'string',
    defaultsTo: function(self){ return self.first + " " + self.second}
  }
}
...
```

full attribute default value will be 'Foo Bar'

Added tests to create and createEach for this feature
