### PR TITLE
Remove model.destroy() criteria check

### DIFF
--- a/lib/waterline/adapter/dql.js
+++ b/lib/waterline/adapter/dql.js
@@ -256,8 +256,6 @@ module.exports = {
     cb = normalize.callback(cb);
     criteria = normalize.criteria(criteria);
 
-    //if(!criteria) return cb(new Error('No criteria or id specified!'));
-
     // Build Default Error Message
     var err = 'No destroy() method defined in adapter!';
 

--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -43,7 +43,6 @@ module.exports = function(criteria, cb) {
 
   var usage = utils.capitalize(this.identity) + '.destroy([options], callback)';
 
-//  if(!criteria) return usageError('No options were defined!', usage, cb);
   if(typeof cb !== 'function') return usageError('Invalid callback specified!', usage, cb);
 
   callbacks.beforeDestroy(self, criteria, function(err) {


### PR DESCRIPTION
Fixes #548 by removing the model.destroy() criteria check since it is supposed to be optional

Tests are over here on this waterline-adapter-tests PR: https://github.com/balderdashy/waterline-adapter-tests/pull/20
