### PR TITLE
Fixed updating records with associations attached

### DIFF
--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -71,6 +71,9 @@ function prepareArguments(criteria, values) {
   var _values = _.cloneDeep(values);
   var associations = nestedOperations.valuesParser.call(this, this.identity, this.waterline.schema, values);
 
+  //remove associated objects and replace them with their foreign keys
+  values = nestedOperations.reduceAssociations.call(this, this.identity, this.waterline.schema, values);
+
   // Cast values to proper types (handle numbers as strings)
   values = this._cast.run(values);
 

--- a/lib/waterline/utils/nestedOperations/index.js
+++ b/lib/waterline/utils/nestedOperations/index.js
@@ -3,6 +3,7 @@
  */
 
 module.exports = {
+  reduceAssociations: require('./reduceAssociations'),
   valuesParser: require('./valuesParser'),
   create: require('./create'),
   update: require('./update')

--- a/lib/waterline/utils/nestedOperations/reduceAssociations.js
+++ b/lib/waterline/utils/nestedOperations/reduceAssociations.js
@@ -1,0 +1,36 @@
+/**
+ * Module Dependencies
+ */
+
+var hasOwnProperty = require('../helpers').object.hasOwnProperty;
+
+/**
+ * Traverse an object representing values replace associated objects with their
+ * foreign keys.
+ *
+ * @param {String} model
+ * @param {Object} schema
+ * @param {Object} values
+ * @return {Object}
+ * @api private
+ */
+
+
+module.exports = function(model, schema, values) {
+  var self = this;
+
+  Object.keys(values).forEach(function(key) {
+
+    var attribute = schema[model].attributes[key];
+
+    //Check to see if this key is a foreign key
+    if(hasOwnProperty(attribute, 'foreignKey') && attribute.foreignKey === true && typeof(values[key]) === "object" && values[key] != null){
+      //If so, replace the object value with this key
+      var fk = values[key][attribute.on];
+      values[key] = fk;
+    }
+
+  });
+
+  return values;
+};


### PR DESCRIPTION
Added a step within prepareArguements that reduces all associated
objects to their foreign keys before attempting to update the record in
the DB. This prevents NaN values from being put into the query
