### PR TITLE
schemaName meta-data passthrough for postgresql

### DIFF
--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -154,12 +154,9 @@ Waterline.prototype.initialize = function(options, cb) {
         });
 
         // Grab JunctionTable flag
-        var meta = {};
+        var meta = collection.meta || {};
         meta.junctionTable = hasOwnProperty(collection.waterline.schema[collection.identity], 'junctionTable') ?
           collection.waterline.schema[collection.identity].junctionTable : false;
-
-        // Set schemaName meta data
-        meta.schemaName = collection.schemaName;
 
         schemas[collection.identity] = {
           definition: schema,


### PR DESCRIPTION
Passthrough for schemaName model attribute, to be used by postgresql adapter.
(missing tests, and may be in the wrong place - looking for feedback)
