### PR TITLE
Fixes associations when being sent null as value in association array when creating a model

### DIFF
--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -120,7 +120,7 @@ Add.prototype.createAssociations = function(key, records, cb) {
 
     // If an object was passed in it should be created.
     // This allows new records to be created through the association interface
-    if(typeof association === 'object' && Object.keys(association).length > 0) {
+    if(association !== null && typeof association === 'object' && Object.keys(association).length > 0) {
 
       // Check if the record contains a primary key, if so just link the values
       if(hasOwnProperty(association, associatedCollection.primaryKey)) {


### PR DESCRIPTION
In a many-to-many association, ie. User--Group, if a user is created with {"name":"John Doe", groups:[null]}, Waterline breaks, as null is an object, and Object.keys(null) breaks Waterline. Added null check to the if statement
