### PR TITLE
changed .done() to .exec() in the example script

### DIFF
--- a/example/express/express-example.js
+++ b/example/express/express-example.js
@@ -99,7 +99,7 @@ app.use(express.methodOverride());
 // Build Express Routes (CRUD routes for /users)
 
 app.get('/users', function(req, res) {
-  app.models.user.find().done(function(err, models) {
+  app.models.user.find().exec(function(err, models) {
     if(err) return res.json({ err: err }, 500);
     res.json(models);
   });


### PR DESCRIPTION
.done() is deprecated in 0.10, it is replaced by .exec()
