### PR TITLE
fix to prevent server crash on an invalid attempt to delete assocation

### DIFF
--- a/lib/waterline/model/lib/associationMethods/remove.js
+++ b/lib/waterline/model/lib/associationMethods/remove.js
@@ -202,7 +202,7 @@ Remove.prototype.validatePrimaryKey = function(key) {
   if(_.isString(key) && utils.matchMongoId(key)) validAssociation = true;
 
   // Check it can be turned into a string
-  if(key.toString() !== '[object Object]') validAssociation = true;
+  if(key && key.toString() !== '[object Object]') validAssociation = true;
 
   return validAssociation;
 };


### PR DESCRIPTION
Fixes a problem whereby DELETE /model/:id/association causes the server to crash.

See https://github.com/balderdashy/waterline/issues/740
