### PR TITLE
Fix populating more than 2 associations with criteria

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -261,7 +261,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
     }
 
     // Set the criteria joins
-    this._criteria.joins = _.union(this._criteria.joins || [], joins);
+    this._criteria.joins = Array.prototype.concat(this._criteria.joins || [], joins);
 
     return this;
   }


### PR DESCRIPTION
If `Model.populate(keyName, criteria)` called N times, there might be N ~ 2N joins. If there is a criteria for each population, only the first join or the second join will use the criteria, and it will be override during the next call of `Model.populate()`, see lines between 256 ~ 261.

This fix let each join to use the correct criteria when there are more than 2 joins.
