### PR TITLE
Detection of changed properties

### DIFF
--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -37,6 +37,14 @@ module.exports = function(context, mixins) {
       return new defaultMethods.destroy(context, this, cb);
     },
 
+    dirty: function(attribute) {
+      return defaultMethods.dirty(context, this, attribute);
+    },
+
+    clean: function(attribute) {
+      defaultMethods.dirty.clean(context, this, attribute);
+    },
+
     _defineAssociations: function() {
       new internalMethods.defineAssociations(context, this);
     },

--- a/lib/waterline/model/lib/defaultMethods/dirty.js
+++ b/lib/waterline/model/lib/defaultMethods/dirty.js
@@ -1,0 +1,40 @@
+var _ = require('lodash');
+var diff = require('deep-diff').diff;
+
+/**
+ * Model.dirty()
+ *
+ * Returns whether the given attribute has changed since instantiation.
+ *
+ * @param {Object} context
+ * @param {Object} proto
+ * @param {Object} attributes
+ * @return bool
+ * @api public
+ */
+module.exports = function(context, proto, attribute) {
+    var comp = diff(proto._originalValues[attribute], proto[attribute]);
+
+    return typeof comp !== 'undefined';
+};
+
+/**
+ * Model.clean()
+ *
+ * Resets the "dirty" state.
+ *
+ * @param {Object} context
+ * @param {Object} proto
+ * @param {Object} attributes
+ * @return void
+ * @api public
+ */
+module.exports.clean = function (context, proto, attribute) {
+    if (typeof attribute === 'undefined') {
+        for (var key in proto) {
+            proto._originalValues[key] = _.cloneDeep(proto[key]);
+        }
+    } else {
+        proto._originalValues[attribute] = _.cloneDeep(proto[attribute]);
+    }
+};

--- a/lib/waterline/model/lib/defaultMethods/index.js
+++ b/lib/waterline/model/lib/defaultMethods/index.js
@@ -6,5 +6,6 @@
 module.exports = {
   toObject: require('./toObject'),
   destroy: require('./destroy'),
-  save: require('./save')
+  save: require('./save'),
+  dirty: require('./dirty')
 };

--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -41,9 +41,17 @@ var Model = module.exports = function(attrs, options) {
   // Build association getters and setters
   this._defineAssociations();
 
+  // List of original attributes of the object, so we know what is dirty!
+  Object.defineProperty(this, '_originalValues', {
+    enumerable: false,
+    value: {}
+  });
+
   // Attach attributes to the model instance
   for(var key in attrs) {
     this[key] = attrs[key];
+    // Add a copy of the attribute to the cache.
+    this._originalValues[key] = _.cloneDeep(attrs[key]);
 
     if(this.associationsCache.hasOwnProperty(key)) {
       this.associationsCache[key] = _.cloneDeep(attrs[key]);

--- a/test/unit/model/dirty.js
+++ b/test/unit/model/dirty.js
@@ -1,0 +1,43 @@
+var assert = require('assert'),
+    belongsToFixture = require('../../support/fixtures/model/context.belongsTo.fixture'),
+    Model = require('../../../lib/waterline/model');
+
+describe('model dirty', function() {
+
+  /////////////////////////////////////////////////////
+  // TEST SETUP
+  ////////////////////////////////////////////////////
+
+  var fixture, model;
+
+  before(function() {
+    fixture = belongsToFixture();
+    model = new Model(fixture);
+  });
+
+
+  /////////////////////////////////////////////////////
+  // TEST METHODS
+  ////////////////////////////////////////////////////
+
+  it('works with basic values', function() {
+    var person = new model();
+    assert(person.dirty('foo') === false);
+    person.foo = 'lala';
+    assert(person.dirty('foo') === true);
+    person.foo = undefined;
+    assert(person.dirty('foo') === false);
+  });
+
+  it('cleans correctly', function() {
+    var person = new model();
+    person.foo = 'lala';
+    assert(person.dirty('foo') === true);
+    person.clean();
+    assert(person.dirty('foo') === false);
+    person.foo = 'asdf';
+    assert(person.dirty('foo') === true);
+    person.foo = 'lala';
+    assert(person.dirty('foo') === false);
+  });
+});


### PR DESCRIPTION
Added the ability to check changed properties. This was particularly useful to us when seeing if the password was updated updated on a user's `beforeUpdate` event. With this code, one could nicely check:

```js
    beforeUpdate: function (values, callback) {
        if (this.dirty('password')) {
            bcrypt.hash(/* ... */);
        }
    }
```

Without use of additional metadata or manually hashing when the password is updated.