### PR TITLE
Typo: Callback function undefined

### DIFF
--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies
  */
@@ -169,7 +168,7 @@ Add.prototype.createNewRecord = function(collection, attribute, values, cb) {
     if(!junctionTable) return cb();
 
     // if junction table but there was an error don't try and link the records
-    if(err) return callback();
+    if(err) return cb();
 
     // Find the insertCollection's Primary Key value
     var primaryKey = self.findPrimaryKey(collection._attributes, record.toObject());


### PR DESCRIPTION
This is a typo where the callback's name should be cb() and not callback(). It was throwing an error about this undefined function when it encountered an error.
