### PR TITLE
Fixed query promises to be able to resolve multiple times

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -23,6 +23,8 @@ var Deferred = module.exports = function(context, method, criteria, values) {
   this._criteria = criteria;
   this._values = values || null;
 
+  this._deferred = null; // deferred object for promises
+
   return this;
 };
 
@@ -491,11 +493,15 @@ Deferred.prototype.exec = function(cb) {
  */
 
 Deferred.prototype.toPromise = function() {
-  var deferred = Q.defer();
 
-  this.exec(deferred.makeNodeResolver());
+  if (!this._deferred)
+  {
+    this._deferred = Q.defer();
 
-  return deferred.promise;
+    this.exec(this._deferred.makeNodeResolver());
+  }
+
+  return this._deferred.promise;
 };
 
 /**

--- a/test/unit/query/query.promises.js
+++ b/test/unit/query/query.promises.js
@@ -74,5 +74,21 @@ describe('Collection Promise', function () {
         done();
       });
     });
+
+    it('should only resolve once', function(done){
+      var promise = query.find({});
+      var prevResult;
+      promise
+        .then(function(result){
+          prevResult = result;
+          return promise;
+        }).then(function(result){
+          assert.strictEqual(result, prevResult, "Previous and current result should be equal");
+          done();
+        })
+        .fail(function(err){
+          done(err);
+        });
+    });
   });
 });


### PR DESCRIPTION
The current implementation of .then does not follow the Promise/A+ spec.

A promise once resolved or rejected should not be able to change its value. The current situation does allow that. For example:

```
var promise = query.find({});
var prevResult;
promise
  .then(function(result){
    prevResult = result;
    return promise;
  }).then(function(result){
    if (result === prevResult)
      return "the same";
    else
      return "not the same";
  });
```

This will return "not the same" whereas if "promise" was an actual promise this should return "the same".

Solution: Store the promise in the deferred object and create it only once.
