### PR TITLE
Fix empty collection issue during schema sync

### DIFF
--- a/lib/waterline/adapter/sync/strategies/alter.js
+++ b/lib/waterline/adapter/sync/strategies/alter.js
@@ -68,6 +68,9 @@ module.exports = function(cb) {
         return cb(err);
       }
 
+      // If the collection exists but is empty, then do nothing.
+      if (existingData.length === 0) return cb();
+
       //
       // From this point forward, we must be very careful.
       //


### PR DESCRIPTION
With some adapters, things will break if you try to run `.createEach()` with an empty list. Specifically, mongodb doesn't like this. If your local dev db has the collections created from a previous sync run but no data was added, it will bomb out with `MongoError: Message contains no documents`.
