### PR TITLE
Auto pick association fields from REST request

### DIFF
--- a/lib/waterline/utils/nestedOperations/create.js
+++ b/lib/waterline/utils/nestedOperations/create.js
@@ -32,6 +32,9 @@ module.exports = function(parentModel, values, associations, cb) {
 
     var optValues = values[association];
     if(!optValues) return;
+    if(!_.isArray(optValues)){
+    	optValues = _.isString(optValues) ? optValues.split(',') : [optValues];
+    }
     optValues.forEach(function(val) {
 
       // If value is not an object, queue up an add


### PR DESCRIPTION
Making a REST PUT request with the association field and value throws an error at the forEach step. Correction to that. 

Additionally, for One-to-Many or Many-to-Many all IDs can be passed as comma-separated values.
