### PR TITLE
Promisify validate

### DIFF
--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -4,6 +4,7 @@
  */
 
 var _ = require('lodash');
+var Bluebird = require('bluebird');
 var Model = require('./lib/model');
 var defaultMethods = require('./lib/defaultMethods');
 var internalMethods = require('./lib/internalMethods');
@@ -75,19 +76,23 @@ module.exports = function(context, mixins) {
      * Takes the currently set attributes and validates the model
      * Shorthand for Model.validate({ attributes }, cb)
      *
-     * @param {Function} callback
-     * @return callback - (err)
+     * @param {Function} callback - (err)
+     * @return {Promise}
      */
 
     validate: function(cb) {
-      var self = this;
-
       // Collect current values
       var values = this.toObject();
 
-      context.validate( values, function(err) {
-        if(err) return cb(err);
-        cb();
+      return new Bluebird(function (resolve, reject) {
+        context.validate( values, function(err) {
+          if(err) {
+            reject(err);
+            return cb(err);
+          }
+          resolve();
+          cb();
+        });
       });
     }
 

--- a/test/unit/model/model.validate.js
+++ b/test/unit/model/model.validate.js
@@ -61,5 +61,18 @@ describe('Model', function() {
       });
     });
 
+    it('should also work with promises', function(done) {
+      var person = new collection._model({ email: 'none' });
+
+      // Update a value
+      person.last_name = 'foobaz';
+
+      person.validate()
+        .catch(function(err) {
+          assert(err);
+          done();
+        });
+    });
+
   });
 });


### PR DESCRIPTION
Made `.validate()` promise-happy. Backwards compatible, still works with callback.

![](http://i.imgur.com/NEA0wAY.jpg)

Builds fails as master branch currently fails, but no additional test were harmed in the making of this PR.
