### PR TITLE
Added guarding/fill ability to waterline models

### DIFF
--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -37,6 +37,10 @@ module.exports = function(context, mixins) {
       return new defaultMethods.destroy(context, this, cb);
     },
 
+    fill: function(attributes) {
+      defaultMethods.fill(context, this, attributes);
+    },
+
     _defineAssociations: function() {
       new internalMethods.defineAssociations(context, this);
     },

--- a/lib/waterline/model/lib/defaultMethods/fill.js
+++ b/lib/waterline/model/lib/defaultMethods/fill.js
@@ -8,13 +8,14 @@ var _ = require('lodash');
 /**
  * Model.fill()
  *
- * Takes the currently set attributes and updates the database.
- * Shorthand for Model.update({ attributes }, cb)
+ * Updates the model's attributes, removing any attributes which appear to be
+ * "guarded" or attributes which are not on the model's set of defined
+ * attributes.
  *
  * @param {Object} context
  * @param {Object} proto
- * @param {Function} callback
- * @return {Promise}
+ * @param {Object} attributes
+ * @return void
  * @api public
  */
 module.exports = function(context, proto, attributes) {
@@ -28,6 +29,6 @@ module.exports = function(context, proto, attributes) {
       delete attributes[key];
     }
   });
-  
+
   _.extend(proto, attributes);
 }

--- a/lib/waterline/model/lib/defaultMethods/fill.js
+++ b/lib/waterline/model/lib/defaultMethods/fill.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 /**
  * Model.fill()
  *

--- a/lib/waterline/model/lib/defaultMethods/fill.js
+++ b/lib/waterline/model/lib/defaultMethods/fill.js
@@ -1,10 +1,3 @@
-
-/**
- * Module dependencies
- */
-
-var _ = require('lodash');
-
 /**
  * Model.fill()
  *
@@ -24,11 +17,12 @@ module.exports = function(context, proto, attributes) {
   attributes = _.cloneDeep(attributes);
 
   Object.keys(attributes).forEach(function(key) {
-    if (!! _.find(context.guarded || [], key) ||
-           typeof context.attributes[key] === 'undefined') {
+    if (context.guarded.indexOf(key) !== -1 ||
+        typeof context.attributes[key] === 'undefined') {
+
       delete attributes[key];
     }
   });
 
   _.extend(proto, attributes);
-}
+};

--- a/lib/waterline/model/lib/defaultMethods/fill.js
+++ b/lib/waterline/model/lib/defaultMethods/fill.js
@@ -17,7 +17,7 @@ module.exports = function(context, proto, attributes) {
   attributes = _.cloneDeep(attributes);
 
   Object.keys(attributes).forEach(function(key) {
-    if (context.guarded.indexOf(key) !== -1 ||
+    if ((context.guarded || []).indexOf(key) !== -1 ||
         typeof context.attributes[key] === 'undefined') {
 
       delete attributes[key];

--- a/lib/waterline/model/lib/defaultMethods/fill.js
+++ b/lib/waterline/model/lib/defaultMethods/fill.js
@@ -1,0 +1,33 @@
+
+/**
+ * Module dependencies
+ */
+
+var _ = require('lodash');
+
+/**
+ * Model.fill()
+ *
+ * Takes the currently set attributes and updates the database.
+ * Shorthand for Model.update({ attributes }, cb)
+ *
+ * @param {Object} context
+ * @param {Object} proto
+ * @param {Function} callback
+ * @return {Promise}
+ * @api public
+ */
+module.exports = function(context, proto, attributes) {
+
+  // Ensure we have a fresh attributes set so we don't screw other things up!
+  attributes = _.cloneDeep(attributes);
+
+  Object.keys(attributes).forEach(function(key) {
+    if (!! _.find(context.guarded || [], key) ||
+           typeof context.attributes[key] === 'undefined') {
+      delete attributes[key];
+    }
+  });
+  
+  _.extend(proto, attributes);
+}

--- a/lib/waterline/model/lib/defaultMethods/index.js
+++ b/lib/waterline/model/lib/defaultMethods/index.js
@@ -6,5 +6,6 @@
 module.exports = {
   toObject: require('./toObject'),
   destroy: require('./destroy'),
-  save: require('./save')
+  save: require('./save'),
+  fill: require('./fill')
 };

--- a/test/support/fixtures/model/context.belongsTo.fixture.js
+++ b/test/support/fixtures/model/context.belongsTo.fixture.js
@@ -12,6 +12,8 @@ module.exports = function() {
 
   context.primaryKey = 'id';
 
+  context.guarded = ['seekrit'];
+
   // Set collection attributes
   context._attributes = {
     id: {
@@ -25,7 +27,8 @@ module.exports = function() {
     bars: {
       collection: 'bar',
       via: 'foo'
-    }
+    },
+    seekrit: { type: 'string' }
   };
 
   // Build a mock global schema object
@@ -34,6 +37,7 @@ module.exports = function() {
       identity: 'foo',
       attributes: {
         name: 'string',
+        seekrit: 'string',
         bars: {
           collection: 'bar',
           references: 'bar',

--- a/test/unit/model/fill.js
+++ b/test/unit/model/fill.js
@@ -1,0 +1,32 @@
+var assert = require('assert'),
+    belongsToFixture = require('../../support/fixtures/model/context.belongsTo.fixture'),
+    Model = require('../../../lib/waterline/model');
+
+describe('model fill', function() {
+
+  /////////////////////////////////////////////////////
+  // TEST SETUP
+  ////////////////////////////////////////////////////
+
+  var fixture, model;
+
+  before(function() {
+    fixture = belongsToFixture();
+    model = new Model(fixture, {});
+  });
+
+
+  /////////////////////////////////////////////////////
+  // TEST METHODS
+  ////////////////////////////////////////////////////
+
+  it('should fill values correctly', function(done) {
+    var person = new model();
+    person.seekrit = 'ok';
+    person.fill({ name: 'Joe', seekrit: 'this should not be set' });
+
+    assert(person.name === 'Joe');
+    assert(person.seekrit === 'ok');
+    done();
+  });
+});

--- a/test/unit/model/fill.js
+++ b/test/unit/model/fill.js
@@ -23,10 +23,11 @@ describe('model fill', function() {
   it('should fill values correctly', function(done) {
     var person = new model();
     person.seekrit = 'ok';
-    person.fill({ name: 'Joe', seekrit: 'this should not be set' });
+    person.fill({ name: 'Joe', seekrit: 'this should not be set', extra: 'blarg' });
 
     assert(person.name === 'Joe');
     assert(person.seekrit === 'ok');
+    assert(typeof person.extra === 'undefined');
     done();
   });
 });


### PR DESCRIPTION
Guarding ability as seen in #649, just had to move it to a new branch.

Previously, there wasn't a really _good_ way of updating a model's attributes en masse (e.g. from form input) without manually filtering out attributes you didn't want to have the user be able to set. That doesn't lend itself to very DRY design, and is a pain in the neck!

I've added the ability to denote "guarded" properties of the model, then use a method "fill" to effectively extend the model based on dirty input.

For example, you can have a model like:
```js
{
  attributes: {
    id: {
      type: 'integer',
      autoIncrement: true,
      primaryKey: true,
      unique: true
    },
    email: { type: 'email' }
  },
  guarded: ['id']
}
```

Now, by calling `model.fill(input)`, the user would only be able to change their email, _not_ their ID. Additionally, anything given in the "input" which is not an attribute of the model will be discarded.