### PR TITLE
improve initialize() performance

### DIFF
--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -282,7 +282,7 @@ Waterline.prototype.bootstrap = function bootstrap(cb) {
 
   // Run auto-migration strategies on each collection
   // async.each(toBeSynced, function(collection, next) {
-  async.eachSeries(toBeSynced, function(collection, next) {
+  async.each(toBeSynced, function(collection, next) {
   // async.eachLimit(toBeSynced, 9, function(collection, next) {
     collection.sync(next);
   }, cb);


### PR DESCRIPTION
- use async.each instead of eachSeries

This improves performance in proportion to the number of concurrent operations the datastore is capable of. For example, on a 4-core machine with HT, performance improvement is roughly 6x. Time to create 304 tables (approx 11k columns total) decreased from 2 minutes to ~17 seconds with `sails-postgres` adapter. Performance seems unchanged in `sails-disk` and `sails-memory`.
