### PR TITLE
Allow objects that implement toDate to be cast

### DIFF
--- a/lib/waterline/core/typecast.js
+++ b/lib/waterline/core/typecast.js
@@ -205,6 +205,9 @@ Cast.prototype.date = function date(value) {
   if (value.__proto__ == Date.prototype) {
     _value = new Date(value.getTime());
   }
+  else if (typeof value.toDate === 'function') {
+    _value = value.toDate();
+  }
   else {
     _value = new Date(Date.parse(value));
   }

--- a/test/unit/core/core.cast/cast.date.js
+++ b/test/unit/core/core.cast/cast.date.js
@@ -38,5 +38,15 @@ describe('Core Type Casting', function() {
       assert(values.name.toUTCString() === 'Wed, 18 Sep 2013 00:00:00 GMT');
     });
 
+    it('should objects that implement toDate()', function() {
+      function Foo() {}
+      Foo.prototype.toDate = function () { return new Date(1379462400000); };
+      var values = person._cast.run({
+        name: new Foo()
+      });
+      assert(values.name.constructor.name === 'Date');
+      assert(values.name.toUTCString() === 'Wed, 18 Sep 2013 00:00:00 GMT');
+    });
+
   });
 });


### PR DESCRIPTION
This means, for example, that I could pass in a Moment.js instance (or any of my own objects that implement toDate) straight into waterline and, with this PR, it would be cast appropriately.

Just a nice developer-friendly addition :smile: 