### PR TITLE
Add `.pick()` and `.omit()` methods

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -94,6 +94,23 @@ Deferred.prototype.pick = function() {
 };
 
 /**
+ * Add a `omit` clause to the criteria object.
+ *
+ * Used for specifying a subset of attributes to `exclude` from the result.
+ *
+ * @param {Array|Object} List of keys to exclude
+ * @return this
+ * @chainable
+ */
+Deferred.prototype.omit = function() {
+  var omitCriteria = this._criteria.omit || {};
+  _.extend(omitCriteria, utils.parseProjectionCriteria(0, arguments));
+
+  this._criteria.omit = omitCriteria;
+  return this;
+}
+
+/**
  * Add a `joins` clause to the criteria object.
  *
  * Used for populating associations.

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -74,7 +74,23 @@ Deferred.prototype.populateAll = function(criteria) {
     self.populate(association.alias, criteria);
   });
   return this;
+};
 
+/**
+ * Add a `pick` clause to the criteria object.
+ *
+ * Used for specifying a subset of attributes to `include` within the result.
+ *
+ * @param {Array|Object} List of keys to include
+ * @return this
+ * @chainable
+ */
+Deferred.prototype.pick = function() {
+  var pickCriteria = this._criteria.pick || {};
+  _.extend(pickCriteria, utils.parseProjectionCriteria(1, arguments));
+
+  this._criteria.pick = pickCriteria;
+  return this;
 };
 
 /**

--- a/lib/waterline/utils/helpers.js
+++ b/lib/waterline/utils/helpers.js
@@ -87,3 +87,23 @@ exports.matchMongoId = function matchMongoId(id) {
   ) return false;
   else return id.toString().match(/^[a-fA-F0-9]{24}$/) ? true : false;
 };
+
+/**
+ * Generates a standardized projection criteria object from an arguments object.
+ *
+ * @param {Boolean} Visibility flag to set for the fields
+ * @param {Object} Projection arguments object to parse
+ */
+exports.parseProjectionCriteria = function parseProjectionCriteria(visability, args) {
+  var firstArg = args[0];
+  var firstArgIsArray  = (_.isArray(firstArg));
+  var firstArgIsObject = (!firstArgIsArray && _.isObject(firstArg));
+  var argsToParse = _.values(args);
+
+  if (firstArgIsObject) {argsToParse = _.keys(firstArg)}
+  if (firstArgIsArray)  {argsToParse = firstArg}
+
+  var objectValues = _.map(argsToParse, function() {return visability});
+
+  return _.object(argsToParse, objectValues);
+}

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -110,7 +110,8 @@ var normalize = module.exports = {
     // If criteria doesn't seem to contain operational keys, assume all the keys are criteria
     if(!criteria.where && !criteria.joins && !criteria.join && !criteria.limit && !criteria.skip &&
       !criteria.sort && !criteria.sum && !criteria.average &&
-      !criteria.groupBy && !criteria.min && !criteria.max && !criteria.select) {
+      !criteria.groupBy && !criteria.min && !criteria.max &&
+      !criteria.select && !criteria.pick && !criteria.omit ) {
 
       // Delete any residuals and then use the remaining keys as attributes in a criteria query
       delete criteria.where;
@@ -119,6 +120,8 @@ var normalize = module.exports = {
       delete criteria.limit;
       delete criteria.skip;
       delete criteria.sort;
+      delete criteria.pick;
+      delete criteria.omit;
       criteria = {
         where: criteria
       };

--- a/test/unit/query/query.find.js
+++ b/test/unit/query/query.find.js
@@ -159,5 +159,132 @@ describe('Collection Query', function() {
         });
       });
     });
+
+    describe('.pick()', function() {
+      it('should take projection criteria as string arguments', function(done) {
+        query.find()
+        .pick('foo', 'bar')
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].pick.foo === 1);
+          assert(results[0].pick.bar === 1);
+
+          done();
+        });
+
+      });
+
+      it('should take projection criteria as an array', function(done) {
+        query.find()
+        .pick(['foo', 'bar'])
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].pick.foo === 1);
+          assert(results[0].pick.bar === 1);
+
+          done();
+        });
+      });
+
+      it('should take projection criteria as an object', function(done) {
+        query.find()
+        .pick({foo: 1, bar: 1})
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].pick.foo === 1);
+          assert(results[0].pick.bar === 1);
+
+          done();
+        });
+      });
+
+      it('should change all object keys to 1', function(done) {
+        query.find()
+        .pick({foo: 0, bar: 'foobar'})
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].pick.foo === 1);
+          assert(results[0].pick.bar === 1);
+
+          done();
+        });
+      });
+
+      it('should be chainable', function(done) {
+        query.find()
+        .pick('foo')
+        .pick('bar')
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].pick.foo === 1);
+          assert(results[0].pick.bar === 1);
+
+          done();
+        });
+      });
+    });
+
+    describe('.omit()', function() {
+      it('should take projection criteria as string arguments', function(done) {
+        query.find()
+        .omit('foo', 'bar')
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].omit.foo === 0);
+          assert(results[0].omit.bar === 0);
+
+          done();
+        });
+      });
+
+      it('should take projection criteria as an array', function(done) {
+        query.find()
+        .omit(['foo', 'bar'])
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].omit.foo === 0);
+          assert(results[0].omit.bar === 0);
+
+          done();
+        });
+      });
+
+      it('should take projection criteria as an object', function(done) {
+        query.find()
+        .omit({foo: 1, bar: 1})
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].omit.foo === 0);
+          assert(results[0].omit.bar === 0);
+
+          done();
+        });
+      });
+
+      it('should change all object keys to 0', function(done) {
+        query.find()
+        .omit({foo: 1, bar: 'foobar'})
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].omit.foo === 0);
+          assert(results[0].omit.bar === 0);
+
+          done();
+        });
+      });
+
+      it('should be chainable', function(done) {
+        query.find()
+        .omit('foo')
+        .omit('bar')
+        .exec(function(err, results) {
+          assert(!err);
+          assert(results[0].omit.foo === 0);
+          assert(results[0].omit.bar === 0);
+
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds the ability to apply projections to waterline queries. It's an extension of the work accomplished in  #162 by adding flexibility for how selection arguments are supplied as well as exclusions via `.omit()`. With this change, the adapters will always receive a standardized selection criteria object which they can process as needed for their specific query language. Here's an example of this object:
```js
// User.find().pick('name', 'age').exec(cb);
{ where: null, pick: { name: 1, age: 1 } }

// User.find().omit('name', 'age').exec(cb);
{ where: null, omit: { name: 0, age: 0 } }
```

Usage examples:
```js
// Include only 
User.find().pick('name', 'age').exec(cb);
User.find().pick(['name', 'age']).exec(cb);
User.find().pick({name: 1, age: 1}).exec(cb);

// Exclusion
User.find().omit('name', 'age').exec(cb);
User.find().omit(['name', 'age']).exec(cb);
User.find().omit({name: 0, age: 0}).exec(cb);
```

fixes #73