### PR TITLE
Fix .find() when passing options and returning a promise.

### DIFF
--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -207,7 +207,7 @@ module.exports = {
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {
-      return new Deferred(this, this.find, criteria);
+      return new Deferred(this, this.find, criteria, options);
     }
 
     // If there was something defined in the criteria that would return no results, don't even


### PR DESCRIPTION
The options param wasn't being passed through when returning a Deferred.
This caused them to be silently dropped.
