### PR TITLE
Add ability to disable dynamicFinders and associationFinders

### DIFF
--- a/lib/waterline/query/finders/dynamicFinders.js
+++ b/lib/waterline/query/finders/dynamicFinders.js
@@ -26,8 +26,10 @@ finder.buildDynamicFinders = function() {
   Object.keys(this._schema.schema).forEach(function(attrName) {
 
     // Check if attribute is an association, if so generate limited dynamic finders
-    if(hasOwnProperty(self._schema.schema[attrName], 'foreignKey')) {
-      self.generateAssociationFinders(attrName);
+    if (hasOwnProperty(self._schema.schema[attrName], 'foreignKey')) {
+      if (self.associationFinders !== false) {
+        self.generateAssociationFinders(attrName);
+      }
       return;
     }
 
@@ -36,13 +38,15 @@ finder.buildDynamicFinders = function() {
 
     var lowercasedMethods = ['*StartsWith', '*Contains', '*EndsWith'];
 
-    capitalizedMethods.forEach(function(method) {
-      self.generateDynamicFinder(attrName, method);
-    });
 
-    lowercasedMethods.forEach(function(method) {
-      self.generateDynamicFinder(attrName, method, true);
-    });
+    if (self.dynamicFinders !== false) {
+      capitalizedMethods.forEach(function(method) {
+        self.generateDynamicFinder(attrName, method);
+      });
+      lowercasedMethods.forEach(function(method) {
+        self.generateDynamicFinder(attrName, method, true);
+      });
+    }
   });
 };
 

--- a/test/unit/query/query.dynamicFinders.js
+++ b/test/unit/query/query.dynamicFinders.js
@@ -4,78 +4,135 @@ var Waterline = require('../../../lib/waterline'),
 describe('Collection Query', function() {
 
   describe('dynamicFinders', function() {
-    var query;
 
-    before(function(done) {
+    describe('configuration', function() {
+      var collections;
 
-      var waterline = new Waterline();
-      var User = Waterline.Collection.extend({
-        identity: 'user',
-        connection: 'foo',
-        attributes: {
-          name: 'string',
-          group: {
-            model: 'group'
+      before(function (done) {
+
+        var waterline = new Waterline();
+        var User = Waterline.Collection.extend({
+          identity: 'user',
+          connection: 'foo',
+          associationFinders: false,
+          attributes: {
+            name: 'string',
+            group: {
+              model: 'group'
+            }
           }
-        }
+        });
+
+        var Group = Waterline.Collection.extend({
+          identity: 'group',
+          connection: 'foo',
+          dynamicFinders: false,
+          attributes: {
+            name: 'string'
+          }
+        });
+
+        waterline.loadCollection(User);
+        waterline.loadCollection(Group);
+
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        waterline.initialize({ adapters: { foobar: {} }, connections: connections }, function(err, orm) {
+          if (err) return done(err);
+
+          collections = orm.collections;
+          done();
+        });
       });
 
-      var Group = Waterline.Collection.extend({
-        identity: 'group',
-        connection: 'foo',
-        attributes: {
-          name: 'string'
-        }
+      it('can disable dynamicFinders', function () {
+        assert(typeof collections.group.findOneByName === 'undefined');
+      });
+      it('can disable associationFinders', function () {
+        assert(typeof collections.user.findByName === 'function');
+        assert(typeof collections.user.findByGroupIn === 'undefined');
       });
 
-      waterline.loadCollection(User);
-      waterline.loadCollection(Group);
+    });
 
-      var connections = {
-        'foo': {
-          adapter: 'foobar'
-        }
-      };
+    describe('usage', function () {
+      var query;
 
-      waterline.initialize({ adapters: { foobar: {} }, connections: connections }, function(err, colls) {
-        if(err) return done(err);
-        query = colls.collections.user;
-        done();
+      before(function(done) {
+
+        var waterline = new Waterline();
+        var User = Waterline.Collection.extend({
+          identity: 'user',
+          connection: 'foo',
+          attributes: {
+            name: 'string',
+            group: {
+              model: 'group'
+            }
+          }
+        });
+
+        var Group = Waterline.Collection.extend({
+          identity: 'group',
+          connection: 'foo',
+          attributes: {
+            name: 'string'
+          }
+        });
+
+        waterline.loadCollection(User);
+        waterline.loadCollection(Group);
+
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        waterline.initialize({ adapters: { foobar: {} }, connections: connections }, function(err, colls) {
+          if(err) return done(err);
+          query = colls.collections.user;
+          done();
+        });
       });
-    });
 
-    it('should add dynamic finder functions', function() {
-      assert(typeof query.findOneByName === 'function');
-      assert(typeof query.findOneByNameIn === 'function');
-      assert(typeof query.findOneByNameLike === 'function');
-      assert(typeof query.findByName === 'function');
-      assert(typeof query.findByNameIn === 'function');
-      assert(typeof query.findByNameLike === 'function');
-      assert(typeof query.countByName === 'function');
-      assert(typeof query.countByNameIn === 'function');
-      assert(typeof query.countByNameLike === 'function');
-      assert(typeof query.nameStartsWith === 'function');
-      assert(typeof query.nameEndsWith === 'function');
-      assert(typeof query.nameContains === 'function');
-    });
+      it('should add dynamic finder functions', function() {
+        assert(typeof query.findOneByName === 'function');
+        assert(typeof query.findOneByNameIn === 'function');
+        assert(typeof query.findOneByNameLike === 'function');
+        assert(typeof query.findByName === 'function');
+        assert(typeof query.findByNameIn === 'function');
+        assert(typeof query.findByNameLike === 'function');
+        assert(typeof query.countByName === 'function');
+        assert(typeof query.countByNameIn === 'function');
+        assert(typeof query.countByNameLike === 'function');
+        assert(typeof query.nameStartsWith === 'function');
+        assert(typeof query.nameEndsWith === 'function');
+        assert(typeof query.nameContains === 'function');
+      });
 
-    it('should not create generic dynamic finders for has_one and belongs_to associations', function() {
-      assert(!query.findOneByGroupIn);
-      assert(!query.findOneByGroupLike);
-      assert(!query.findByGroupIn);
-      assert(!query.findByGroupLike);
-      assert(!query.countByGroup);
-      assert(!query.countByGroupIn);
-      assert(!query.countByGroupLike);
-      assert(!query.groupStartsWith);
-      assert(!query.groupEndsWith);
-      assert(!query.groupContains);
-    });
+      it('should not create generic dynamic finders for has_one and belongs_to associations', function() {
+        assert(!query.findOneByGroupIn);
+        assert(!query.findOneByGroupLike);
+        assert(!query.findByGroupIn);
+        assert(!query.findByGroupLike);
+        assert(!query.countByGroup);
+        assert(!query.countByGroupIn);
+        assert(!query.countByGroupLike);
+        assert(!query.groupStartsWith);
+        assert(!query.groupEndsWith);
+        assert(!query.groupContains);
+      });
 
-    it.skip('should create limited dynamic finders for has_one and belongs_to associations', function() {
-      assert(typeof query.findByGroup === 'function');
-      assert(typeof query.findOneByGroup === 'function');
-    });
+      it.skip('should create limited dynamic finders for has_one and belongs_to associations', function() {
+        assert(typeof query.findByGroup === 'function');
+        assert(typeof query.findOneByGroup === 'function');
+      });
 
+    });
   });
 });


### PR DESCRIPTION
- resolves #592

modified:   lib/waterline/query/finders/dynamicFinders.js
- only generate dynamic finders and association finders if the
  dynamicFinders and associationFinders flags are not false

modified:   test/unit/query/query.dynamicFinders.js
- unit test ability to enable/disable dynamicFinders and
  associationFinders
