### PR TITLE
Create no longer mutates arrays

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -43,6 +43,8 @@ module.exports = {
     if(!Array.isArray(valuesList)) return usageError('Invalid valuesList specified (should be an array!)', usage, cb);
     if(typeof cb !== 'function') return usageError('Invalid callback specified!', usage, cb);
 
+    valuesList = _.cloneDeep(valuesList);
+
     // Remove all undefined values
     valuesList = _.remove(valuesList, undefined);
 

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -30,7 +30,7 @@ module.exports = function(values, cb) {
     values = args.pop();
   }
 
-  values = values || {};
+  values = _.cloneDeep(values) || {};
 
   // Remove all undefined values
   if(_.isArray(values)) {

--- a/test/unit/query/query.create.js
+++ b/test/unit/query/query.create.js
@@ -239,6 +239,14 @@ describe('Collection Query', function() {
           done();
         });
       });
+
+      it('should not be detructive to passed-in arrays', function(done) {
+        var myPreciousArray = [{ name: 'foo', age: '27' }];
+        query.createEach(myPreciousArray, function(err, values) {
+          assert(myPreciousArray.length === 1);
+          done();
+        });
+      });
     });
 
   });

--- a/test/unit/query/query.createEach.js
+++ b/test/unit/query/query.createEach.js
@@ -171,6 +171,14 @@ describe('Collection Query', function() {
           done();
         });
       });
+
+      it('should not be detructive to passed-in arrays', function(done) {
+        var myPreciousArray = [{ name: 'foo', age: '27' }];
+        query.createEach(myPreciousArray, function(err, values) {
+          assert(myPreciousArray.length === 1);
+          done();
+        });
+      });
     });
 
   });


### PR DESCRIPTION
Clone user-given arguments to create and createEach before calling _.remove
on them. Also add unit tests to ensure this

Fixes #734 
