### PR TITLE
fix createBelongsTo() uses wrong `this`

### DIFF
--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -109,7 +109,7 @@ function createBelongsTo(valuesObject, cb) {
     var pkValue = valuesObject.originalValues[item][model.primaryKey];
 
     var criteria = {};
-    criteria[this.primaryKey] = pkValue;
+    criteria[model.primaryKey] = pkValue;
 
     // If a pkValue if found, do a findOrCreate and look for a record matching the pk.
     var query;

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -114,7 +114,7 @@ function createBelongsTo(valuesObject, cb) {
     var pkValue = valuesObject.originalValues[item][model.primaryKey];
 
     var criteria = {};
-    criteria[this.primaryKey] = pkValue;
+    criteria[model.primaryKey] = pkValue;
 
     // If a pkValue if found, do a findOrCreate and look for a record matching the pk.
     var query;


### PR DESCRIPTION
`this` is actually `global` at runtime, cause `criteria` to have an `undefined` property.
