### PR TITLE
when creating a model, with association, and association assigned null, waterline breaks

### DIFF
--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -120,7 +120,7 @@ Add.prototype.createAssociations = function(key, records, cb) {
 
     // If an object was passed in it should be created.
     // This allows new records to be created through the association interface
-    if(typeof association === 'object' && Object.keys(association).length > 0) {
+    if(association !== null && typeof association === 'object' && Object.keys(association).length > 0) {
       return self.createNewRecord(associatedCollection, schema, association, next);
     }
 


### PR DESCRIPTION
when creating a model, that has an association, if the association attribute is assigned [null] , it breaks waterline. Added check for null.

Ex, sending {"name":"some name", groups:[null]} for a user<==>group many-to-many association
