### PR TITLE
#770 Allows custom adapter methods to return on model call

### DIFF
--- a/lib/waterline/query/adapters.js
+++ b/lib/waterline/query/adapters.js
@@ -32,7 +32,7 @@ module.exports = function() {
         // Concat self.identity with args (must massage arguments into a proper array)
         // Use a normalized _tableName set in the core module.
         var args = [conn, tableName].concat(Array.prototype.slice.call(arguments));
-        adapter[key].apply(self, args);
+        return adapter[key].apply(self, args);
       };
     });
   });


### PR DESCRIPTION
Added the ability for custom adapter methods to return values on wrapped model calls. This was an issue because it prevented custom methods from returning promises.

See Waterline issue #770.