### PR TITLE
When adapter.syncable is false, don't sync

### DIFF
--- a/lib/waterline/query/adapters.js
+++ b/lib/waterline/query/adapters.js
@@ -17,6 +17,12 @@ module.exports = function() {
       // Don't override keys that already exists
       if(self[key]) return;
 
+      // Don't override a property, only functions
+      if(typeof adapter[key] != 'function')  {
+				self[key] = adapter[key];
+				return;
+			}
+
       // Apply the Function with passed in args and set this.identity as
       // the first argument
       self[key] = function() {

--- a/lib/waterline/query/index.js
+++ b/lib/waterline/query/index.js
@@ -42,7 +42,6 @@ Query.prototype.sync = function(cb) {
   // If not syncable, don't sync
   if (hop(this.adapter, 'syncable') && !this.adapter.syncable) {
     this.migrate = 'safe';
-		cb();
   }
 
   // Assign synchronization behavior depending on migrate option in collection


### PR DESCRIPTION
Added back the line to skip attempting to run the migration when an adapter doesn't support it.  Happy to expand on this.

For our Sails CouchDB Adapter (https://github.com/codeswarm/sails-couchdb-orm) this flag completely breaks.  Should our adapter implement a safe migration? If it's not syncable, why should we have to do that?
