### PR TITLE
0.9.x - fix for #338

### DIFF
--- a/lib/waterline/adapter/setupTeardown.js
+++ b/lib/waterline/adapter/setupTeardown.js
@@ -23,7 +23,7 @@ module.exports = {
         );
 
         // Extend collection with what we have for the actual collection
-        collection = _.extend(collection, self.query);
+        collection = _.extend(self.query, collection);
 
         return item.registerCollection(collection, cb);
       }


### PR DESCRIPTION
This definintely fixes the "databaseName must be a string" error, but it may have some unintended consequences somewhere. 

Basically, somehow the self.query object has a key 'config' which is undefined, and it overwrites collection.config, which causes the "databaseName must be a string" error when the connection is being established. 

I think I should be setting that somewhere else (on the self.query object maybe?) But I could not trace where I should put it. Help will be appreciated here.
