### PR TITLE
Adds ability to specify a function as the defaultsTo property for models

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -54,7 +54,8 @@ module.exports = {
       // Set Default Values if available
       for(var key in self.attributes) {
         if(!record[key] && record[key] !== false && hasOwnProperty(self.attributes[key], 'defaultsTo')) {
-          record[key] = _.clone(self.attributes[key].defaultsTo);
+          var defaultsTo = self.attributes[key].defaultsTo;
+          record[key] = typeof defaultsTo === 'function' ? defaultsTo.call(valuesList) : _.clone(defaultsTo);
         }
       }
 
@@ -211,7 +212,8 @@ module.exports = {
       // Set Default Values if available
       for(var key in self.attributes) {
         if(!record[key] && record[key] !== false && hasOwnProperty(self.attributes[key], 'defaultsTo')) {
-          record[key] = _.clone(self.attributes[key].defaultsTo);
+          var defaultsTo = self.attributes[key].defaultsTo;
+          record[key] = typeof defaultsTo === 'function' ? defaultsTo.call(valuesList) : _.clone(defaultsTo);
         }
       }
 

--- a/lib/waterline/query/dql.js
+++ b/lib/waterline/query/dql.js
@@ -55,7 +55,8 @@ module.exports = {
     // Set Default Values if available
     for(var key in this.attributes) {
       if(!hasOwnProperty(values, key) && hasOwnProperty(this.attributes[key], 'defaultsTo')) {
-        values[key] = _.clone(this.attributes[key].defaultsTo);
+        var defaultsTo = this.attributes[key].defaultsTo;
+        values[key] = typeof defaultsTo === 'function' ? defaultsTo.call(values) : _.clone(defaultsTo);
       }
     }
 


### PR DESCRIPTION
This should be helpful to some people. Calls the `defaultsTo` function with the context of the model, so all attributes are available during model creation. Use #228 if you need the test cases, otherwise this pull has a more elegant solution.
