### PR TITLE
create beforeFind lifecycle callback

### DIFF
--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -13,7 +13,8 @@ var usageError = require('../../utils/usageError'),
     waterlineCriteria = require('waterline-criteria'),
     _ = require('lodash'),
     async = require('async'),
-    hasOwnProperty = utils.object.hasOwnProperty;
+    hasOwnProperty = utils.object.hasOwnProperty,
+    callbacks = require('../../utils/callbacksRunner');
 
 module.exports = {
 
@@ -39,6 +40,10 @@ module.exports = {
 
     // Normalize criteria
     criteria = normalize.criteria(criteria);
+
+    this.beforeCallbacks.call(self,criteria.where,function(err){
+      if (err) {return cb(err);}
+    });
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {
@@ -205,6 +210,10 @@ module.exports = {
       return usageError('Invalid options specified!', usage, cb);
     }
 
+    this.beforeCallbacks.call(self,criteria.where,function(err){
+      if (err) return cb(err);
+    });
+
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {
       return new Deferred(this, this.find, criteria);
@@ -351,6 +360,15 @@ module.exports = {
       }
 
     });
+  },
+
+  beforeCallbacks:function(criteria,cb){
+    var self = this;
+    async.series([
+      function(cb){
+        callbacks.beforeFind(self,criteria,cb);
+      }
+    ]);
   },
 
   where: function() {

--- a/lib/waterline/utils/callbacks.js
+++ b/lib/waterline/utils/callbacks.js
@@ -10,5 +10,6 @@ module.exports = [
   'beforeCreate',
   'afterCreate',
   'beforeDestroy',
-  'afterDestroy'
+  'afterDestroy',
+  'beforeFind'
 ];

--- a/lib/waterline/utils/callbacksRunner.js
+++ b/lib/waterline/utils/callbacksRunner.js
@@ -138,3 +138,21 @@ runner.afterDestroy = function(context, values, cb) {
 
   async.eachSeries(context._callbacks.afterDestroy, fn, cb);
 };
+
+/**
+ * Run before Find Callbacks
+ *
+ * @param {Object} context
+ * @param {Object} values
+ * @param {Function} cb
+ * @api public
+ */
+
+runner.beforeFind = function(context, values, cb) {
+
+  var fn = function(item, next) {
+    item(values, next);
+  };
+
+  async.eachSeries(context._callbacks.beforeFind, fn, cb);
+};

--- a/test/unit/callbacks/beforeFind.find.js
+++ b/test/unit/callbacks/beforeFind.find.js
@@ -1,0 +1,155 @@
+var Waterline = require('../../../lib/waterline'),
+    assert = require('assert');
+
+describe('.beforeFind()', function() {
+
+  describe('basic function', function() {
+    var person;
+
+    before(function(done) {
+      var waterline = new Waterline();
+      var Model = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          name: 'string',
+          isDeleted:'boolean'
+        },
+
+        beforeFind: function(values, cb) {
+          values.isDeleted = false;
+          cb();
+        }
+      });
+
+      waterline.loadCollection(Model);
+
+      // Fixture Adapter Def
+      var adapterDef = {
+        find: function(con, col, values, cb) { return cb(null, [values.where]);},
+        findOne:function(conn,col,values,cb){return cb(null,values.where);}
+      };
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        person = colls.collections.user;
+        done();
+      });
+    });
+
+    // /**
+    //  * find
+    //  */
+
+    describe('.find()', function() {
+
+      it('should run beforeFind and mutate values', function(done) {
+
+        person.find({name:'billy'}, function(err, users) {
+          assert(!err);
+          assert(users[0].isDeleted === false);
+          done();
+        });
+
+      });
+    });
+
+
+    // /**
+    //  * findOne
+    //  */
+
+    describe('.findOne()', function() {
+
+      it('should run beforefind and mutate values', function(done) {
+
+        person.findOne({name:'billy'}, function(err, user) {
+          assert(!err);
+          assert(user.isDeleted === false);
+          done();
+        });
+
+      });
+    });
+
+
+
+  });
+
+
+  /**
+   * Test Callbacks can be defined as arrays and run in order.
+   */
+
+  describe('array of functions', function() {
+    var person;
+
+    before(function(done) {
+      var waterline = new Waterline();
+      var Model = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          name: 'string'
+        },
+
+        beforeFind: [
+          // Function 1
+          function(values, cb) {
+            values.name = values.name + ' fn1';
+            cb();
+          },
+
+          // Function 2
+          function(values, cb) {
+            values.name = values.name + ' fn2';
+            cb();
+          }
+        ]
+      });
+
+      waterline.loadCollection(Model);
+
+      // Fixture Adapter Def
+      var adapterDef = {
+        find: function(con, col, values, cb) { return cb(null, [values.where,]);},
+        findOne:function(conn,col,values,cb){return cb(null,values.where);}
+      };
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        person = colls.collections.user;
+        done();
+      });
+    });
+
+    it('should run the functions in order on find()', function(done) {
+      person.find({ name: 'test' }, function(err, users) {
+        assert(!err);
+        assert(users[0].name === 'test fn1 fn2');
+        done();
+      });
+    });
+    it('should run the functions in order on findOne()', function(done) {
+      person.findOne({ name: 'test' }, function(err, user) {
+        assert(!err);
+        assert(user.name === 'test fn1 fn2');
+        done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
I created a beforeFind lifecycle callback to allow a user to always modify a model's find or findOne queries with some criteria. A good use case would be if you're using a soft-delete system and you'd like to tack on an isDeleted:false to any find query on a model. Please feel free to critique the code/suggest changes, I tried to stick to the style that already exists.