### PR TITLE
Added missing err checking in create portion of findOrCreate()

### DIFF
--- a/lib/waterline/query/composite.js
+++ b/lib/waterline/query/composite.js
@@ -62,6 +62,7 @@ module.exports = {
 
       // Create a new record if nothing is found.
       self.create(values).exec(function(err, result) {
+        if (err) return cb(err);
         return cb(null, result);
       });
     });


### PR DESCRIPTION
Whenever create fails in findOrCreate, the err variable is always null. I've added the missing `cb(err)`.