### PR TITLE
Support batch creation if adapter implements createEach method (issue #700).

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -9,6 +9,8 @@ var async = require('async'),
     normalize = require('../utils/normalize'),
     callbacks = require('../utils/callbacksRunner'),
     Deferred = require('./deferred'),
+    nestedOperations = require('../utils/nestedOperations'),
+    Promise = require('bluebird'),
     hasOwnProperty = utils.object.hasOwnProperty;
 
 module.exports = {
@@ -47,6 +49,82 @@ module.exports = {
     if(errStr) return usageError(errStr, usage, cb);
 
     var records = [];
+    var processedValues = [];
+
+    function preprocessValuesForCreateMethod(value, next) {
+      self._preprocessValuesForCreateMethod(value, function(err, valueObject) {
+        if(err) return next(err);
+        // Automatically add updatedAt and createdAt (if enabled)
+        if(self.autoCreatedAt && !valueObject.values.createdAt) {
+          valueObject.values.createdAt = new Date();
+        }
+
+        if(self.autoUpdatedAt && !valueObject.values.updatedAt) {
+          valueObject.values.updatedAt = new Date();
+        }
+
+        // Transform Values
+        valueObject.values = self._transformer.serialize(valueObject.values);
+
+        // Clean attributes
+        valueObject.values = self._schema.cleanValues(valueObject.values);
+        
+        records.push(valueObject);
+        processedValues.push(valueObject.values);
+        next();
+      });
+    }
+
+    function createEach(valuesList, cb) {
+      self.adapter.createEach(valuesList, function(err, values) {
+        if (err) {
+          if (typeof err === 'object') { err.model = self._model.globalId; }
+          return cb(err);
+        }
+
+        // Unserialize Values
+        var unserializedValues = [];
+
+        values.forEach(function(value) {
+          value = self._transformer.unserialize(value);
+          unserializedValues.push(value);
+        });
+
+        // Set values array to the transformed array
+        values = unserializedValues;
+
+        var promiseCallingAfterCreate = [];
+        // Run AfterCreate Callbacks and return models
+        for (var i = 0; i < values.length; i++) {
+          promiseCallingAfterCreate.push(new Promise(function(resolve, reject) {
+            function after(values) {
+              // Run After Create Callbacks
+              callbacks.afterCreate(self, values, function(err) {
+                if(err) reject(err);
+
+                // Return an instance of Model
+                var model = new self._model(values);
+                resolve(model);
+              });
+            }
+            if (records[i].associations.collections.length === 0) return after(values[i]);
+
+            var parentModel = new self._model(values[i]);
+            nestedOperations.create.call(self, parentModel, records[i].originalValues, records[i].associations.collections, function(err) {
+              if (err) return reject(err);
+              return after(parentModel.toObject());
+            });
+          }));
+        }
+        Promise.all(promiseCallingAfterCreate)
+          .then(function(models) {
+            cb(null, models);
+          })
+          .catch(function(err) {
+            cb(err);
+          });
+      });
+    }
 
     function create(value, next) {
       self.create(value, function(err, record) {
@@ -56,10 +134,17 @@ module.exports = {
       });
     }
 
-    async.each(valuesList, create, function(err) {
-      if(err) return cb(err);
-      cb(null, records);
-    });
+    if(hasOwnProperty(self, '_preprocessValuesForCreateMethod')) {
+      async.each(valuesList, preprocessValuesForCreateMethod, function(err) {
+        if(err) return cb(err);
+        createEach(processedValues, cb);
+      });
+    } else {
+      async.each(valuesList, create, function(err) {
+        if(err) return cb(err);
+        cb(null, records);
+      });
+    }
   },
 
   /**

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -35,22 +35,31 @@ module.exports = function(values, cb) {
     return new Deferred(this, this.create, {}, values);
   }
 
+  if(!hop(self, '_preprocessValuesForCreateMethod')) {
+    self._preprocessValuesForCreateMethod = function (values, cb) {
+      // Process Values
+      var valuesObject = processValues.call(this, values);
+
+      // Create any of the belongsTo associations and set the foreign key values
+      createBelongsTo.call(this, valuesObject, function(err) {
+        if(err) return cb(err);
+
+        beforeCallbacks.call(self, valuesObject, function(err){
+          if(err) return cb(err);
+          cb(err, valuesObject);
+        });
+      });
+    };
+  }
+
   // Handle Array of values
   if(Array.isArray(values)) {
     return this.createEach(values, cb);
   }
 
-  // Process Values
-  var valuesObject = processValues.call(this, values);
-
-  // Create any of the belongsTo associations and set the foreign key values
-  createBelongsTo.call(this, valuesObject, function(err) {
+  self._preprocessValuesForCreateMethod(values, function(err, valuesObject){
     if(err) return cb(err);
-
-    beforeCallbacks.call(self, valuesObject, function(err) {
-      if(err) return cb(err);
-      createValues.call(self, valuesObject, cb);
-    });
+    createValues.call(self, valuesObject, cb);
   });
 };
 


### PR DESCRIPTION
Share the code in "lib/waterline/query/dql/create.js" with "lib/waterline/query/aggregate.js" to support batch creation if adapter implements createEach method.
