### PR TITLE
Allow validation rule 'required: false', ignoring it

### DIFF
--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -126,6 +126,11 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
       if(value === null || value === '') return cb();
     }
 
+    // if required is set to 'false', don't enforce as required rule
+    if (curValidation.hasOwnProperty('required')&&!curValidation.required) {
+        return cb();
+    }
+
     // If Boolean and required manually check
     if(curValidation.required && curValidation.type === 'boolean' && (typeof value !== 'undefined' && value !== null)) {
       if(value.toString() == 'true' || value.toString() == 'false') return cb();


### PR DESCRIPTION
This will allow setting 'required: false' in a ruleset, effectively ignoring the rule.
