### PR TITLE
Adding consistency to primary key discovery. Fixes #606.

### DIFF
--- a/lib/waterline/core/index.js
+++ b/lib/waterline/core/index.js
@@ -92,8 +92,9 @@ Core._initialize = function(options) {
 
   // Set the collection's primaryKey attribute
   Object.keys(schemaAttributes).forEach(function(key) {
-    if(!hasOwnProperty(schemaAttributes[key], 'primaryKey')) return;
-    self.primaryKey = key;
+    if(hasOwnProperty(schemaAttributes[key], 'primaryKey') && schemaAttributes[key].primaryKey) {
+      self.primaryKey = key;
+    }
   });
 
   // Build Data Transformer

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -159,8 +159,10 @@ Schema.prototype.objectAttribute = function(attrName, value) {
         var attrs = this.context.waterline.schema[value[key].toLowerCase()].attributes;
 
         for(var attribute in attrs) {
-          if(!hasOwnProperty(attrs[attribute], 'primaryKey')) continue;
-          type = attrs[attribute].type;
+          if(hasOwnProperty(attrs[attribute], 'primaryKey') && attrs[attribute].primaryKey) {
+            type = attrs[attribute].type;
+            break;
+          }
         }
 
         attr.type = type.toLowerCase();

--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -61,8 +61,9 @@ Add.prototype.findPrimaryKey = function(attributes, values) {
   var primaryKey = null;
 
   for(var attribute in attributes) {
-    if(hasOwnProperty(attributes[attribute], 'primaryKey')) {
+    if(hasOwnProperty(attributes[attribute], 'primaryKey') && attributes[attribute].primaryKey) {
       primaryKey = attribute;
+      break;
     }
   }
 

--- a/lib/waterline/model/lib/associationMethods/remove.js
+++ b/lib/waterline/model/lib/associationMethods/remove.js
@@ -54,8 +54,9 @@ Remove.prototype.findPrimaryKey = function(attributes, values) {
   var primaryKey = null;
 
   for(var attribute in attributes) {
-    if(hasOwnProperty(attributes[attribute], 'primaryKey')) {
+    if(hasOwnProperty(attributes[attribute], 'primaryKey') && attributes[attribute].primaryKey) {
       primaryKey = attribute;
+      break;
     }
   }
 

--- a/lib/waterline/model/lib/associationMethods/update.js
+++ b/lib/waterline/model/lib/associationMethods/update.js
@@ -74,8 +74,9 @@ Update.prototype.findPrimaryKey = function(attributes, values) {
   var primaryKey = null;
 
   for(var attribute in attributes) {
-    if(hop(attributes[attribute], 'primaryKey')) {
+    if(hop(attributes[attribute], 'primaryKey') && attributes[attribute].primaryKey) {
       primaryKey = attribute;
+      break;
     }
   }
 

--- a/lib/waterline/model/lib/defaultMethods/destroy.js
+++ b/lib/waterline/model/lib/defaultMethods/destroy.js
@@ -73,8 +73,9 @@ Destroy.prototype.findPrimaryKey = function(attributes, values) {
   var primaryKey = null;
 
   for(var attribute in attributes) {
-    if(hasOwnProperty(attributes[attribute], 'primaryKey')) {
+    if(hasOwnProperty(attributes[attribute], 'primaryKey') && attributes[attribute].primaryKey) {
       primaryKey = attribute;
+      break;
     }
   }
 

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -128,7 +128,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
     // Get the current collection's primary key attribute
     Object.keys(this._context._attributes).forEach(function(key) {
-      if(hasOwnProperty(self._context._attributes[key], 'primaryKey')) {
+      if(hasOwnProperty(self._context._attributes[key], 'primaryKey') && self._context._attributes[key].primaryKey) {
         pk = self._context._attributes[key].columnName || key;
       }
     });

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -79,7 +79,9 @@ module.exports = {
       var primaryKey = 'id';
 
       Object.keys(self._schema.schema).forEach(function(key) {
-        if(self._schema.schema[key].hasOwnProperty('primaryKey')) primaryKey = key;
+        if(self._schema.schema[key].hasOwnProperty('primaryKey') && self._schema.schema[key].primaryKey) {
+          primaryKey = key;
+        }
       });
 
 
@@ -249,7 +251,9 @@ module.exports = {
       var primaryKey = 'id';
 
       Object.keys(self._schema.schema).forEach(function(key) {
-        if(self._schema.schema[key].hasOwnProperty('primaryKey')) primaryKey = key;
+        if(self._schema.schema[key].hasOwnProperty('primaryKey') && self._schema.schema[key].primaryKey) {
+          primaryKey = key;
+        }
       });
 
       // Perform in-memory joins

--- a/lib/waterline/query/finders/dynamicFinders.js
+++ b/lib/waterline/query/finders/dynamicFinders.js
@@ -241,7 +241,7 @@ function buildJoin() {
 
   // Get the current collection's primary key attribute
   Object.keys(self._attributes).forEach(function(key) {
-    if(hasOwnProperty(self._attributes[key], 'primaryKey')) {
+    if(hasOwnProperty(self._attributes[key], 'primaryKey') && self._attributes[key].primaryKey) {
       pk = key;
     }
   });

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -703,8 +703,10 @@ Operations.prototype._findCollectionPK = function _findCollectionPK(collectionNa
 
   for(var attribute in this.context.waterline.collections[collectionName]._attributes) {
     var attr = this.context.waterline.collections[collectionName]._attributes[attribute];
-    if(!hasOwnProperty(attr, 'primaryKey')) continue;
-    pk = attr.columnName || attribute;
+    if(hasOwnProperty(attr, 'primaryKey') && attr.primaryKey) {
+      pk = attr.columnName || attribute;
+      break;
+    }
   }
 
   return pk || null;


### PR DESCRIPTION
This is mean't to fix issue #606 and possible others.

Right now if you set `primaryKey` to `false` on some attribute (which is common if you need to generate models dynamically), it's not properly checked and you end up with the wrong attribute being set as the model `primaryKey`.

I had to change this in 10 places, whereas I could have changed this only once. In the long run I believe we could have this on a function `findPrimaryKey()` in some common include file so we use the same function all over the place.
