### PR TITLE
Return undefined if values is undefined or null

### DIFF
--- a/lib/waterline/core/typecast.js
+++ b/lib/waterline/core/typecast.js
@@ -52,6 +52,10 @@ Cast.prototype.initialize = function(attrs) {
 
 Cast.prototype.run = function(values) {
   var self = this;
+  
+  if (values === undefined || values === null) {
+    return;
+  }
 
   Object.keys(values).forEach(function(key) {
 


### PR DESCRIPTION
I am trying to implement [traceur](https://github.com/google/traceur-compiler) as a hook into sails 0.11 (see https://github.com/balderdashy/sails/issues/2517) and the only issue, apart from hook order is the `Object.keys(values).forEach` line when `values === null`. 

This if and return statement fixed it for me and traceur/ES6/7 code is now working in sails. Would love to see get this merged.