### PR TITLE
add findOne to adapter

### DIFF
--- a/lib/waterline/adapter/dql.js
+++ b/lib/waterline/adapter/dql.js
@@ -142,6 +142,19 @@ module.exports = {
     // If no criteria is specified or where is empty return an error
     if(!criteria || criteria.where === null) return cb(new Error(err));
 
+    // Detects if there is a `findOne` in the adapter. Use it if it exists.
+    if(hasOwnProperty(this.dictionary, 'findOne')) {
+      var connName = this.dictionary.findOne;
+      var adapter = this.connections[connName]._adapter;
+
+      if(adapter.findOne) {
+        // Normalize Arguments
+        criteria = normalize.criteria(criteria);
+        return adapter.findOne(connName, this.collection, criteria, cb);
+      }
+    }
+
+    // Fallback to use `find()` to simulate a `findOne()`
     // Enforce limit to 1
     criteria.limit = 1;
 


### PR DESCRIPTION
Detects if there is a `findOne` in the adapter. Use it if it exists. And if not, fallback to use `find()` to simulate a `findOne()` as it currently does.
