### PR TITLE
Support embeddable association (denormalization)

### DIFF
--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -148,6 +148,11 @@ Schema.prototype.objectAttribute = function(value) {
         attr.size = value[key];
         break;
 
+      // Set schema[attribute].embed
+      case 'embed':
+        attr.embed = value[key];
+        break;
+
       // Handle Belongs To Attributes
       case 'model':
         var type;

--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -71,7 +71,7 @@ Validator.prototype.initialize = function(attrs, types) {
       // If property is reserved don't do anything with it
       if(['defaultsTo', 'primaryKey', 'autoIncrement', 'unique', 'index', 'collection', 'dominant',
           'columnName', 'foreignKey', 'references', 'on', 'groupKey', 'model', 'via', 'size',
-          'example', 'validationMessage', 'validations', 'populateSettings'].indexOf(prop) > -1) return;
+          'example', 'validationMessage', 'validations', 'populateSettings', 'embed'].indexOf(prop) > -1) return;
 
       // use the Anchor `in` method for enums
       if(prop === 'enum') {

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -122,10 +122,21 @@ function createBelongsTo(valuesObject, cb) {
     query.exec(function(err, val) {
       if(err) return next(err);
 
-      // attach the new model's pk value to the original value's key
-      var pk = val[model.primaryKey];
+      if (attribute.embed) {
+        if (_.isArray(attribute.embed)) {
+          // attach selected attributes as an embedded sub-document
+          valuesObject.values[item] = _.pick(val, model.primaryKey, attribute.embed);
+        } else {
+          // attach the whole model as an embedded sub-document
+          valuesObject.values[item] = val;
+        }
+      } else {
+        // attach the new model's pk value to the original value's key
+        var pk = val[model.primaryKey];
 
-      valuesObject.values[item] = pk;
+        valuesObject.values[item] = pk;
+      }
+
       next();
     });
 

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -95,10 +95,11 @@ function createBelongsTo(valuesObject, cb) {
 
   async.each(valuesObject.associations.models, function(item, next) {
 
-    // Check if value is an object. If not don't try and create it.
-    if(!_.isPlainObject(valuesObject.values[item])) return next();
-
     var attribute = self._schema.schema[item];
+
+    // Check if value is an object. If not don't try and create it.
+    if(!_.isPlainObject(valuesObject.values[item]) && !attribute.embed) return next();
+
     var modelName;
 
     if(hasOwnProperty(attribute, 'collection')) modelName = attribute.collection;
@@ -106,7 +107,8 @@ function createBelongsTo(valuesObject, cb) {
     if(!modelName) return next();
 
     var model = self.waterline.collections[modelName];
-    var pkValue = valuesObject.originalValues[item][model.primaryKey];
+    var pkValue = _.isPlainObject(valuesObject.originalValues[item])
+       ? valuesObject.originalValues[item][model.primaryKey] : valuesObject.originalValues[item];
 
     var criteria = {};
     criteria[model.primaryKey] = pkValue;

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -100,10 +100,11 @@ function createBelongsTo(valuesObject, cb) {
 
   async.each(valuesObject.associations.models, function(item, next) {
 
-    // Check if value is an object. If not don't try and create it.
-    if(!_.isPlainObject(valuesObject.values[item])) return next();
-
     var attribute = self._schema.schema[item];
+
+    // Check if value is an object. If not don't try and create it.
+    if(!_.isPlainObject(valuesObject.values[item]) && !attribute.embed) return next();
+
     var modelName;
 
     if(hasOwnProperty(attribute, 'collection')) modelName = attribute.collection;
@@ -111,7 +112,8 @@ function createBelongsTo(valuesObject, cb) {
     if(!modelName) return next();
 
     var model = self.waterline.collections[modelName];
-    var pkValue = valuesObject.originalValues[item][model.primaryKey];
+    var pkValue = _.isPlainObject(valuesObject.originalValues[item])
+       ? valuesObject.originalValues[item][model.primaryKey] : valuesObject.originalValues[item];
 
     var criteria = {};
     criteria[model.primaryKey] = pkValue;

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -127,10 +127,21 @@ function createBelongsTo(valuesObject, cb) {
     query.exec(function(err, val) {
       if(err) return next(err);
 
-      // attach the new model's pk value to the original value's key
-      var pk = val[model.primaryKey];
+      if (attribute.embed) {
+        if (_.isArray(attribute.embed)) {
+          // attach selected attributes as an embedded sub-document
+          valuesObject.values[item] = _.pick(val, model.primaryKey, attribute.embed);
+        } else {
+          // attach the whole model as an embedded sub-document
+          valuesObject.values[item] = val;
+        }
+      } else {
+        // attach the new model's pk value to the original value's key
+        var pk = val[model.primaryKey];
 
-      valuesObject.values[item] = pk;
+        valuesObject.values[item] = pk;
+      }
+
       next();
     });
 

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -458,7 +458,14 @@ Operations.prototype._buildChildOpts = function _buildChildOpts(parentResults, c
 
       if(!hasOwnProperty(result, item.join.parentKey)) return;
       if(result[item.join.parentKey] === null || typeof result[item.join.parentKey] === undefined) return;
-      parents.push(result[item.join.parentKey]);
+      if(_.isPlainObject(result[item.join.parentKey])) {
+        // If value is a sub-document with a pk, append the pk to the build list
+        if(!result[item.join.parentKey][item.join.childKey]) return;
+        parents.push(result[item.join.parentKey][item.join.childKey]);
+      }
+      else {
+        parents.push(result[item.join.parentKey]);
+      }
 
     });
 

--- a/lib/waterline/query/integrator/_partialJoin.js
+++ b/lib/waterline/query/integrator/_partialJoin.js
@@ -61,11 +61,22 @@ module.exports = function partialJoin (options) {
   var CHILD_ATTR_PREFIX = (options.childNamespace || '.');
 
   // If the rows aren't a match, bail out
-  if (
-    options.childRow[options.childKey] !==
-    options.parentRow[options.parentKey]
-    ) {
-    return false;
+  if (_.isPlainObject(options.parentRow[options.parentKey])) {
+    // If parentKey maps to a sub-document in parentRow, check if the
+    // sub-document match the childRow
+    if (
+      options.childRow[options.childKey] !==
+      options.parentRow[options.parentKey][options.childKey]
+      ) {
+      return false;
+    }
+  } else {
+    if (
+      options.childRow[options.childKey] !==
+      options.parentRow[options.parentKey]
+      ) {
+      return false;
+    }
   }
 
   // deep clone the childRow, then delete `childKey` in the copy.

--- a/lib/waterline/utils/nestedOperations/reduceAssociations.js
+++ b/lib/waterline/utils/nestedOperations/reduceAssociations.js
@@ -44,8 +44,19 @@ module.exports = function(model, schema, values) {
     if (typeof attribute !== 'object') return;
 
     if(!hop(values[key], attribute.on)) return;
-    var fk = values[key][attribute.on];
-    values[key] = fk;
+
+    if (attribute.embed) {
+      if (_.isArray(attribute.embed)) {
+        // attach selected attributes as an embedded sub-document
+        values[key] = _.pick(values[key], attribute.on, attribute.embed);
+      } else {
+        // keep the whole model as an embedded sub-document
+        // values[key] = values[key];
+      }
+    } else {
+      var fk = values[key][attribute.on];
+      values[key] = fk;
+    }
   });
 
   return values;


### PR DESCRIPTION
With certain commits in `waterline-schema` and `sails-mongo`,
association can be set to embeddable using `embed` keyword. And if so,
the associating model can be fully or partially embedded. This is
denormalization, and only works with `sails-mongo` currently.

https://github.com/balderdashy/waterline/issues/427