### PR TITLE
Switch promises from Q to Bluebird

### DIFF
--- a/lib/waterline/model/lib/defaultMethods/destroy.js
+++ b/lib/waterline/model/lib/defaultMethods/destroy.js
@@ -5,7 +5,7 @@
 
 var utils = require('../../../utils/helpers');
 var hasOwnProperty = utils.object.hasOwnProperty;
-var Q = require('q');
+var defer = require('../../../utils/defer');
 var noop = function() {};
 
 /**
@@ -25,7 +25,7 @@ var Destroy = module.exports = function(context, proto, cb) {
 
   cb = cb || noop;
 
-  deferred = Q.defer();
+  deferred = defer();
   values = proto.toObject();
   attributes = context.waterline.schema[context.identity].attributes;
   primaryKey = this.findPrimaryKey(attributes, values);

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -5,7 +5,7 @@ var updateInstance = require('../associationMethods/update');
 var addAssociation = require('../associationMethods/add');
 var removeAssociation = require('../associationMethods/remove');
 var hop = require('../../../utils/helpers').object.hasOwnProperty;
-var Q = require('q');
+var defer = require('../../../utils/defer');
 var noop = function() {};
 
 /**
@@ -22,7 +22,7 @@ var noop = function() {};
  */
 
 module.exports = function(context, proto, cb) {
-  var deferred = Q.defer();
+  var deferred = defer();
   cb = cb || noop;
 
   /**

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -5,7 +5,7 @@
  */
 
 var util = require('util');
-var Q = require('q'),
+var Promise = require('bluebird'),
     _ = require('lodash'),
     normalize = require('../utils/normalize'),
     utils = require('../utils/helpers'),
@@ -498,15 +498,10 @@ Deferred.prototype.exec = function(cb) {
  */
 
 Deferred.prototype.toPromise = function() {
-
-  if (!this._deferred)
-  {
-    this._deferred = Q.defer();
-
-    this.exec(this._deferred.makeNodeResolver());
+  if (!this._deferred) {
+    this._deferred = Promise.promisify(this.exec).bind(this)();
   }
-
-  return this._deferred.promise;
+  return this._deferred;
 };
 
 /**
@@ -530,8 +525,8 @@ Deferred.prototype.spread = function(cb) {
  * returns a promise and gets resolved with error
  */
 
-Deferred.prototype.fail = function(cb) {
-  return this.toPromise().fail(cb);
+Deferred.prototype.catch = function(cb) {
+  return this.toPromise().catch(cb);
 };
 
 

--- a/lib/waterline/utils/defer.js
+++ b/lib/waterline/utils/defer.js
@@ -1,0 +1,16 @@
+var Promise = require('bluebird');
+
+module.exports = function defer() {
+  var resolve, reject;
+
+  var promise = new Promise(function() {
+    resolve = arguments[0];
+    reject = arguments[1];
+  });
+
+  return {
+    resolve: resolve,
+    reject: reject,
+    promise: promise
+  };
+};

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "dependencies": {
     "anchor": "~0.10.0-rc2",
     "async": "~0.9.0",
+    "bluebird": "^2.3.4",
     "deep-diff": "~0.1.7",
     "lodash": "~2.4.1",
     "node-switchback": "~0.1.0",
     "prompt": "~0.2.12",
-    "q": "~1.0.1",
     "waterline-criteria": "~0.10.7",
     "waterline-schema": "~0.1.16"
   },

--- a/test/unit/model/save.js
+++ b/test/unit/model/save.js
@@ -95,7 +95,7 @@ describe('instance methods', function() {
           assert(!data);
           done("promise should be rejected, not resolved");
         })
-        .fail(function(err){
+        .catch(function(err){
           assert(err);
           done();
         });
@@ -141,12 +141,12 @@ describe('instance methods', function() {
           assert(!data);
           done("promise should be rejected, not resolved");
         })
-        .fail(function(err){
+        .catch(function(err){
           assert(err);
           done();
         });
       })
     })
-    
+
   });
 });

--- a/test/unit/query/query.promises.js
+++ b/test/unit/query/query.promises.js
@@ -50,7 +50,7 @@ describe('Collection Promise', function () {
       }).then(function (test) {
         assert(test === 'test');
         done();
-      }).fail(function (err) {
+      }).catch(function (err) {
         done(err);
       });
     });
@@ -60,7 +60,7 @@ describe('Collection Promise', function () {
         throw new Error("Error in promise handler");
       }).then(function (unexpected) {
         done(new Error("Unexpected success"));
-      }).fail(function (expected) {
+      }).catch(function (expected) {
         done();
       });
     });
@@ -70,7 +70,7 @@ describe('Collection Promise', function () {
         throw new Error("Error in promise handler");
       }).then(function (unexpected) {
         done(new Error("Unexpected success"));
-      }).fail(function (expected) {
+      }).catch(function (expected) {
         done();
       });
     });
@@ -86,7 +86,7 @@ describe('Collection Promise', function () {
           assert.strictEqual(result, prevResult, "Previous and current result should be equal");
           done();
         })
-        .fail(function(err){
+        .catch(function(err){
           done(err);
         });
     });


### PR DESCRIPTION
While Q is a great library for Promises, [Bluebird](https://github.com/petkaantonov/bluebird) promises are [almost as fast as callbacks](https://github.com/petkaantonov/bluebird/blob/master/benchmark/stats/latest.md), and even faster than callbacks when using generators, while Q tends to take up a lot of extra memory and runs much slower. Bluebird also has much more [detailed stack traces](https://github.com/petkaantonov/bluebird#how-do-long-stack-traces-differ-from-eg-q).

**Changes:**
- Replace Q with [Bluebird](https://github.com/petkaantonov/bluebird)
- Replace `.fail` with `.catch`
