### PR TITLE
Ignore `through` keyword when validating collections

### DIFF
--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -69,7 +69,7 @@ Validator.prototype.initialize = function(attrs, types) {
       if(attrs[attr][prop] === null) return;
 
       // If property is reserved don't do anything with it
-      if(['defaultsTo', 'primaryKey', 'autoIncrement', 'unique', 'index', 'collection', 'dominant',
+      if(['defaultsTo', 'primaryKey', 'autoIncrement', 'unique', 'index', 'collection', 'dominant', 'through',
           'columnName', 'foreignKey', 'references', 'on', 'groupKey', 'model', 'via', 'size',
           'example', 'validationMessage', 'validations', 'populateSettings'].indexOf(prop) > -1) return;
 


### PR DESCRIPTION
Many-to-Many Through associations are currently defined with the `through` keyword in

```
"attributeName" : {
  collection : "..",
  through: ".."
}
```

This used to work great in sails 10-rc5, but throws "Unkown rule: through" in 10-rc7, so I guess it should be added here to prevent that error.
Or did the internal syntax for defining Many-to-Many Through change?

Cheers!
M
