### PR TITLE
Fixed 2 situations on model.save where the promise was not rejected

### DIFF
--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -159,7 +159,9 @@ module.exports = function(context, proto, cb) {
     var PK = context.primaryKey;
 
     if(!results.updateRecord.length) {
-      return cb(new Error('Error updating a record.'));
+      var error = new Error('Error updating a record.');
+      deferred.reject(error);
+      return cb(error);
     }
 
     var obj = results.updateRecord[0].toObject();
@@ -174,7 +176,11 @@ module.exports = function(context, proto, cb) {
     });
 
     query.exec(function(err, data) {
-      if(err) return cb(err);
+      if(err) 
+      {
+        deferred.reject(err);
+        return cb(err);
+      }
       deferred.resolve(data);
       cb(null, data);
     });


### PR DESCRIPTION
There were 2 situations in model instance.save where with the callback was called with an error, but the promise wasn't rejected.
