### PR TITLE
Bind model context to lifecycle callback

### DIFF
--- a/lib/waterline/query/validate.js
+++ b/lib/waterline/query/validate.js
@@ -24,7 +24,7 @@ module.exports = {
       // Run Before Validate Lifecycle Callbacks
       function(cb) {
         var runner = function(item, callback) {
-          item(values, function(err) {
+          item.call(self, values, function(err) {
             if(err) return callback(err);
             callback();
           });

--- a/lib/waterline/utils/callbacksRunner.js
+++ b/lib/waterline/utils/callbacksRunner.js
@@ -38,7 +38,7 @@ runner.validate = function(context, values, presentOnly, cb) {
 runner.beforeCreate = function(context, values, cb) {
 
   var fn = function(item, next) {
-    item.call(Object.getPrototypeOf(context), values, next);
+    item.call(context, values, next);
   };
 
   async.eachSeries(context._callbacks.beforeCreate, fn, cb);
@@ -57,7 +57,7 @@ runner.beforeCreate = function(context, values, cb) {
 runner.afterCreate = function(context, values, cb) {
 
   var fn = function(item, next) {
-    item.call(Object.getPrototypeOf(context), values, next);
+    item.call(context, values, next);
   };
 
   async.eachSeries(context._callbacks.afterCreate, fn, cb);
@@ -76,7 +76,7 @@ runner.afterCreate = function(context, values, cb) {
 runner.beforeUpdate = function(context, values, cb) {
 
   var fn = function(item, next) {
-    item.call(Object.getPrototypeOf(context), values, next);
+    item.call(context, values, next);
   };
 
   async.eachSeries(context._callbacks.beforeUpdate, fn, cb);
@@ -95,7 +95,7 @@ runner.beforeUpdate = function(context, values, cb) {
 runner.afterUpdate = function(context, values, cb) {
 
   var fn = function(item, next) {
-    item.call(Object.getPrototypeOf(context), values, next);
+    item.call(context, values, next);
   };
 
   async.eachSeries(context._callbacks.afterUpdate, fn, cb);
@@ -114,7 +114,7 @@ runner.afterUpdate = function(context, values, cb) {
 runner.beforeDestroy = function(context, criteria, cb) {
 
   var fn = function(item, next) {
-    item.call(Object.getPrototypeOf(context), criteria, next);
+    item.call(context, criteria, next);
   };
 
   async.eachSeries(context._callbacks.beforeDestroy, fn, cb);
@@ -133,7 +133,7 @@ runner.beforeDestroy = function(context, criteria, cb) {
 runner.afterDestroy = function(context, values, cb) {
 
   var fn = function(item, next) {
-    item.call(Object.getPrototypeOf(context), values, next);
+    item.call(context, values, next);
   };
 
   async.eachSeries(context._callbacks.afterDestroy, fn, cb);


### PR DESCRIPTION
For example, I want to set a "counter" on my model depending on a criteria.
```javascript
beforeValidate: function(values, cb) {
  this.findOne({
    where: criteria,
    sort: { updatedAt: 'desc' }
  }).exec(function(err, user) {
    values.counter = user ? 0 : user.counter + 1;
    cb();
  });
```
Currently the context passed is the model prototype, why not the model ?
I could access to findOne but I got an error because _transformer is undefined.
