### PR TITLE
Unused variable insertCollection

### DIFF
--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies
  */
@@ -144,8 +143,7 @@ Add.prototype.createAssociations = function(key, records, cb) {
  */
 
 Add.prototype.createNewRecord = function(collection, attribute, values, cb) {
-  var self = this,
-      insertCollection = null;
+  var self = this;
 
   // Check if this is a many-to-many by looking at the junctionTable flag
   var schema = this.collection.waterline.schema[attribute.collection.toLowerCase()];
@@ -159,7 +157,7 @@ Add.prototype.createNewRecord = function(collection, attribute, values, cb) {
     if(err) {
       self.failedTransactions.push({
         type: 'insert',
-        collection: insertCollection.identity,
+        collection: collection.identity,
         values: values,
         err: err.message
       });
@@ -171,7 +169,7 @@ Add.prototype.createNewRecord = function(collection, attribute, values, cb) {
     // if junction table but there was an error don't try and link the records
     if(err) return callback();
 
-    // Find the insertCollection's Primary Key value
+    // Find the collection's Primary Key value
     var primaryKey = self.findPrimaryKey(collection._attributes, record.toObject());
 
     if(!primaryKey) {


### PR DESCRIPTION
I kept getting an error about insertCollection being null. When I looked into it, I noticed `insertCollection` was set to `null` and never set to anything else in this function. As a result, it wasn't properly throwing an error when it should have because it kept getting stuck on this `null` property.

To be specific, here's what I kept getting: 

`/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/add.js:162
        collection: insertCollection.identity,
                                    ^
TypeError: Cannot read property 'identity' of null
    at Add.createNewRecord (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/add.js:162:37)
    at module.exports (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/waterline/lib/waterline/utils/usageError.js:7:17)
    at bound.module.exports.createEach (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/waterline/lib/waterline/query/aggregate.js:47:23)
    at bound [as createEach] (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/lodash/dist/lodash.js:729:21)
    at bound.module.exports.create (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/waterline/lib/waterline/query/dql.js:54:19)
    at bound [as create] (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/lodash/dist/lodash.js:729:21)
    at Add.createNewRecord (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/add.js:157:14)
    at Add.createAssociations (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/add.js:125:19)
    at replenish (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/async/lib/async.js:179:21)
    at _eachLimit (/Users/glenselle/.nvm/v0.10.25/lib/node_modules/sails/node_modules/async/lib/async.js:196:15)`

But after changing `insertCollection` to `collection` and `callback()` to `cb()` (https://github.com/balderdashy/waterline/pull/309), I got an error I should have gotten all along, but wasn't because it kept failing in these two places: 

`err: 'duplicate key value violates unique constraint "message_pkey"'`
