### PR TITLE
Make lifecycle callbacks consistently use verbs, refs #274

### DIFF
--- a/lib/waterline/query/validate.js
+++ b/lib/waterline/query/validate.js
@@ -29,7 +29,7 @@ module.exports = {
           });
         };
 
-        async.eachSeries(self._callbacks.beforeValidation, runner, function(err) {
+        async.eachSeries(self._callbacks.beforeValidate, runner, function(err) {
           if(err) return cb(err);
           cb();
         });
@@ -52,7 +52,7 @@ module.exports = {
           });
         };
 
-        async.eachSeries(self._callbacks.afterValidation, runner, function(err) {
+        async.eachSeries(self._callbacks.afterValidate, runner, function(err) {
           if(err) return cb(err);
           cb();
         });

--- a/lib/waterline/utils/callbacks.js
+++ b/lib/waterline/utils/callbacks.js
@@ -3,8 +3,8 @@
  */
 
 module.exports = [
-  'beforeValidation',
-  'afterValidation',
+  'beforeValidate',
+  'afterValidate',
   'beforeUpdate',
   'afterUpdate',
   'beforeCreate',

--- a/test/unit/callbacks/afterValidation.create.js
+++ b/test/unit/callbacks/afterValidation.create.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.afterValidation()', function() {
+describe('.afterValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: function(values, cb) {
+        afterValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -45,7 +45,7 @@ describe('.afterValidation()', function() {
 
     describe('.create()', function() {
 
-      it('should run afterValidation and mutate values', function(done) {
+      it('should run afterValidate and mutate values', function(done) {
         person.create({ name: 'test' }, function(err, user) {
           assert(!err);
           assert(user.name === 'test updated');
@@ -72,7 +72,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: [
+        afterValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/callbacks/afterValidation.createEach.js
+++ b/test/unit/callbacks/afterValidation.createEach.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.afterValidation()', function() {
+describe('.afterValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: function(values, cb) {
+        afterValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -45,7 +45,7 @@ describe('.afterValidation()', function() {
 
     describe('.createEach()', function() {
 
-      it('should run afterValidation and mutate values', function(done) {
+      it('should run afterValidate and mutate values', function(done) {
         person.createEach([{ name: 'test' }, { name: 'test2' }], function(err, users) {
           assert(!err);
           assert(users[0].name === 'test updated');
@@ -73,7 +73,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: [
+        afterValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/callbacks/afterValidation.findOrCreate.js
+++ b/test/unit/callbacks/afterValidation.findOrCreate.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.afterValidation()', function() {
+describe('.afterValidate()', function() {
 
   describe('basic function', function() {
 
@@ -24,7 +24,7 @@ describe('.afterValidation()', function() {
               name: 'string'
             },
 
-            afterValidation: function(values, cb) {
+            afterValidate: function(values, cb) {
               values.name = values.name + ' updated';
               cb();
             }
@@ -51,7 +51,7 @@ describe('.afterValidation()', function() {
           });
         });
 
-        it('should run afterValidation and mutate values on create', function(done) {
+        it('should run afterValidate and mutate values on create', function(done) {
           person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
             assert(!err);
             assert(user.name === 'test updated');
@@ -73,7 +73,7 @@ describe('.afterValidation()', function() {
               name: 'string'
             },
 
-            afterValidation: function(values, cb) {
+            afterValidate: function(values, cb) {
               values.name = values.name + ' updated';
               cb();
             }
@@ -100,7 +100,7 @@ describe('.afterValidation()', function() {
           });
         });
 
-        it('should not run afterValidation and mutate values on find', function(done) {
+        it('should not run afterValidate and mutate values on find', function(done) {
           person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
             assert(!err);
             assert(user.name === 'test');
@@ -134,7 +134,7 @@ describe('.afterValidation()', function() {
             name: 'string'
           },
 
-          afterValidation: [
+          afterValidate: [
             // Function 1
             function(values, cb) {
               values.name = values.name + ' fn1';
@@ -192,7 +192,7 @@ describe('.afterValidation()', function() {
             name: 'string'
           },
 
-          afterValidation: [
+          afterValidate: [
             // Function 1
             function(values, cb) {
               values.name = values.name + ' fn1';

--- a/test/unit/callbacks/afterValidation.findOrCreateEach.js
+++ b/test/unit/callbacks/afterValidation.findOrCreateEach.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.afterValidation()', function() {
+describe('.afterValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: function(values, cb) {
+        afterValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -48,7 +48,7 @@ describe('.afterValidation()', function() {
 
     describe('.findOrCreateEach()', function() {
 
-      it('should run afterValidation and mutate values', function(done) {
+      it('should run afterValidate and mutate values', function(done) {
         person.findOrCreateEach([{ name: 'test' }], [{ name: 'test' }], function(err, users) {
           assert(!err);
           assert(users[0].name === 'test updated');
@@ -75,7 +75,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: [
+        afterValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/callbacks/afterValidation.update.js
+++ b/test/unit/callbacks/afterValidation.update.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.afterValidation()', function() {
+describe('.afterValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: function(values, cb) {
+        afterValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -45,7 +45,7 @@ describe('.afterValidation()', function() {
 
     describe('.update()', function() {
 
-      it('should run afterValidation and mutate values', function(done) {
+      it('should run afterValidate and mutate values', function(done) {
         person.update({ name: 'criteria' }, { name: 'test' }, function(err, users) {
           assert(!err);
           assert(users[0].name === 'test updated');
@@ -72,7 +72,7 @@ describe('.afterValidation()', function() {
           name: 'string'
         },
 
-        afterValidation: [
+        afterValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/callbacks/beforeValidation.create.js
+++ b/test/unit/callbacks/beforeValidation.create.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.beforeValidation()', function() {
+describe('.beforeValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: function(values, cb) {
+        beforeValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -45,7 +45,7 @@ describe('.beforeValidation()', function() {
 
     describe('.create()', function() {
 
-      it('should run beforeValidation and mutate values', function(done) {
+      it('should run beforeValidate and mutate values', function(done) {
         person.create({ name: 'test' }, function(err, user) {
           assert(!err);
           assert(user.name === 'test updated');
@@ -72,7 +72,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: [
+        beforeValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/callbacks/beforeValidation.createEach.js
+++ b/test/unit/callbacks/beforeValidation.createEach.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.beforeValidation()', function() {
+describe('.beforeValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: function(values, cb) {
+        beforeValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -45,7 +45,7 @@ describe('.beforeValidation()', function() {
 
     describe('.createEach()', function() {
 
-      it('should run beforeValidation and mutate values', function(done) {
+      it('should run beforeValidate and mutate values', function(done) {
         person.createEach([{ name: 'test' }, { name: 'test2' }], function(err, users) {
           assert(!err);
           assert(users[0].name === 'test updated');
@@ -73,7 +73,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: [
+        beforeValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/callbacks/beforeValidation.findOrCreate.js
+++ b/test/unit/callbacks/beforeValidation.findOrCreate.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.beforeValidation()', function() {
+describe('.beforeValidate()', function() {
 
   describe('basic function', function() {
 
@@ -24,7 +24,7 @@ describe('.beforeValidation()', function() {
               name: 'string'
             },
 
-            beforeValidation: function(values, cb) {
+            beforeValidate: function(values, cb) {
               values.name = values.name + ' updated';
               cb();
             }
@@ -51,7 +51,7 @@ describe('.beforeValidation()', function() {
           });
         });
 
-        it('should run beforeValidation and mutate values on create', function(done) {
+        it('should run beforeValidate and mutate values on create', function(done) {
           person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
             assert(!err);
             assert(user.name === 'test updated');
@@ -73,7 +73,7 @@ describe('.beforeValidation()', function() {
               name: 'string'
             },
 
-            beforeValidation: function(values, cb) {
+            beforeValidate: function(values, cb) {
               values.name = values.name + ' updated';
               cb();
             }
@@ -100,7 +100,7 @@ describe('.beforeValidation()', function() {
           });
         });
 
-        it('should not run beforeValidation and mutate values on find', function(done) {
+        it('should not run beforeValidate and mutate values on find', function(done) {
           person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
             assert(!err);
             assert(user.name === 'test');
@@ -133,7 +133,7 @@ describe('.beforeValidation()', function() {
             name: 'string'
           },
 
-          beforeValidation: [
+          beforeValidate: [
             // Function 1
             function(values, cb) {
               values.name = values.name + ' fn1';
@@ -191,7 +191,7 @@ describe('.beforeValidation()', function() {
             name: 'string'
           },
 
-          beforeValidation: [
+          beforeValidate: [
             // Function 1
             function(values, cb) {
               values.name = values.name + ' fn1';

--- a/test/unit/callbacks/beforeValidation.findOrCreateEach.js
+++ b/test/unit/callbacks/beforeValidation.findOrCreateEach.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.beforeValidation()', function() {
+describe('.beforeValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: function(values, cb) {
+        beforeValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -48,7 +48,7 @@ describe('.beforeValidation()', function() {
 
     describe('.findOrCreateEach()', function() {
 
-      it('should run beforeValidation and mutate values', function(done) {
+      it('should run beforeValidate and mutate values', function(done) {
         person.findOrCreateEach([{ name: 'test' }], [{ name: 'test' }], function(err, users) {
           assert(!err);
           assert(users[0].name === 'test updated');
@@ -75,7 +75,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: [
+        beforeValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/callbacks/beforeValidation.update.js
+++ b/test/unit/callbacks/beforeValidation.update.js
@@ -1,7 +1,7 @@
 var Waterline = require('../../../lib/waterline'),
     assert = require('assert');
 
-describe('.beforeValidation()', function() {
+describe('.beforeValidate()', function() {
 
   describe('basic function', function() {
     var person;
@@ -15,7 +15,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: function(values, cb) {
+        beforeValidate: function(values, cb) {
           values.name = values.name + ' updated';
           cb();
         }
@@ -45,7 +45,7 @@ describe('.beforeValidation()', function() {
 
     describe('.update()', function() {
 
-      it('should run beforeValidation and mutate values', function(done) {
+      it('should run beforeValidate and mutate values', function(done) {
         person.update({ name: 'criteria' }, { name: 'test' }, function(err, users) {
           assert(!err);
           assert(users[0].name === 'test updated');
@@ -72,7 +72,7 @@ describe('.beforeValidation()', function() {
           name: 'string'
         },
 
-        beforeValidation: [
+        beforeValidate: [
           // Function 1
           function(values, cb) {
             values.name = values.name + ' fn1';

--- a/test/unit/core/core.callbacks.js
+++ b/test/unit/core/core.callbacks.js
@@ -37,11 +37,11 @@ describe('Core Lifecycle Callbacks', function() {
     });
 
     it('should build a callbacks object', function() {
-      assert(Array.isArray(person._callbacks.beforeValidation));
-      assert(typeof person._callbacks.beforeValidation[0] === 'function');
+      assert(Array.isArray(person._callbacks.beforeValidate));
+      assert(typeof person._callbacks.beforeValidate[0] === 'function');
 
-      assert(Array.isArray(person._callbacks.afterValidation));
-      assert(typeof person._callbacks.afterValidation[0] === 'function');
+      assert(Array.isArray(person._callbacks.afterValidate));
+      assert(typeof person._callbacks.afterValidate[0] === 'function');
 
       assert(Array.isArray(person._callbacks.beforeUpdate));
       assert(typeof person._callbacks.beforeUpdate[0] === 'function');
@@ -94,7 +94,7 @@ describe('Core Lifecycle Callbacks', function() {
           }
         },
 
-        beforeValidation: ['changeState_1', 'changeState_2']
+        beforeValidate: ['changeState_1', 'changeState_2']
       });
 
       waterline.loadCollection(Person);
@@ -113,13 +113,13 @@ describe('Core Lifecycle Callbacks', function() {
     });
 
     it('should map functions to internal _callbacks object', function() {
-      assert(Array.isArray(person._callbacks.beforeValidation));
-      assert(typeof person._callbacks.beforeValidation[0] === 'function');
+      assert(Array.isArray(person._callbacks.beforeValidate));
+      assert(typeof person._callbacks.beforeValidate[0] === 'function');
     });
 
     it('should mutate values', function() {
       var values = { name: 'Foo' };
-      person._callbacks.beforeValidation.forEach(function(key) {
+      person._callbacks.beforeValidate.forEach(function(key) {
         key.call(values);
       });
 
@@ -149,7 +149,7 @@ describe('Core Lifecycle Callbacks', function() {
           }
         },
 
-        beforeValidation: 'changeState_1'
+        beforeValidate: 'changeState_1'
       });
 
       waterline.loadCollection(Person);
@@ -168,13 +168,13 @@ describe('Core Lifecycle Callbacks', function() {
     });
 
     it('should map functions to internal _callbacks object', function() {
-      assert(Array.isArray(person._callbacks.beforeValidation));
-      assert(typeof person._callbacks.beforeValidation[0] === 'function');
+      assert(Array.isArray(person._callbacks.beforeValidate));
+      assert(typeof person._callbacks.beforeValidate[0] === 'function');
     });
 
     it('should mutate values', function() {
       var values = { name: 'Foo' };
-      person._callbacks.beforeValidation.forEach(function(key) {
+      person._callbacks.beforeValidate.forEach(function(key) {
         key.call(values);
       });
 
@@ -200,7 +200,7 @@ describe('Core Lifecycle Callbacks', function() {
           name: 'string'
         },
 
-        beforeValidation: function() {
+        beforeValidate: function() {
           this.name = this.name + ' changed';
         }
       });
@@ -221,13 +221,13 @@ describe('Core Lifecycle Callbacks', function() {
     });
 
     it('should map functions to internal _callbacks object', function() {
-      assert(Array.isArray(person._callbacks.beforeValidation));
-      assert(typeof person._callbacks.beforeValidation[0] === 'function');
+      assert(Array.isArray(person._callbacks.beforeValidate));
+      assert(typeof person._callbacks.beforeValidate[0] === 'function');
     });
 
     it('should mutate values', function() {
       var values = { name: 'Foo' };
-      person._callbacks.beforeValidation.forEach(function(key) {
+      person._callbacks.beforeValidate.forEach(function(key) {
         key.call(values);
       });
 


### PR DESCRIPTION
Changes `beforeValidation` and `afterValidation` to `*Validate` to use verbs in consistency with all other lifecycle callbacks.
