### PR TITLE
[feature] Add Multi-Tenant support

### DIFF
--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -1,10 +1,10 @@
 var _ = require('lodash'),
-    async = require('async'),
-    Schema = require('waterline-schema'),
-    Connections = require('./waterline/connections'),
-    CollectionLoader = require('./waterline/collection/loader'),
-    COLLECTION_DEFAULTS = require('./waterline/collection/defaults'),
-    hasOwnProperty = require('./waterline/utils/helpers').object.hasOwnProperty;
+  async = require('async'),
+  Schema = require('waterline-schema'),
+  Connections = require('./waterline/connections'),
+  CollectionLoader = require('./waterline/collection/loader'),
+  COLLECTION_DEFAULTS = require('./waterline/collection/defaults'),
+  hasOwnProperty = require('./waterline/utils/helpers').object.hasOwnProperty;
 
 /**
  * Waterline
@@ -12,7 +12,7 @@ var _ = require('lodash'),
 
 var Waterline = module.exports = function() {
 
-  if(!(this instanceof Waterline)) {
+  if (!(this instanceof Waterline)) {
     return new Waterline();
   }
 
@@ -80,13 +80,15 @@ Waterline.prototype.initialize = function(options, cb) {
   var self = this;
 
   // Ensure a config object is passed in containing adapters
-  if(!options) throw new Error('Usage Error: function(options, callback)');
-  if(!options.adapters) throw new Error('Options object must contain an adapters object');
-  if(!options.connections) throw new Error('Options object must contain a connections object');
+  if (!options) throw new Error('Usage Error: function(options, callback)');
+  if (!options.adapters) throw new Error(
+    'Options object must contain an adapters object');
+  if (!options.connections) throw new Error(
+    'Options object must contain a connections object');
 
   // Allow collections to be passed in to the initialize method
-  if(options.collections) {
-    for(var collection in options.collections) {
+  if (options.collections) {
+    for (var collection in options.collections) {
       this.loadCollection(_.cloneDeep(options.collections[collection]));
     }
 
@@ -107,7 +109,7 @@ Waterline.prototype.initialize = function(options, cb) {
   this.schema = new Schema(this._collections, this.connections, defaults);
 
   // Load a Collection into memory
-  function loadCollection(item , next) {
+  function loadCollection(item, next) {
     var loader = new CollectionLoader(item, self.connections, defaults);
     var collection = loader.initialize(self);
 
@@ -123,18 +125,19 @@ Waterline.prototype.initialize = function(options, cb) {
     // Load all the collections into memory
     loadCollections: function(next) {
       async.each(self._collections, loadCollection, function(err) {
-        if(err) return next(err);
+        if (err) return next(err);
 
         // Migrate Junction Tables
         var junctionTables = [];
 
         Object.keys(self.schema).forEach(function(table) {
-          if(!self.schema[table].junctionTable) return;
-          junctionTables.push(Waterline.Collection.extend(self.schema[table]));
+          if (!self.schema[table].junctionTable) return;
+          junctionTables.push(Waterline.Collection.extend(self.schema[
+            table]));
         });
 
         async.each(junctionTables, loadCollection, function(err) {
-          if(err) return next(err);
+          if (err) return next(err);
           next(null, self.collections);
         });
       });
@@ -144,7 +147,7 @@ Waterline.prototype.initialize = function(options, cb) {
     // Build up Collection Schemas
     buildCollectionSchemas: ['loadCollections', function(next, results) {
       var collections = self.collections,
-          schemas = {};
+        schemas = {};
 
       Object.keys(collections).forEach(function(key) {
         var collection = collections[key];
@@ -153,14 +156,16 @@ Waterline.prototype.initialize = function(options, cb) {
         var schema = _.clone(collection._schema.schema);
 
         Object.keys(schema).forEach(function(key) {
-          if(hasOwnProperty(schema[key], 'type')) return;
+          if (hasOwnProperty(schema[key], 'type')) return;
           delete schema[key];
         });
 
         // Grab JunctionTable flag
         var meta = collection.meta || {};
-        meta.junctionTable = hasOwnProperty(collection.waterline.schema[collection.identity], 'junctionTable') ?
-          collection.waterline.schema[collection.identity].junctionTable : false;
+        meta.junctionTable = hasOwnProperty(collection.waterline.schema[
+            collection.identity], 'junctionTable') ?
+          collection.waterline.schema[collection.identity].junctionTable :
+          false;
 
         schemas[collection.identity] = collection;
         schemas[collection.identity].definition = schema;
@@ -172,14 +177,17 @@ Waterline.prototype.initialize = function(options, cb) {
 
 
     // Register the Connections with an adapter
-    registerConnections: ['buildCollectionSchemas', function(next, results) {
-      async.each(Object.keys(self.connections), function(item, nextItem) {
+    registerConnections: ['buildCollectionSchemas', function(next,
+      results) {
+      async.each(Object.keys(self.connections), function(item,
+        nextItem) {
         var connection = self.connections[item],
-            config = {},
-            usedSchemas = {};
+          config = {},
+          usedSchemas = {};
 
         // Check if the connection's adapter has a register connection method
-        if(!hasOwnProperty(connection._adapter, 'registerConnection')) return nextItem();
+        if (!hasOwnProperty(connection._adapter,
+            'registerConnection')) return nextItem();
 
         // Copy all values over to a tempory object minus the adapter definition
         Object.keys(connection.config).forEach(function(key) {
@@ -192,26 +200,33 @@ Waterline.prototype.initialize = function(options, cb) {
         // Grab the schemas used on this connection
         connection._collections.forEach(function(coll) {
           var identity = coll;
-          if(hasOwnProperty(self.collections[coll].__proto__, 'tableName')) {
+          if (hasOwnProperty(self.collections[coll].__proto__,
+              'tableName')) {
             identity = self.collections[coll].__proto__.tableName;
           }
 
-          usedSchemas[identity] = results.buildCollectionSchemas[coll];
+          usedSchemas[identity] = results.buildCollectionSchemas[
+            coll];
         });
 
         // Call the registerConnection method
-        connection._adapter.registerConnection(_.cloneDeep(config), usedSchemas, function(err) {
-          if(err) return nextItem(err);
-          nextItem();
-        });
+        connection._adapter.registerConnection(_.cloneDeep(config),
+          usedSchemas,
+          function(err) {
+            if (err) return nextItem(err);
+            nextItem();
+          });
       }, next);
     }]
 
   }, function(err) {
-    if(err) return cb(err);
+    if (err) return cb(err);
     self.bootstrap(function(err) {
-      if(err) return cb(err);
-      cb(null, { collections: self.collections, connections: self.connections });
+      if (err) return cb(err);
+      cb(null, {
+        collections: self.collections,
+        connections: self.connections
+      });
     });
   });
 
@@ -230,7 +245,7 @@ Waterline.prototype.teardown = function teardown(cb) {
     var connection = self.connections[item];
 
     // Check if the adapter has a teardown method implemented
-    if(!hasOwnProperty(connection._adapter, 'teardown')) return next();
+    if (!hasOwnProperty(connection._adapter, 'teardown')) return next();
 
     connection._adapter.teardown(item, next);
   }, cb);
@@ -276,7 +291,8 @@ Waterline.prototype.bootstrap = function bootstrap(cb) {
 
 
   // For now:
-  var toBeSynced = _.reduce(this.collections, function (resources, collection, ident) {
+  var toBeSynced = _.reduce(this.collections, function(resources, collection,
+    ident) {
     resources.push(collection);
     return resources;
   }, []);
@@ -284,7 +300,7 @@ Waterline.prototype.bootstrap = function bootstrap(cb) {
   // Run auto-migration strategies on each collection
   // async.each(toBeSynced, function(collection, next) {
   async.eachSeries(toBeSynced, function(collection, next) {
-  // async.eachLimit(toBeSynced, 9, function(collection, next) {
+    // async.eachLimit(toBeSynced, 9, function(collection, next) {
     collection.sync(next);
   }, cb);
 };

--- a/lib/waterline/collection/index.js
+++ b/lib/waterline/collection/index.js
@@ -54,3 +54,39 @@ inherits(Collection, Query);
 
 // Make Extendable
 Collection.extend = extend;
+
+
+/**
+* Resolve Collection
+*
+* Helper to resolve `tenant` into
+* Tenant-specific Collection, if applicable
+*
+* @param {String} connection name
+* @param {Function} callback(err, resolvedCollection)
+* @return this
+*/
+Collection.prototype._resolveCollection = function(connectionName, cb) {
+    // Get Connection
+    var connectionName = connectionName || this.adapter.dictionary.identity;
+    var connection = this.connections[connectionName];
+    var config = connection.config;
+    // Check if Multi-Tenant enabled
+    if (config.isMultiTenant) {
+        // Is Multi-Tenant connection
+        // Check if there is a Tenant set
+        var tenant = config.tenant;
+        if (tenant) {
+            // Tenant is set
+            // Use Tenant-specific collection
+            // Check if Tenant's connection has been loaded
+            //   console.log('select tenant', config.tenant);
+            this.tenant(tenant, function(err, tenantCollection) {
+                return cb(null, tenantCollection);
+            });
+        }
+    } else {
+        cb(null, this);
+    }
+    return this;
+};

--- a/lib/waterline/collection/index.js
+++ b/lib/waterline/collection/index.js
@@ -64,7 +64,7 @@ Collection.extend = extend;
 *
 * @param {String} connection name
 * @param {Function} callback(err, resolvedCollection)
-* @return this
+* @return {WLCollection} this
 */
 Collection.prototype._resolveCollection = function(connectionName, cb) {
     // Get Connection
@@ -86,7 +86,7 @@ Collection.prototype._resolveCollection = function(connectionName, cb) {
             });
         } else {
             // Error: No tenant set
-            return cb(new Error('Tenant is required to be specified in operation.'), this);
+            cb(new Error('Tenant is required to be specified in operation.'), this);
         }
     } else {
         cb(null, this);

--- a/lib/waterline/collection/index.js
+++ b/lib/waterline/collection/index.js
@@ -82,7 +82,7 @@ Collection.prototype._resolveCollection = function(connectionName, cb) {
             // Check if Tenant's connection has been loaded
             //   console.log('select tenant', config.tenant);
             this.tenant(tenant, function(err, tenantCollection) {
-                return cb(null, tenantCollection);
+                return cb(err, tenantCollection);
             });
         } else {
             // Error: No tenant set

--- a/lib/waterline/collection/index.js
+++ b/lib/waterline/collection/index.js
@@ -84,6 +84,9 @@ Collection.prototype._resolveCollection = function(connectionName, cb) {
             this.tenant(tenant, function(err, tenantCollection) {
                 return cb(null, tenantCollection);
             });
+        } else {
+            // Error: No tenant set
+            return cb(new Error('Tenant is required to be specified in operation.'), this);
         }
     } else {
         cb(null, this);

--- a/lib/waterline/query/dql/count.js
+++ b/lib/waterline/query/dql/count.js
@@ -53,6 +53,8 @@ module.exports = function(criteria, options, cb) {
   // Resolve Tenant-specific Collection, if applicable
   var connName = this.adapter.dictionary.count || this.adapter.dictionary.find;
   this._resolveCollection(connName, function(err, collection) {
+      if(err) return cb(err);
+      
       collection.adapter.count(criteria, cb);
   });
 

--- a/lib/waterline/query/dql/count.js
+++ b/lib/waterline/query/dql/count.js
@@ -50,5 +50,10 @@ module.exports = function(criteria, options, cb) {
   // Transform Search Criteria
   criteria = this._transformer.serialize(criteria);
 
-  this.adapter.count(criteria, cb);
+  // Resolve Tenant-specific Collection, if applicable
+  var connName = this.adapter.dictionary.count || this.adapter.dictionary.find;
+  this._resolveCollection(connName, function(err, collection) {
+      collection.adapter.count(criteria, cb);
+  });
+
 };

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -54,6 +54,7 @@ module.exports = function(values, cb) {
   // Resolve Tenant-specific Collection, if applicable
   var connName = this.adapter.dictionary.create;
   this._resolveCollection(connName, function(err, self) {
+      if(err) return cb(err);
       
       // Create any of the belongsTo associations and set the foreign key values
       createBelongsTo.call(self, valuesObject, function(err) {

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -51,15 +51,22 @@ module.exports = function(values, cb) {
   // Process Values
   var valuesObject = processValues.call(this, values);
 
-  // Create any of the belongsTo associations and set the foreign key values
-  createBelongsTo.call(this, valuesObject, function(err) {
-    if(err) return cb(err);
+  // Resolve Tenant-specific Collection, if applicable
+  var connName = this.adapter.dictionary.create;
+  this._resolveCollection(connName, function(err, self) {
+      
+      // Create any of the belongsTo associations and set the foreign key values
+      createBelongsTo.call(self, valuesObject, function(err) {
+        if(err) return cb(err);
 
-    beforeCallbacks.call(self, valuesObject, function(err) {
-      if(err) return cb(err);
-      createValues.call(self, valuesObject, cb);
-    });
+        beforeCallbacks.call(self, valuesObject, function(err) {
+          if(err) return cb(err);
+          createValues.call(self, valuesObject, cb);
+        });
+      });
+
   });
+
 };
 
 

--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -48,7 +48,8 @@ module.exports = function(criteria, cb) {
   // Resolve Tenant-specific Collection, if applicable
   var connName = this.adapter.dictionary.destroy;
   this._resolveCollection(connName, function(err, self) {
-
+      if(err) return cb(err);
+      
       callbacks.beforeDestroy(self, criteria, function(err) {
         if(err) return cb(err);
 

--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -45,71 +45,78 @@ module.exports = function(criteria, cb) {
 
   if(typeof cb !== 'function') return usageError('Invalid callback specified!', usage, cb);
 
-  callbacks.beforeDestroy(self, criteria, function(err) {
-    if(err) return cb(err);
+  // Resolve Tenant-specific Collection, if applicable
+  var connName = this.adapter.dictionary.destroy;
+  this._resolveCollection(connName, function(err, self) {
 
-    // Transform Search Criteria
-    criteria = self._transformer.serialize(criteria);
-
-    // Pass to adapter
-    self.adapter.destroy(criteria, function(err, result) {
-      if (err) return cb(err);
-
-      // Look for any m:m associations and destroy the value in the join table
-      var relations = getRelations({
-        schema: self.waterline.schema,
-        parentCollection: self.identity
-      });
-
-      if(relations.length === 0) return after();
-
-      // Find the collection's primary key
-      for(var key in self.attributes) {
-        if(!self.attributes[key].hasOwnProperty('primaryKey')) continue;
-
-        // Check if custom primaryKey value is falsy
-        if(!self.attributes[key].primaryKey) continue;
-
-        pk = key;
-        break;
-      }
-
-      function destroyJoinTableRecords(item, next) {
-        var collection = self.waterline.collections[item];
-        var refKey;
-
-        Object.keys(collection._attributes).forEach(function(key) {
-          var attr = collection._attributes[key];
-          if(attr.references !== self.identity) return;
-          refKey = key;
-        });
-
-        // If no refKey return, this could leave orphaned join table values but it's better
-        // than crashing.
-        if(!refKey) return next();
-
-        var mappedValues = result.map(function(vals) { return vals[pk]; });
-        var criteria = {};
-
-        if(mappedValues.length > 0) {
-          criteria[refKey] = mappedValues;
-        }
-
-        collection.destroy(criteria).exec(next);
-      }
-
-      async.each(relations, destroyJoinTableRecords, function(err) {
+      callbacks.beforeDestroy(self, criteria, function(err) {
         if(err) return cb(err);
-        after();
+
+        // Transform Search Criteria
+        criteria = self._transformer.serialize(criteria);
+
+        // Pass to adapter
+        self.adapter.destroy(criteria, function(err, result) {
+          if (err) return cb(err);
+
+          // Look for any m:m associations and destroy the value in the join table
+          var relations = getRelations({
+            schema: self.waterline.schema,
+            parentCollection: self.identity
+          });
+
+          if(relations.length === 0) return after();
+
+          // Find the collection's primary key
+          for(var key in self.attributes) {
+            if(!self.attributes[key].hasOwnProperty('primaryKey')) continue;
+
+            // Check if custom primaryKey value is falsy
+            if(!self.attributes[key].primaryKey) continue;
+
+            pk = key;
+            break;
+          }
+
+          function destroyJoinTableRecords(item, next) {
+            var collection = self.waterline.collections[item];
+            var refKey;
+
+            Object.keys(collection._attributes).forEach(function(key) {
+              var attr = collection._attributes[key];
+              if(attr.references !== self.identity) return;
+              refKey = key;
+            });
+
+            // If no refKey return, this could leave orphaned join table values but it's better
+            // than crashing.
+            if(!refKey) return next();
+
+            var mappedValues = result.map(function(vals) { return vals[pk]; });
+            var criteria = {};
+
+            if(mappedValues.length > 0) {
+              criteria[refKey] = mappedValues;
+            }
+
+            collection.destroy(criteria).exec(next);
+          }
+
+          async.each(relations, destroyJoinTableRecords, function(err) {
+            if(err) return cb(err);
+            after();
+          });
+
+          function after() {
+            callbacks.afterDestroy(self, result, function(err) {
+              if(err) return cb(err);
+              cb(null, result);
+            });
+          }
+
+        });
       });
 
-      function after() {
-        callbacks.afterDestroy(self, result, function(err) {
-          if(err) return cb(err);
-          cb(null, result);
-        });
-      }
-
-    });
   });
+
 };

--- a/lib/waterline/query/dql/index.js
+++ b/lib/waterline/query/dql/index.js
@@ -8,5 +8,6 @@ module.exports = {
   update: require('./update'),
   destroy: require('./destroy'),
   count: require('./count'),
-  join: require('./join')
+  join: require('./join'),
+  tenant: require('./tenant')
 };

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -9,6 +9,7 @@ var normalize = require('../../utils/normalize');
 var Deferred = require('../deferred');
 var hasOwnProperty = utils.object.hasOwnProperty;
 var CollectionLoader = require('../../collection/loader');
+var extend = require('../../utils/extend');
 
 /**
  * Tenant
@@ -77,39 +78,28 @@ module.exports = function(tenant, cb) {
 
         function createTenantCollection() {
 
+            // console.log('create tenant collection', self instanceof require('../../collection'), self);
+
             var newCollectionIdentity = (baseCollectionIdentity + tenantSuffix).toLowerCase();
 
-            // Take new config and register it's connection
-            // var cols = self.waterline._collections;
-            // console.log('collections', cols);
-            // var col = _.find(cols, function(col) {
-            //     return true;
-            // });
-            // var col = self.collection;
-            // console.log(col);
-            // var colDupModel = _.cloneDeep(self);
-            // var Collection = require('../../collection');
-            //
-            // console.log('connections', self.connections);
-            var colDupModel = self.constructor.extend({
-                // // Set the named connections
-                connections: self.connections,
-                connection: [newConnectionIdentity],
-                //
-                // // Cache reference to the parent
-                // waterline: self.waterline,
-                //
-                // // Default Attributes
-                attributes: self.attributes || {},
-                //
-                tableName: self.tableName,
-                identity: newCollectionIdentity,
-                baseIdentity: baseCollectionIdentity
+            var WaterlineCollection = require('../../collection');
+            var colDupModel = extend.call(WaterlineCollection, {
+                    // Set the named connections
+                    connections: self.connections,
+                    connection: [newConnectionIdentity],
 
+                    // Default Attributes
+                    schema: self.schema,
+                    attributes: self.attributes || {},
+                    tableName: self.tableName,
+                    autoCreatedAt: self.autoCreatedAt,
+                    autoUpdateAt: self.autoUpdateAt,
+                    autoPK: self.autoPK,
+
+                    //
+                    identity: newCollectionIdentity,
+                    baseIdentity: baseCollectionIdentity
             });
-
-            // Change the connection
-            // console.log('colDupModel', colDupModel);
 
             // Load Schema for Tenant's Collection
             self.waterline.schema[newCollectionIdentity] = self.waterline.schema[self.identity];

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -14,13 +14,12 @@ var extend = require('../../utils/extend');
 /**
  * Tenant
  *
- * @param {Object} criteria
- * @param {Object} options
+ * @param {Object} tenant
  * @param {Function} callback
- * @return Deferred object if no callback
+ * @return this if no callback
  */
 
-module.exports = function(tenant, cb) {
+Tenant = module.exports = function(tenant, cb) {
   var self = this;
   // console.log('tenant', arguments);
   var usage = utils.capitalize(this.identity) + '.tenant(tenantId,callback)';

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -84,6 +84,7 @@ Tenant = module.exports = function(tenant, cb) {
             // There is already an existing TenantCollection
             return cb(null, tenantCollection);
           }
+
           // No existing TenantCollection found
           // Create a new TenantCollection!
           var WaterlineCollection = require('../../collection');
@@ -101,7 +102,8 @@ Tenant = module.exports = function(tenant, cb) {
 
           // Load Collection with new connection
           self.waterline.loadCollection(colDupModel);
-          var loader = new CollectionLoader(colDupModel, self.connections,
+          var loader = new CollectionLoader(colDupModel, self.waterline
+            .connections,
             self.defaults);
           var newCollection = loader.initialize(self.waterline);
 
@@ -116,7 +118,7 @@ Tenant = module.exports = function(tenant, cb) {
         }
 
         // Check if the connection already exists
-        if (self.connections[newConnectionIdentity]) {
+        if (self.waterline.connections[newConnectionIdentity]) {
           // Connection already exists, do not create another
           return createTenantCollection();
         } else {
@@ -135,18 +137,43 @@ Tenant = module.exports = function(tenant, cb) {
           // new Tenant-specific Connection is `this` Collection.
           // However, later on this could support pooling of some kind
           // with multiple Collections for a multi-tenant connection.
-          var tempCollections = {};
-          tempCollections[self.identity] = self;
+          var tempCollections = self.waterline.collections;
           // Grab the schemas used on this connection
           var usedSchemas = {};
-          Object.keys(tempCollections).forEach(function(coll) {
+          Object.keys(tempCollections).forEach(function(collName) {
+            var coll = tempCollections[collName];
+            // Check if collection is a base collection
+            if (coll.baseIdentity) {
+              // Knows it has a base collection
+              // Therefore it is a Tenant-Specific Collection
+              // Only want Base Collections
+              return;
+            }
+            // Check if this collection uses this connection
+            // Normalize connection to array
+            if (Array.isArray(coll.connection)) {
+              // Is array
+              if (coll.connection.indexOf(baseConnectionName) === -1) {
+                // Not found
+                // Collection does not use this Connection
+                return;
+              }
+            } else {
+              // Is not array
+              if (coll.connection !== baseConnectionName) {
+                // Not the same
+                // Collection does not use this Connection
+                return;
+              }
+            }
+            // Continue to add schema
             var identity = coll;
-            if (hasOwnProperty(tempCollections[coll].__proto__,
+            if (hasOwnProperty(coll.__proto__,
                 'tableName')) {
-              identity = tempCollections[coll].__proto__.tableName;
+              identity = coll.__proto__.tableName;
             }
             // Collection is already built
-            usedSchemas[identity] = tempCollections[coll];
+            usedSchemas[identity] = coll;
           });
 
           // Build the connection config
@@ -155,7 +182,8 @@ Tenant = module.exports = function(tenant, cb) {
             _adapter: _.cloneDeep(connection._adapter),
             _collections: []
           };
-          self.connections[newConnectionIdentity] = newConnection;
+          self.waterline.connections[newConnectionIdentity] =
+            newConnection;
 
           newConnection._adapter.registerConnection(config, usedSchemas,
             function(err) {
@@ -169,7 +197,7 @@ Tenant = module.exports = function(tenant, cb) {
 
       });
       return self;
-      
+
     } else {
 
       // Change current tenant on this Collection's Connection's config

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -68,6 +68,12 @@ module.exports = function(tenant, cb) {
 
       var configDup = _.cloneDeep(config);
       configDup.tenant = tenant; // Set Tenant
+      // Check if it is the BaseConnection
+      if (connectionName === baseConnectionName) {
+          // Reset the tenant on the connection for the global/main Collection
+          config.tenant = null;
+      }
+      // Get the config for this tenant
       configForTenant.call(self, tenant, configDup, function(err, config) {
         // console.log('configForTenant', err, config);
         if (err) return cb(err);
@@ -79,8 +85,16 @@ module.exports = function(tenant, cb) {
         function createTenantCollection() {
 
             // console.log('create tenant collection', self instanceof require('../../collection'), self);
-
             var newCollectionIdentity = (baseCollectionIdentity + tenantSuffix).toLowerCase();
+
+            // Get TenantCollection, if already exists
+            var tenantCollection = self.waterline.collections[newCollectionIdentity];
+            if (tenantCollection) {
+                // There is already an existing TenantCollection
+                return cb(null, tenantCollection);
+            }
+            // No existing TenantCollection found
+            // Create a new TenantCollection!
 
             var WaterlineCollection = require('../../collection');
             var colDupModel = extend.call(WaterlineCollection, {
@@ -163,10 +177,6 @@ module.exports = function(tenant, cb) {
       });
 
     } else {
-
-      // TODO: Support Promise-Style / Deferred
-      // TODO: Update Deferred to check for Tenant
-      // TODO: Update Operation to check for Tenant
 
       // Change current tenant on this Collection's Connection's config
       config.tenant = tenant;

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -1,0 +1,159 @@
+/**
+ * Module Dependencies
+ */
+
+var _ = require('lodash');
+var usageError = require('../../utils/usageError');
+var utils = require('../../utils/helpers');
+var normalize = require('../../utils/normalize');
+var Deferred = require('../deferred');
+var hasOwnProperty = utils.object.hasOwnProperty;
+var CollectionLoader = require('../../collection/loader');
+
+/**
+ * Tenant
+ *
+ * @param {Object} criteria
+ * @param {Object} options
+ * @param {Function} callback
+ * @return Deferred object if no callback
+ */
+
+module.exports = function(tenant, cb) {
+  var self = this;
+  // console.log('tenant', arguments);
+  var usage = utils.capitalize(this.identity) + '.tenant(tenantId,callback)';
+
+  if (arguments.length === 0) {
+    //
+    // Error
+    return usageError('Tenant must be passed.', usage, cb);
+  }
+
+  if (typeof tenant === 'function') {
+    // Tenant is required
+    // Error
+    return usageError('Tenant must be passed.', usage, cb);
+  }
+
+
+  // Change connection settings based on tenant
+  // console.log('collections', this.waterline.collections);
+  // console.log('adapterDictionary', this.waterline, this.adapterDictionary);
+  var connectionName = this.adapterDictionary['identity'];
+  var connection = this.connections[connectionName];
+  // Change for Multi-Tenancy support
+  // console.log('connection', connection);
+  var config = connection.config;
+  // console.log('config', config);
+
+  if (config.isMultiTenant && typeof config.getTenant === "function") {
+
+    var configForTenant = config.configForTenant;
+
+    // Return Deferred or pass to adapter
+    if (typeof cb === 'function') {
+
+      var configDup = _.cloneDeep(config);
+      configDup.tenant = tenant; // Set Tenant
+      configForTenant.call(self, tenant, configDup, function(err, config) {
+        // console.log('configForTenant', err, config);
+        if (err) return cb(err);
+
+        // Tenant's config namespace
+        var tenantSuffix = "<tenant:" + tenant + ">";
+        var newConnectionIdentity = (connectionName + tenantSuffix).toLowerCase();
+
+        // Check if the connection's adapter has a register connection method
+        if (!hasOwnProperty(connection._adapter,
+            'registerConnection'))
+          return cb(null, self);
+
+        // Register adapter connection
+        config.identity = newConnectionIdentity;
+        // console.log('newConfig', config);
+        // console.log('registerConnnection', self.registerConnection.toString());
+        var usedSchemas = {};
+        usedSchemas[self.identity] = self;
+
+        // Build the connection config
+        var newConnection = {
+            config: _.merge({}, connection._adapter.defaults, config),
+            _adapter: _.cloneDeep(connection._adapter),
+            _collections: []
+        };
+        self.connections[newConnectionIdentity] = newConnection;
+        // console.log('connection, old:new:', connection, newConnection);
+
+        newConnection._adapter.registerConnection(config, usedSchemas,
+          function(err) {
+            if (err) return cb(err);
+
+            var newCollectionIdentity = (self.identity + tenantSuffix).toLowerCase();
+
+            // Take new config and register it's connection
+            // var cols = self.waterline._collections;
+            // console.log('collections', cols);
+            // var col = _.find(cols, function(col) {
+            //     return true;
+            // });
+            // var col = self.collection;
+            // console.log(col);
+            // var colDupModel = _.cloneDeep(self);
+            // var Collection = require('../../collection');
+            //
+            // console.log('connections', self.connections);
+            var colDupModel = self.constructor.extend({
+                // // Set the named connections
+                connections: self.connections,
+                connection: [newConnectionIdentity],
+                //
+                // // Cache reference to the parent
+                // waterline: self.waterline,
+                //
+                // // Default Attributes
+                attributes: self.attributes || {},
+                //
+                tableName: self.tableName,
+                identity: newCollectionIdentity
+
+            });
+
+            // Change the connection
+            // console.log('colDupModel', colDupModel);
+
+            // Load Schema for Tenant's Collection
+            self.waterline.schema[newCollectionIdentity] = self.waterline.schema[self.identity];
+
+            // Load Collection with new connection
+            self.waterline.loadCollection(colDupModel);
+            var loader = new CollectionLoader(colDupModel, self.connections, self.defaults);
+            var newCollection = loader.initialize(self.waterline);
+
+            // Store the instantiated collection so it can be used
+            // internally to create other records
+            self.waterline.collections[newCollectionIdentity] = newCollection;
+
+            // console.log('oldCollection', self);
+            // console.log('newCollection', newCollection);
+
+            // Return the new Collection linked with the new Connection
+            return cb(null, newCollection);
+          });
+      });
+
+    } else {
+      // TODO: Support Promise-Style / Deferred
+      // TODO: Update Deferred to check for Tenant
+      // TODO: Update Operation to check for Tenant
+      return usageError('Promise-style call not yet supported.', usage, cb);
+    }
+
+  } else {
+    // Invalid, Multi-Tenancy not supported with this connection
+    return usageError(
+      'Multi-Tenancy not supported with this connection\'s configuration',
+      '{isMultiTenant:true}', cb);
+  }
+
+};

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -168,7 +168,8 @@ Tenant = module.exports = function(tenant, cb) {
         }
 
       });
-
+      return self;
+      
     } else {
 
       // Change current tenant on this Collection's Connection's config

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -40,7 +40,18 @@ module.exports = function(tenant, cb) {
   // Change connection settings based on tenant
   // console.log('collections', this.waterline.collections);
   // console.log('adapterDictionary', this.waterline, this.adapterDictionary);
+
+  var baseCollectionIdentity = self.baseIdentity || self.identity;
   var connectionName = this.adapterDictionary['identity'];
+  var baseConnectionName = connectionName;
+  if (baseCollectionIdentity != self.identity) {
+      // Is not the base Collection
+      // Get base collection
+      var baseCollection = self.waterline.collections[baseCollectionIdentity];
+    //   console.log('baseCollection', baseCollectionIdentity);
+      baseConnectionName = baseCollection.adapterDictionary['identity'];
+    //   console.log('baseConnectionName', baseConnectionName);
+  }
   var connection = this.connections[connectionName];
   // Change for Multi-Tenancy support
   // console.log('connection', connection);
@@ -62,34 +73,11 @@ module.exports = function(tenant, cb) {
 
         // Tenant's config namespace
         var tenantSuffix = "<tenant:" + tenant + ">";
-        var newConnectionIdentity = (connectionName + tenantSuffix).toLowerCase();
+        var newConnectionIdentity = (baseConnectionName + tenantSuffix).toLowerCase();
 
-        // Check if the connection's adapter has a register connection method
-        if (!hasOwnProperty(connection._adapter,
-            'registerConnection'))
-          return cb(null, self);
+        function createTenantCollection() {
 
-        // Register adapter connection
-        config.identity = newConnectionIdentity;
-        // console.log('newConfig', config);
-        // console.log('registerConnnection', self.registerConnection.toString());
-        var usedSchemas = {};
-        usedSchemas[self.identity] = self;
-
-        // Build the connection config
-        var newConnection = {
-            config: _.merge({}, connection._adapter.defaults, config),
-            _adapter: _.cloneDeep(connection._adapter),
-            _collections: []
-        };
-        self.connections[newConnectionIdentity] = newConnection;
-        // console.log('connection, old:new:', connection, newConnection);
-
-        newConnection._adapter.registerConnection(config, usedSchemas,
-          function(err) {
-            if (err) return cb(err);
-
-            var newCollectionIdentity = (self.identity + tenantSuffix).toLowerCase();
+            var newCollectionIdentity = (baseCollectionIdentity + tenantSuffix).toLowerCase();
 
             // Take new config and register it's connection
             // var cols = self.waterline._collections;
@@ -115,7 +103,8 @@ module.exports = function(tenant, cb) {
                 attributes: self.attributes || {},
                 //
                 tableName: self.tableName,
-                identity: newCollectionIdentity
+                identity: newCollectionIdentity,
+                baseIdentity: baseCollectionIdentity
 
             });
 
@@ -139,14 +128,60 @@ module.exports = function(tenant, cb) {
 
             // Return the new Collection linked with the new Connection
             return cb(null, newCollection);
-          });
+
+        }
+
+        // Check if the connection already exists
+        if (self.connections[newConnectionIdentity]) {
+            // Connection already exists, do not create another
+            return createTenantCollection();
+        } else {
+            // Connection does not already exist, create it now
+
+            // Check if the connection's adapter has a register connection method
+            if (!hasOwnProperty(connection._adapter,
+                'registerConnection'))
+              return cb(null, self);
+
+            // Register adapter connection
+            config.baseIdentity = baseConnectionName;
+            config.identity = newConnectionIdentity;
+            // console.log('newConfig', config);
+            // console.log('registerConnnection', self.registerConnection.toString());
+            var usedSchemas = {};
+            usedSchemas[self.identity] = self;
+
+            // Build the connection config
+            var newConnection = {
+                config: _.merge({}, connection._adapter.defaults, config),
+                _adapter: _.cloneDeep(connection._adapter),
+                _collections: []
+            };
+            self.connections[newConnectionIdentity] = newConnection;
+            // console.log('connection, old:new:', connection, newConnection);
+
+            newConnection._adapter.registerConnection(config, usedSchemas,
+              function(err) {
+                if (err) return cb(err);
+
+                return createTenantCollection();
+
+              });
+
+        }
+
       });
 
     } else {
+
       // TODO: Support Promise-Style / Deferred
       // TODO: Update Deferred to check for Tenant
       // TODO: Update Operation to check for Tenant
-      return usageError('Promise-style call not yet supported.', usage, cb);
+
+      // Change current tenant on this Collection's Connection's config
+      config.tenant = tenant;
+      return self;
+
     }
 
   } else {

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -58,7 +58,7 @@ Tenant = module.exports = function(tenant, cb) {
   var config = connection.config;
   // console.log('config', config);
 
-  if (config.isMultiTenant && typeof config.getTenant === "function") {
+  if (config.isMultiTenant && typeof config.configForTenant === "function") {
 
     var configForTenant = config.configForTenant;
 

--- a/lib/waterline/query/dql/tenant.js
+++ b/lib/waterline/query/dql/tenant.js
@@ -21,7 +21,6 @@ var extend = require('../../utils/extend');
 
 Tenant = module.exports = function(tenant, cb) {
   var self = this;
-  // console.log('tenant', arguments);
   var usage = utils.capitalize(this.identity) + '.tenant(tenantId,callback)';
 
   if (arguments.length === 0) {
@@ -38,25 +37,18 @@ Tenant = module.exports = function(tenant, cb) {
 
 
   // Change connection settings based on tenant
-  // console.log('collections', this.waterline.collections);
-  // console.log('adapterDictionary', this.waterline, this.adapterDictionary);
-
   var baseCollectionIdentity = self.baseIdentity || self.identity;
   var connectionName = this.adapterDictionary['identity'];
   var baseConnectionName = connectionName;
   if (baseCollectionIdentity != self.identity) {
-      // Is not the base Collection
-      // Get base collection
-      var baseCollection = self.waterline.collections[baseCollectionIdentity];
-    //   console.log('baseCollection', baseCollectionIdentity);
-      baseConnectionName = baseCollection.adapterDictionary['identity'];
-    //   console.log('baseConnectionName', baseConnectionName);
+    // Is not the base Collection
+    // Get base collection
+    var baseCollection = self.waterline.collections[baseCollectionIdentity];
+    baseConnectionName = baseCollection.adapterDictionary['identity'];
   }
   var connection = this.connections[connectionName];
   // Change for Multi-Tenancy support
-  // console.log('connection', connection);
   var config = connection.config;
-  // console.log('config', config);
 
   if (config.isMultiTenant && typeof config.configForTenant === "function") {
 
@@ -69,12 +61,11 @@ Tenant = module.exports = function(tenant, cb) {
       configDup.tenant = tenant; // Set Tenant
       // Check if it is the BaseConnection
       if (connectionName === baseConnectionName) {
-          // Reset the tenant on the connection for the global/main Collection
-          config.tenant = null;
+        // Reset the tenant on the connection for the global/main Collection
+        config.tenant = null;
       }
       // Get the config for this tenant
       configForTenant.call(self, tenant, configDup, function(err, config) {
-        // console.log('configForTenant', err, config);
         if (err) return cb(err);
 
         // Tenant's config namespace
@@ -83,93 +74,96 @@ Tenant = module.exports = function(tenant, cb) {
 
         function createTenantCollection() {
 
-            // console.log('create tenant collection', self instanceof require('../../collection'), self);
-            var newCollectionIdentity = (baseCollectionIdentity + tenantSuffix).toLowerCase();
+          var newCollectionIdentity = (baseCollectionIdentity +
+            tenantSuffix).toLowerCase();
 
-            // Get TenantCollection, if already exists
-            var tenantCollection = self.waterline.collections[newCollectionIdentity];
-            if (tenantCollection) {
-                // There is already an existing TenantCollection
-                return cb(null, tenantCollection);
-            }
-            // No existing TenantCollection found
-            // Create a new TenantCollection!
+          // Get TenantCollection, if already exists
+          var tenantCollection = self.waterline.collections[
+            newCollectionIdentity];
+          if (tenantCollection) {
+            // There is already an existing TenantCollection
+            return cb(null, tenantCollection);
+          }
+          // No existing TenantCollection found
+          // Create a new TenantCollection!
+          var WaterlineCollection = require('../../collection');
+          var m = _.cloneDeep(self.__proto__);
+          _.merge(m, {
+            connection: [newConnectionIdentity],
+            identity: newCollectionIdentity,
+            baseIdentity: baseCollectionIdentity
+          });
+          var colDupModel = extend.call(WaterlineCollection, m);
 
-            var WaterlineCollection = require('../../collection');
-            var colDupModel = extend.call(WaterlineCollection, {
-                    // Set the named connections
-                    connections: self.connections,
-                    connection: [newConnectionIdentity],
+          // Load Schema for Tenant's Collection
+          self.waterline.schema[newCollectionIdentity] = self.waterline
+            .schema[self.identity];
 
-                    // Default Attributes
-                    schema: self.schema,
-                    attributes: self.attributes || {},
-                    tableName: self.tableName,
-                    autoCreatedAt: self.autoCreatedAt,
-                    autoUpdateAt: self.autoUpdateAt,
-                    autoPK: self.autoPK,
+          // Load Collection with new connection
+          self.waterline.loadCollection(colDupModel);
+          var loader = new CollectionLoader(colDupModel, self.connections,
+            self.defaults);
+          var newCollection = loader.initialize(self.waterline);
 
-                    //
-                    identity: newCollectionIdentity,
-                    baseIdentity: baseCollectionIdentity
-            });
+          // Store the instantiated collection so it can be used
+          // internally to create other records
+          self.waterline.collections[newCollectionIdentity] =
+            newCollection;
 
-            // Load Schema for Tenant's Collection
-            self.waterline.schema[newCollectionIdentity] = self.waterline.schema[self.identity];
-
-            // Load Collection with new connection
-            self.waterline.loadCollection(colDupModel);
-            var loader = new CollectionLoader(colDupModel, self.connections, self.defaults);
-            var newCollection = loader.initialize(self.waterline);
-
-            // Store the instantiated collection so it can be used
-            // internally to create other records
-            self.waterline.collections[newCollectionIdentity] = newCollection;
-
-            // console.log('oldCollection', self);
-            // console.log('newCollection', newCollection);
-
-            // Return the new Collection linked with the new Connection
-            return cb(null, newCollection);
+          // Return the new Collection linked with the new Connection
+          return cb(null, newCollection);
 
         }
 
         // Check if the connection already exists
         if (self.connections[newConnectionIdentity]) {
-            // Connection already exists, do not create another
-            return createTenantCollection();
+          // Connection already exists, do not create another
+          return createTenantCollection();
         } else {
-            // Connection does not already exist, create it now
+          // Connection does not already exist, create it now
 
-            // Check if the connection's adapter has a register connection method
-            if (!hasOwnProperty(connection._adapter,
-                'registerConnection'))
-              return cb(null, self);
+          // Check if the connection's adapter has a register connection method
+          if (!hasOwnProperty(connection._adapter,
+              'registerConnection'))
+            return cb(null, self);
 
-            // Register adapter connection
-            config.baseIdentity = baseConnectionName;
-            config.identity = newConnectionIdentity;
-            // console.log('newConfig', config);
-            // console.log('registerConnnection', self.registerConnection.toString());
-            var usedSchemas = {};
-            usedSchemas[self.identity] = self;
+          // Register adapter connection
+          config.baseIdentity = baseConnectionName;
+          config.identity = newConnectionIdentity;
 
-            // Build the connection config
-            var newConnection = {
-                config: _.merge({}, connection._adapter.defaults, config),
-                _adapter: _.cloneDeep(connection._adapter),
-                _collections: []
-            };
-            self.connections[newConnectionIdentity] = newConnection;
-            // console.log('connection, old:new:', connection, newConnection);
+          // Currently the only Collection for this
+          // new Tenant-specific Connection is `this` Collection.
+          // However, later on this could support pooling of some kind
+          // with multiple Collections for a multi-tenant connection.
+          var tempCollections = {};
+          tempCollections[self.identity] = self;
+          // Grab the schemas used on this connection
+          var usedSchemas = {};
+          Object.keys(tempCollections).forEach(function(coll) {
+            var identity = coll;
+            if (hasOwnProperty(tempCollections[coll].__proto__,
+                'tableName')) {
+              identity = tempCollections[coll].__proto__.tableName;
+            }
+            // Collection is already built
+            usedSchemas[identity] = tempCollections[coll];
+          });
 
-            newConnection._adapter.registerConnection(config, usedSchemas,
-              function(err) {
-                if (err) return cb(err);
+          // Build the connection config
+          var newConnection = {
+            config: _.merge({}, connection._adapter.defaults, config),
+            _adapter: _.cloneDeep(connection._adapter),
+            _collections: []
+          };
+          self.connections[newConnectionIdentity] = newConnection;
 
-                return createTenantCollection();
+          newConnection._adapter.registerConnection(config, usedSchemas,
+            function(err) {
+              if (err) return cb(err);
 
-              });
+              return createTenantCollection();
+
+            });
 
         }
 

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -46,7 +46,8 @@ module.exports = function(criteria, values, cb) {
   // Resolve Tenant-specific Collection, if applicable
   var connName = this.adapter.dictionary.update;
   this._resolveCollection(connName, function(err, self) {
-
+      if(err) return cb(err);
+      
       // Create any of the belongsTo associations and set the foreign key values
       createBelongsTo.call(self, valuesObject, function(err) {
         if(err) return cb(err);

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -43,15 +43,22 @@ module.exports = function(criteria, values, cb) {
   // Format Criteria and Values
   var valuesObject = prepareArguments.call(this, criteria, values);
 
-  // Create any of the belongsTo associations and set the foreign key values
-  createBelongsTo.call(this, valuesObject, function(err) {
-    if(err) return cb(err);
+  // Resolve Tenant-specific Collection, if applicable
+  var connName = this.adapter.dictionary.update;
+  this._resolveCollection(connName, function(err, self) {
 
-    beforeCallbacks.call(self, valuesObject.values, function(err) {
-      if(err) return cb(err);
-      updateRecords.call(self, valuesObject, cb);
-    });
+      // Create any of the belongsTo associations and set the foreign key values
+      createBelongsTo.call(self, valuesObject, function(err) {
+        if(err) return cb(err);
+
+        beforeCallbacks.call(self, valuesObject.values, function(err) {
+          if(err) return cb(err);
+          updateRecords.call(self, valuesObject, cb);
+        });
+      });
+
   });
+
 };
 
 

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -59,115 +59,122 @@ module.exports = {
       return cb(null, null);
     }
 
-    // Build up an operations set
-    var operations = new Operations(self, criteria, 'findOne');
+    // Resolve Tenant-specific Collection, if applicable
+    var connName = this.adapter.dictionary.findOne || this.adapter.dictionary.find;
+    this._resolveCollection(connName, function(err, self) {
 
-    // Run the operations
-    operations.run(function(err, values) {
-      if(err) return cb(err);
-      if(!values.cache) return cb();
+        // Build up an operations set
+        var operations = new Operations(self, criteria, 'findOne');
 
-      // If no joins are used grab the only item from the cache and pass to the returnResults
-      // function.
-      if(!criteria.joins) {
-        values = values.cache[self.identity];
-        return returnResults(values);
-      }
+        // Run the operations
+        operations.run(function(err, values) {
+          if(err) return cb(err);
+          if(!values.cache) return cb();
 
-      // If the values are already combined, return the results
-      if(values.combined) {
-        return returnResults(values.cache[self.identity]);
-      }
-
-      // Find the primaryKey of the current model so it can be passed down to the integrator.
-      // Use 'id' as a good general default;
-      var primaryKey = 'id';
-
-      Object.keys(self._schema.schema).forEach(function(key) {
-        if(self._schema.schema[key].hasOwnProperty('primaryKey') && self._schema.schema[key].primaryKey) {
-          primaryKey = key;
-        }
-      });
-
-
-      // Perform in-memory joins
-      Integrator(values.cache, criteria.joins, primaryKey, function(err, results) {
-        if(err) return cb(err);
-        if(!results) return cb();
-
-        // We need to run one last check on the results using the criteria. This allows a self
-        // association where we end up with two records in the cache both having each other as
-        // embedded objects and we only want one result. However we need to filter any join criteria
-        // out of the top level where query so that searchs by primary key still work.
-        var tmpCriteria = _.cloneDeep(criteria.where);
-        if(!tmpCriteria) tmpCriteria = {};
-
-        criteria.joins.forEach(function(join) {
-          if(!hasOwnProperty(join, 'alias')) return;
-
-          // Check for `OR` criteria
-          if(hasOwnProperty(tmpCriteria, 'or')) {
-            tmpCriteria.or.forEach(function(search) {
-              if(!hasOwnProperty(search, join.alias)) return;
-              delete search[join.alias];
-            });
-            return;
+          // If no joins are used grab the only item from the cache and pass to the returnResults
+          // function.
+          if(!criteria.joins) {
+            values = values.cache[self.identity];
+            return returnResults(values);
           }
 
-          if(!hasOwnProperty(tmpCriteria, join.alias)) return;
-          delete tmpCriteria[join.alias];
-        });
+          // If the values are already combined, return the results
+          if(values.combined) {
+            return returnResults(values.cache[self.identity]);
+          }
 
-        // Pass results into Waterline-Criteria
-        var _criteria = { where: tmpCriteria };
-        results = waterlineCriteria('parent', { parent: results }, _criteria).results;
+          // Find the primaryKey of the current model so it can be passed down to the integrator.
+          // Use 'id' as a good general default;
+          var primaryKey = 'id';
 
-        results.forEach(function(res) {
-
-          // Go Ahead and perform any sorts on the associated data
-          criteria.joins.forEach(function(join) {
-            if(!join.criteria) return;
-            var c = normalize.criteria(join.criteria);
-            if(!c.sort) return;
-
-            var alias = join.alias;
-            res[alias] = sorter(res[alias], c.sort);
+          Object.keys(self._schema.schema).forEach(function(key) {
+            if(self._schema.schema[key].hasOwnProperty('primaryKey') && self._schema.schema[key].primaryKey) {
+              primaryKey = key;
+            }
           });
+
+
+          // Perform in-memory joins
+          Integrator(values.cache, criteria.joins, primaryKey, function(err, results) {
+            if(err) return cb(err);
+            if(!results) return cb();
+
+            // We need to run one last check on the results using the criteria. This allows a self
+            // association where we end up with two records in the cache both having each other as
+            // embedded objects and we only want one result. However we need to filter any join criteria
+            // out of the top level where query so that searchs by primary key still work.
+            var tmpCriteria = _.cloneDeep(criteria.where);
+            if(!tmpCriteria) tmpCriteria = {};
+
+            criteria.joins.forEach(function(join) {
+              if(!hasOwnProperty(join, 'alias')) return;
+
+              // Check for `OR` criteria
+              if(hasOwnProperty(tmpCriteria, 'or')) {
+                tmpCriteria.or.forEach(function(search) {
+                  if(!hasOwnProperty(search, join.alias)) return;
+                  delete search[join.alias];
+                });
+                return;
+              }
+
+              if(!hasOwnProperty(tmpCriteria, join.alias)) return;
+              delete tmpCriteria[join.alias];
+            });
+
+            // Pass results into Waterline-Criteria
+            var _criteria = { where: tmpCriteria };
+            results = waterlineCriteria('parent', { parent: results }, _criteria).results;
+
+            results.forEach(function(res) {
+
+              // Go Ahead and perform any sorts on the associated data
+              criteria.joins.forEach(function(join) {
+                if(!join.criteria) return;
+                var c = normalize.criteria(join.criteria);
+                if(!c.sort) return;
+
+                var alias = join.alias;
+                res[alias] = sorter(res[alias], c.sort);
+              });
+            });
+
+            returnResults(results);
+          });
+
+          function returnResults(results) {
+
+            if(!results) return cb();
+
+            // Normalize results to an array
+            if(!Array.isArray(results) && results) results = [results];
+
+            // Unserialize each of the results before attempting any join logic on them
+            var unserializedModels = [];
+            results.forEach(function(result) {
+              unserializedModels.push(self._transformer.unserialize(result));
+            });
+
+            var models = [];
+            var joins = criteria.joins ? criteria.joins : [];
+            var data = new Joins(joins, unserializedModels, self.identity, self._schema.schema, self.waterline.collections);
+
+            // If `data.models` is invalid (not an array) return early to avoid getting into trouble.
+            if (!data || !data.models || !data.models.forEach) {
+              return cb(new Error('Values returned from operations set are not an array...'));
+            }
+
+            // Create a model for the top level values
+            data.models.forEach(function(model) {
+              models.push(new self._model(model, data.options));
+            });
+
+            cb(null, models[0]);
+          }
         });
 
-        returnResults(results);
-      });
-
-      function returnResults(results) {
-
-        if(!results) return cb();
-
-        // Normalize results to an array
-        if(!Array.isArray(results) && results) results = [results];
-
-        // Unserialize each of the results before attempting any join logic on them
-        var unserializedModels = [];
-        results.forEach(function(result) {
-          unserializedModels.push(self._transformer.unserialize(result));
-        });
-
-        var models = [];
-        var joins = criteria.joins ? criteria.joins : [];
-        var data = new Joins(joins, unserializedModels, self.identity, self._schema.schema, self.waterline.collections);
-
-        // If `data.models` is invalid (not an array) return early to avoid getting into trouble.
-        if (!data || !data.models || !data.models.forEach) {
-          return cb(new Error('Values returned from operations set are not an array...'));
-        }
-
-        // Create a model for the top level values
-        data.models.forEach(function(model) {
-          models.push(new self._model(model, data.options));
-        });
-
-        cb(null, models[0]);
-      }
     });
+
   },
 
   /**
@@ -235,126 +242,131 @@ module.exports = {
 
     criteria = self._transformer.serialize(criteria);
 
+    // Resolve Tenant-specific Collection, if applicable
+    var connName = self.adapter.dictionary.find;
+    self._resolveCollection(connName, function(err, self) {
 
-    // Build up an operations set
-    var operations = new Operations(self, criteria, 'find');
+        // Build up an operations set
+        var operations = new Operations(self, criteria, 'find');
 
-    // Run the operations
-    operations.run(function(err, values) {
-      if(err) return cb(err);
-      if(!values.cache) return cb();
+        // Run the operations
+        operations.run(function(err, values) {
+          if(err) return cb(err);
+          if(!values.cache) return cb();
 
-      // If no joins are used grab current collection's item from the cache and pass to the returnResults
-      // function.
-      if(!criteria.joins) {
-        values = values.cache[self.identity];
-        return returnResults(values);
-      }
-
-      // If the values are already combined, return the results
-      if(values.combined) {
-        return returnResults(values.cache[self.identity]);
-      }
-
-      // Find the primaryKey of the current model so it can be passed down to the integrator.
-      // Use 'id' as a good general default;
-      var primaryKey = 'id';
-
-      Object.keys(self._schema.schema).forEach(function(key) {
-        if(self._schema.schema[key].hasOwnProperty('primaryKey') && self._schema.schema[key].primaryKey) {
-          primaryKey = key;
-        }
-      });
-
-      // Perform in-memory joins
-      Integrator(values.cache, criteria.joins, primaryKey, function(err, results) {
-        if(err) return cb(err);
-        if(!results) return cb();
-
-        // We need to run one last check on the results using the criteria. This allows a self
-        // association where we end up with two records in the cache both having each other as
-        // embedded objects and we only want one result. However we need to filter any join criteria
-        // out of the top level where query so that searchs by primary key still work.
-        var tmpCriteria = _.cloneDeep(criteria.where);
-        if(!tmpCriteria) tmpCriteria = {};
-
-        criteria.joins.forEach(function(join) {
-          if(!hasOwnProperty(join, 'alias')) return;
-
-          // Check for `OR` criteria
-          if(hasOwnProperty(tmpCriteria, 'or')) {
-            tmpCriteria.or.forEach(function(search) {
-              if(!hasOwnProperty(search, join.alias)) return;
-              delete search[join.alias];
-            });
-            return;
+          // If no joins are used grab current collection's item from the cache and pass to the returnResults
+          // function.
+          if(!criteria.joins) {
+            values = values.cache[self.identity];
+            return returnResults(values);
           }
 
-          if(!hasOwnProperty(tmpCriteria, join.alias)) return;
-          delete tmpCriteria[join.alias];
-        });
+          // If the values are already combined, return the results
+          if(values.combined) {
+            return returnResults(values.cache[self.identity]);
+          }
 
-        // Pass results into Waterline-Criteria
-        var _criteria = { where: tmpCriteria };
-        results = waterlineCriteria('parent', { parent: results }, _criteria).results;
+          // Find the primaryKey of the current model so it can be passed down to the integrator.
+          // Use 'id' as a good general default;
+          var primaryKey = 'id';
 
-        // Serialize values coming from an in-memory join before modelizing
-        var _results = [];
-        results.forEach(function(res) {
-
-          // Go Ahead and perform any sorts on the associated data
-          criteria.joins.forEach(function(join) {
-            if(!join.criteria) return;
-            var c = normalize.criteria(join.criteria);
-            if(!c.sort) return;
-
-            var alias = join.alias;
-            res[alias] = sorter(res[alias], c.sort);
+          Object.keys(self._schema.schema).forEach(function(key) {
+            if(self._schema.schema[key].hasOwnProperty('primaryKey') && self._schema.schema[key].primaryKey) {
+              primaryKey = key;
+            }
           });
-        });
 
-        returnResults(results);
-      });
+          // Perform in-memory joins
+          Integrator(values.cache, criteria.joins, primaryKey, function(err, results) {
+            if(err) return cb(err);
+            if(!results) return cb();
 
-      function returnResults(results) {
+            // We need to run one last check on the results using the criteria. This allows a self
+            // association where we end up with two records in the cache both having each other as
+            // embedded objects and we only want one result. However we need to filter any join criteria
+            // out of the top level where query so that searchs by primary key still work.
+            var tmpCriteria = _.cloneDeep(criteria.where);
+            if(!tmpCriteria) tmpCriteria = {};
 
-        if(!results) return cb(null, []);
+            criteria.joins.forEach(function(join) {
+              if(!hasOwnProperty(join, 'alias')) return;
 
-        // Normalize results to an array
-        if(!Array.isArray(results) && results) results = [results];
+              // Check for `OR` criteria
+              if(hasOwnProperty(tmpCriteria, 'or')) {
+                tmpCriteria.or.forEach(function(search) {
+                  if(!hasOwnProperty(search, join.alias)) return;
+                  delete search[join.alias];
+                });
+                return;
+              }
 
-        // Unserialize each of the results before attempting any join logic on them
-        var unserializedModels = [];
+              if(!hasOwnProperty(tmpCriteria, join.alias)) return;
+              delete tmpCriteria[join.alias];
+            });
 
-        if(results) {
-          results.forEach(function(result) {
-            unserializedModels.push(self._transformer.unserialize(result));
+            // Pass results into Waterline-Criteria
+            var _criteria = { where: tmpCriteria };
+            results = waterlineCriteria('parent', { parent: results }, _criteria).results;
+
+            // Serialize values coming from an in-memory join before modelizing
+            var _results = [];
+            results.forEach(function(res) {
+
+              // Go Ahead and perform any sorts on the associated data
+              criteria.joins.forEach(function(join) {
+                if(!join.criteria) return;
+                var c = normalize.criteria(join.criteria);
+                if(!c.sort) return;
+
+                var alias = join.alias;
+                res[alias] = sorter(res[alias], c.sort);
+              });
+            });
+
+            returnResults(results);
           });
-        }
 
-        var models = [];
-        var joins = criteria.joins ? criteria.joins : [];
-        var data = new Joins(joins, unserializedModels, self.identity, self._schema.schema, self.waterline.collections);
+          function returnResults(results) {
 
-        // NOTE:
-        // If a "belongsTo" (i.e. HAS_FK) association is null, should it be transformed into
-        // an empty array here?  That is not what is happening currently, and it can cause
-        // unexpected problems when implementing the native join method as an adapter implementor.
-        // ~Mike June 22, 2014
+            if(!results) return cb(null, []);
 
-        // If `data.models` is invalid (not an array) return early to avoid getting into trouble.
-        if (!data || !data.models || !data.models.forEach) {
-          return cb(new Error('Values returned from operations set are not an array...'));
-        }
+            // Normalize results to an array
+            if(!Array.isArray(results) && results) results = [results];
 
-        // Create a model for the top level values
-        data.models.forEach(function(model) {
-          models.push(new self._model(model, data.options));
+            // Unserialize each of the results before attempting any join logic on them
+            var unserializedModels = [];
+
+            if(results) {
+              results.forEach(function(result) {
+                unserializedModels.push(self._transformer.unserialize(result));
+              });
+            }
+
+            var models = [];
+            var joins = criteria.joins ? criteria.joins : [];
+            var data = new Joins(joins, unserializedModels, self.identity, self._schema.schema, self.waterline.collections);
+
+            // NOTE:
+            // If a "belongsTo" (i.e. HAS_FK) association is null, should it be transformed into
+            // an empty array here?  That is not what is happening currently, and it can cause
+            // unexpected problems when implementing the native join method as an adapter implementor.
+            // ~Mike June 22, 2014
+
+            // If `data.models` is invalid (not an array) return early to avoid getting into trouble.
+            if (!data || !data.models || !data.models.forEach) {
+              return cb(new Error('Values returned from operations set are not an array...'));
+            }
+
+            // Create a model for the top level values
+            data.models.forEach(function(model) {
+              models.push(new self._model(model, data.options));
+            });
+
+
+            cb(null, models);
+          }
+
         });
-
-
-        cb(null, models);
-      }
 
     });
   },

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -62,7 +62,8 @@ module.exports = {
     // Resolve Tenant-specific Collection, if applicable
     var connName = this.adapter.dictionary.findOne || this.adapter.dictionary.find;
     this._resolveCollection(connName, function(err, self) {
-
+        if(err) return cb(err);
+        
         // Build up an operations set
         var operations = new Operations(self, criteria, 'findOne');
 
@@ -245,6 +246,7 @@ module.exports = {
     // Resolve Tenant-specific Collection, if applicable
     var connName = self.adapter.dictionary.find;
     self._resolveCollection(connName, function(err, self) {
+        if(err) return cb(err);
 
         // Build up an operations set
         var operations = new Operations(self, criteria, 'find');

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -420,6 +420,8 @@ Operations.prototype._runOperation = function _runOperation(collectionName, meth
       console.warn('Currently unsupported method for Tenant-Collection Operators: '+method);
     //   console.log('dictionary', adapter.dictionary);
     //   console.log('_runOperation', method, connectionName, collection.adapterDictionary, connection);
+      // Run the operation
+      collection.adapter[method](criteria, cb);
   } else {
 
       var config = connection.config;
@@ -445,9 +447,6 @@ Operations.prototype._runOperation = function _runOperation(collectionName, meth
           }
       }
   }
-
-  // Run the operation
-  collection.adapter[method](criteria, cb);
 
 };
 

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -427,12 +427,13 @@ Operations.prototype._runOperation = function _runOperation(collectionName, meth
       if (config.isMultiTenant) {
           // Is Multi-Tenant connection
           // Check if there is a Tenant set
-          if (config.tenant) {
+          var tenant = config.tenant;
+          if (tenant) {
               // Tenant is set
               // Use Tenant-specific collection
               // Check if Tenant's connection has been loaded
-            //   console.log('select tenant', config.tenant);
-              collection.tenant(config.tenant, function(err, tenantCollection) {
+              //   console.log('select tenant', config.tenant);
+              collection.tenant(tenant, function(err, tenantCollection) {
                 //   console.log('tenant', err, tenantCollection);
                   // Run the operation
                   tenantCollection.adapter[method](criteria, cb);

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -399,28 +399,52 @@ Operations.prototype._runOperation = function _runOperation(collectionName, meth
   // console.log('_runOperation connections', collection.connections);
   // console.log('_runOperation adapterDictionary', collection.adapterDictionary);
   //
-  // var connectionName = collection.adapterDictionary[method];
-  // var connection = collection.connections[connectionName];
-  // if (!connection) {
-  //     console.log('_runOperation', method, connectionName, collection.adapterDictionary, connection);
-  // }
-  // var config = connection.config;
-  //
-  // // Check if multi-tenant
-  // if (config.isMultiTenant) {
-  //     // Is Multi-Tenant connection
-  //     // Check if there is a Tenant set
-  //     if (config.tenant) {
-  //         // Tenant is set
-  //         // Use Tenant-specific collection
-  //         // Check if Tenant's connection has been loaded
-  //
-  //     } else {
-  //         // Error: No tenant set
-  //         return cb(new Error('Tenant is required to be specified in operation.'));
-  //     }
-  // }
-  //
+  var adapter = collection.adapter;
+  var connectionName = adapter.dictionary[method];
+  var connection = collection.connections[connectionName];
+  // Handle methods
+  switch (method) {
+      case 'findOne': {
+          if (!hasOwnProperty(adapter.dictionary, 'findOne')) {
+              // Could not find `findOne`
+              // Fallback to `find`
+              connectionName = adapter.dictionary['find'];
+              connection = collection.connections[connectionName];
+          }
+          break;
+      }
+      default:
+  }
+
+  if (!connection) {
+      console.warn('Currently unsupported method for Tenant-Collection Operators: '+method);
+    //   console.log('dictionary', adapter.dictionary);
+    //   console.log('_runOperation', method, connectionName, collection.adapterDictionary, connection);
+  } else {
+
+      var config = connection.config;
+      // Check if multi-tenant
+      if (config.isMultiTenant) {
+          // Is Multi-Tenant connection
+          // Check if there is a Tenant set
+          if (config.tenant) {
+              // Tenant is set
+              // Use Tenant-specific collection
+              // Check if Tenant's connection has been loaded
+            //   console.log('select tenant', config.tenant);
+              collection.tenant(config.tenant, function(err, tenantCollection) {
+                //   console.log('tenant', err, tenantCollection);
+                  // Run the operation
+                  tenantCollection.adapter[method](criteria, cb);
+              });
+              return;
+          } else {
+              // Error: No tenant set
+              return cb(new Error('Tenant is required to be specified in operation.'));
+          }
+      }
+  }
+
   // Run the operation
   collection.adapter[method](criteria, cb);
 

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -395,7 +395,32 @@ Operations.prototype._runOperation = function _runOperation(collectionName, meth
 
   // Find the connection object to run the operation
   var collection = this.context.waterline.collections[collectionName];
-
+  // console.log('_runOperation collectionName', collectionName);
+  // console.log('_runOperation connections', collection.connections);
+  // console.log('_runOperation adapterDictionary', collection.adapterDictionary);
+  //
+  // var connectionName = collection.adapterDictionary[method];
+  // var connection = collection.connections[connectionName];
+  // if (!connection) {
+  //     console.log('_runOperation', method, connectionName, collection.adapterDictionary, connection);
+  // }
+  // var config = connection.config;
+  //
+  // // Check if multi-tenant
+  // if (config.isMultiTenant) {
+  //     // Is Multi-Tenant connection
+  //     // Check if there is a Tenant set
+  //     if (config.tenant) {
+  //         // Tenant is set
+  //         // Use Tenant-specific collection
+  //         // Check if Tenant's connection has been loaded
+  //
+  //     } else {
+  //         // Error: No tenant set
+  //         return cb(new Error('Tenant is required to be specified in operation.'));
+  //     }
+  // }
+  //
   // Run the operation
   collection.adapter[method](criteria, cb);
 

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -387,6 +387,7 @@ Operations.prototype._getConnections = function _getConnections() {
  */
 
 Operations.prototype._runOperation = function _runOperation(collectionName, method, criteria, cb) {
+    // console.log('_runOperation', collectionName, method, criteria);
 
   // Ensure the collection exist
   if(!hasOwnProperty(this.context.waterline.collections, collectionName)) {
@@ -395,58 +396,8 @@ Operations.prototype._runOperation = function _runOperation(collectionName, meth
 
   // Find the connection object to run the operation
   var collection = this.context.waterline.collections[collectionName];
-  // console.log('_runOperation collectionName', collectionName);
-  // console.log('_runOperation connections', collection.connections);
-  // console.log('_runOperation adapterDictionary', collection.adapterDictionary);
-  //
-  var adapter = collection.adapter;
-  var connectionName = adapter.dictionary[method];
-  var connection = collection.connections[connectionName];
-  // Handle methods
-  switch (method) {
-      case 'findOne': {
-          if (!hasOwnProperty(adapter.dictionary, 'findOne')) {
-              // Could not find `findOne`
-              // Fallback to `find`
-              connectionName = adapter.dictionary['find'];
-              connection = collection.connections[connectionName];
-          }
-          break;
-      }
-      default:
-  }
-
-  if (!connection) {
-      console.warn('Currently unsupported method for Tenant-Collection Operators: '+method);
-    //   console.log('dictionary', adapter.dictionary);
-    //   console.log('_runOperation', method, connectionName, collection.adapterDictionary, connection);
-      // Run the operation
-      collection.adapter[method](criteria, cb);
-  } else {
-
-      var config = connection.config;
-      // Check if multi-tenant
-      if (config.isMultiTenant) {
-          // Is Multi-Tenant connection
-          // Check if there is a Tenant set
-          var tenant = config.tenant;
-          if (tenant) {
-              // Tenant is set
-              // Use Tenant-specific collection
-              // Check if Tenant's connection has been loaded
-              //   console.log('select tenant', config.tenant);
-              collection.tenant(tenant, function(err, tenantCollection) {
-                //   console.log('tenant', err, tenantCollection);
-                  // Run the operation
-                  tenantCollection.adapter[method](criteria, cb);
-              });
-              return;
-          } else {
-              // Error: No tenant set
-              return cb(new Error('Tenant is required to be specified in operation.'));
-          }
-      }
-  }
+  // Run the operation
+  collection.adapter[method](criteria, cb);
 
 };
 

--- a/test/integration/Collection.multiTenant.js
+++ b/test/integration/Collection.multiTenant.js
@@ -252,9 +252,6 @@ describe('Waterline Collection', function() {
         // database: 'default_database',
         isMultiTenant: true,
         // defaultTenant: false, // false, <string>, or <number>
-        getTenant: function(req, cb) {
-          return cb(req.params.tenant);
-        },
         configForTenant: function(tenantId, config, cb) {
           //   console.log('getTenantConfig', tenantId, config);
           // Validate Tenant

--- a/test/integration/Collection.multiTenant.js
+++ b/test/integration/Collection.multiTenant.js
@@ -100,18 +100,106 @@ describe('Waterline Collection', function() {
 
           });
         },
-        create: function(connectionName, collectionName, options,
+        findOne: function(connectionName, collectionName,
+          criteria,
+          cb) {
+          //   console.log('update criteria', criteria, typeof criteria.where.id);
+          var self = this;
+          // Force to be async
+          process.nextTick(function() {
+            var records = self.getRecords(connectionName,
+              collectionName);
+            var index = -1;
+            if (criteria && criteria.where && criteria.where
+              .id !== null && typeof criteria.where.id ===
+              "number") {
+              index = criteria.where.id;
+            } else {
+              index = records.indexOf(criteria.where)
+            }
+            if (index > -1) {
+              var record = records[index];
+              return cb(null, record);
+            }
+            //   console.log('create1 records', records);
+            return cb(null, null);
+          });
+        },
+        count: function(connectionName, collectionName, options,
           cb) {
           var self = this;
           // Force to be async
           process.nextTick(function() {
             var records = self.getRecords(connectionName,
               collectionName);
-            records.push(options);
+            return cb(null, records.length);
+          });
+        },
+        create: function(connectionName, collectionName, data,
+          cb) {
+          var self = this;
+          // Force to be async
+          process.nextTick(function() {
+            var records = self.getRecords(connectionName,
+              collectionName);
+            records.push(data);
             //   console.log('create1 records', records);
-            return cb(null, options);
+            return cb(null, data);
+          });
+        },
+        destroy: function(connectionName, collectionName,
+          criteria,
+          cb) {
+          //   console.log('destroy criteria', criteria, typeof criteria.where.id);
+          var self = this;
+          // Force to be async
+          process.nextTick(function() {
+            var records = self.getRecords(connectionName,
+              collectionName);
+            var index = -1;
+            if (criteria && criteria.where && criteria.where
+              .id !== null && typeof criteria.where.id ===
+              "number") {
+              index = criteria.where.id;
+            } else {
+              index = records.indexOf(criteria.where)
+            }
+            if (index > -1) {
+              records.splice(index, 1);
+            }
+            //   console.log('create1 records', records);
+            return cb(null, records);
+          });
+        },
+        update: function(connectionName, collectionName,
+          criteria,
+          data,
+          cb) {
+          //   console.log('update criteria', criteria, typeof criteria.where.id);
+          var self = this;
+          // Force to be async
+          process.nextTick(function() {
+            var records = self.getRecords(connectionName,
+              collectionName);
+            var index = -1;
+            if (criteria && criteria.where && criteria.where
+              .id !== null && typeof criteria.where.id ===
+              "number") {
+              index = criteria.where.id;
+            } else {
+              index = records.indexOf(criteria.where)
+            }
+            if (index > -1) {
+              var record = records[index];
+              _.merge(record, data);
+              return cb(null, record);
+            } else {
+              //   console.log('create1 records', records);
+              return cb(null, null);
+            }
           });
         }
+
       };
       return adapter;
     })();
@@ -191,42 +279,231 @@ describe('Waterline Collection', function() {
   describe('with Multitenancy', function() {
 
     it('should have setup correctly', function() {
-      assert(status == 2);
+      assert(status == 2, 'connections have been registered');
     });
 
-    it('should error complaining no specified tenant', function(done) {
+    describe('using Callback-Style API', function() {
 
-      Collection
-        .find({})
-        .exec(function(err, result) {
-          //   console.log('find result', err.details, result);
-          assert(err instanceof Error);
-          //   assert(err.toString(), 'Tenant is required to be specified in operation.', 'tenant is missing as expected');
-          done();
+
+      it('should find records for specified tenant-1', function(
+        done) {
+
+        Collection
+          .tenant("1", function(err, TenantCollection) {
+            // Now you have a Tenant-specific Collection!
+            TenantCollection
+              .find({})
+              .exec(function(err, results) {
+                assert(!err, 'no error');
+                assert(results.length === 1,
+                  'tenant-1 has 1 record');
+                assert(results[0].message === db['tenant-1']
+                  [
+                    'tests'
+                  ][0].message,
+                  'records are from the tenant-1 database'
+                );
+                done();
+              });
+          });
+
+      });
+
+      it('should find records for specified tenant-2', function(
+        done) {
+
+        Collection
+          .tenant("2", function(err, TenantCollection) {
+            // Now you have a Tenant-specific Collection!
+            TenantCollection
+              .find({})
+              .exec(function(err, results) {
+                assert(!err, 'no error');
+                assert(results.length === 1,
+                  'tenant-2 has 1 record');
+                assert(results[0].message === db['tenant-2']
+                  [
+                    'tests'
+                  ][0].message,
+                  'records are from the tenant-2 database'
+                );
+                done();
+              });
+          });
+
+      });
+
+      it('should count records for specified tenant-1', function(
+        done) {
+
+        Collection
+          .tenant("1", function(err, TenantCollection) {
+            // Now you have a Tenant-specific Collection!
+            TenantCollection
+              .count({})
+              .exec(function(err, count) {
+                assert(!err, 'no error');
+                assert(count === 1,
+                  'tenant-1 has 1 record');
+                done();
+              });
+          });
+
+      });
+
+
+      it('should findOne record for specified tenant-1', function(
+        done) {
+
+        Collection
+          .tenant("1", function(err, TenantCollection) {
+            // Now you have a Tenant-specific Collection!
+            TenantCollection
+              .findOne(0)
+              .exec(function(err, result) {
+                assert(!err, 'no error');
+                assert(result,
+                  'tenant-1 has record');
+                assert(result.message === db['tenant-1'][
+                    'tests'
+                  ][0].message,
+                  'record is from the tenant-1 database'
+                );
+                done();
+              });
+          });
+
+      });
+
+
+      it('should destroy record for specified tenant-1', function(
+        done) {
+
+        Collection
+          .tenant("1", function(err, TenantCollection) {
+            // Now you have a Tenant-specific Collection!
+            TenantCollection
+              .destroy(0)
+              .exec(function(err, records) {
+                // console.log(err, records);
+                assert(!err, 'no error');
+                assert(records.length === 0,
+                  'tenant-1 has no records');
+                done();
+              });
+          });
+
+      });
+
+      it('should update record for specified tenant-1', function(
+        done) {
+        var data = {
+          'message': 'it updated 1!'
+        };
+        Collection
+          .tenant("1", function(err, TenantCollection) {
+            // Now you have a Tenant-specific Collection!
+            TenantCollection
+              .update(0, data)
+              .exec(function(err, records) {
+                // console.log(err, records);
+                assert(!err, 'no error');
+                assert(records, 'has records');
+                assert(records.length === 1,
+                  'tenant-1 has 1 record');
+                assert(records[0].message === data.message,
+                  'message was updated!');
+                done();
+              });
+          });
+
+      });
+
+      it(
+        'should create a record for specified tenant-1',
+        function(done) {
+          var tenant = "1";
+          Collection
+            .tenant(tenant, function(err, TenantCollection) {
+              // Now you have a Tenant-specific Collection!
+              var newRecord = {
+                'message': 'new record!'
+              }
+              TenantCollection
+                .create(newRecord)
+                .exec(function(err, result) {
+                  // console.log(err, result);
+                  assert(!err, 'no error');
+                  TenantCollection.find({}, function(err,
+                    results) {
+                    assert(!err, 'no error');
+                    assert(results.length === 2,
+                      'tenant-' +
+                      tenant + ' has 2 records');
+                    assert(results[1].message === db[
+                        'tenant-' +
+                        tenant]['tests'][1].message,
+                      'records are from the tenant-2 database'
+                    );
+                    assert(results[1].message ===
+                      newRecord.message,
+                      'new record has same message');
+                    done();
+                  });
+                });
+            });
+
         });
 
     });
 
-    it('should error complaining no specified tenant', function(done) {
+    describe('using Promise-Style (Fluent Interface) API', function() {
 
-      Collection
-        .tenant(null)
-        .find({})
-        .exec(function(err, result) {
-          //   console.log('find result', err.details, result);
-          assert(err instanceof Error);
-          //   assert(err.toString(), 'Tenant is required to be specified in operation.', 'tenant is missing as expected');
-          done();
-        });
+      it('should error complaining no specified tenant', function(
+        done) {
 
-    });
+        Collection
+          .find({})
+          .exec(function(err, result) {
+            //   console.log('find result', err.details, result);
+            assert(err instanceof Error);
+            //   assert(err.toString(), 'Tenant is required to be specified in operation.', 'tenant is missing as expected');
+            done();
+          });
 
-    it('should find records for specified tenant-1', function(done) {
+      });
 
-      Collection
-        .tenant("1", function(err, TenantCollection) {
-          // Now you have a Tenant-specific Collection!
-          TenantCollection
+      it('should error complaining no specified tenant', function(
+        done) {
+
+        Collection
+          .tenant(null)
+          .find({})
+          .exec(function(err, result) {
+            //   console.log('find result', err.details, result);
+            assert(err instanceof Error);
+            //   assert(err.toString(), 'Tenant is required to be specified in operation.', 'tenant is missing as expected');
+            done();
+          });
+
+      });
+
+      it('should find records for multiple tenant requests',
+        function(
+          done) {
+
+          var pending = 0;
+          var completionCallback = function() {
+            pending--;
+            if (pending === 0) {
+              done();
+            }
+          }
+          pending = 2;
+
+          // 1
+          Collection
+            .tenant(1)
             .find({})
             .exec(function(err, results) {
               assert(!err, 'no error');
@@ -236,18 +513,12 @@ describe('Waterline Collection', function() {
                   'tests'
                 ][0].message,
                 'records are from the tenant-1 database');
-              done();
+              completionCallback();
             });
-        });
 
-    });
-
-    it('should find records for specified tenant-2', function(done) {
-
-      Collection
-        .tenant("2", function(err, TenantCollection) {
-          // Now you have a Tenant-specific Collection!
-          TenantCollection
+          // 2
+          Collection
+            .tenant("2")
             .find({})
             .exec(function(err, results) {
               assert(!err, 'no error');
@@ -255,197 +526,137 @@ describe('Waterline Collection', function() {
                 'tenant-2 has 1 record');
               assert(results[0].message === db['tenant-2'][
                   'tests'
-                ][0].message,
+                ][0]
+                .message,
                 'records are from the tenant-2 database');
-              done();
+              completionCallback();
             });
+
+
         });
 
-    });
 
-    it(
-      'should create a record using callback-style API for specified tenant-1',
-      function(done) {
-        var tenant = "1";
+      it('should error from improper usage', function(done) {
+
+        // Setup test
+        var pending = 0;
+        var completionCallback = function() {
+          pending--;
+          if (pending === 0) {
+            done();
+          }
+        }
+        pending = 2;
+
+        // Create promise and do not execute it immediately
+        // This can be okay, however you should *always*
+        // be sure to `exec` the deferred function before
+        // calling an async function and giving the opportunity
+        // for other code to execute before this resolves
+        // the proper TenantCollection.
+        var promise1 = Collection
+          .tenant("1")
+          .find({});
+
+        // BAD: Async call
+        // Give control back to Node.js and allow it to run other code first,
+        // before this `exec` is called
+        process.nextTick(function() {
+          // This is executed after Tenant="2" code was executed
+          promise1.exec(function(err, results) {
+            // This executed after the code below
+            // So this Collection is now a TenantCollection for Tenant="2"
+            //   console.log(err, results);
+            assert(err instanceof Error);
+            //   assert(!err, 'no error');
+            //   assert(results.length === 1,
+            //     'tenant-1 has 1 record');
+            //   assert(results[0].message === db['tenant-1'][
+            //       'tests'
+            //     ][0].message,
+            //     'records are from the tenant-1 database');
+            completionCallback();
+          });
+        });
+
+        // Proper usage
         Collection
-          .tenant(tenant, function(err, TenantCollection) {
-            // Now you have a Tenant-specific Collection!
-            var newRecord = {
-              'message': 'new record!'
-            }
-            TenantCollection
-              .create(newRecord)
-              .exec(function(err, result) {
-                // console.log(err, result);
-                assert(!err, 'no error');
-                TenantCollection.find({}, function(err, results) {
-                  assert(!err, 'no error');
-                  assert(results.length === 2, 'tenant-' +
-                    tenant + ' has 2 records');
-                  assert(results[1].message === db['tenant-' +
-                      tenant]['tests'][1].message,
-                    'records are from the tenant-2 database'
-                  );
-                  assert(results[1].message === newRecord.message,
-                    'new record has same message');
-                  done();
-                });
-              });
+          .tenant("2")
+          .find({})
+          .exec(function(err, results) {
+            // Tenant is 2
+            // Same as callback-style, the Colllection is now a `TenantCollection` and will remain correctly scoped to the tenant
+            //   console.log(err, results);
+            assert(!err, 'no error');
+            assert(results.length === 1,
+              'tenant-2 has 1 record');
+            assert(results[0].message === db['tenant-2'][
+                'tests'
+              ][0]
+              .message,
+              'records are from the tenant-2 database');
+            completionCallback();
           });
 
       });
 
-    // it(
-    //   'should create a record using promise-style API for specified tenant-1',
-    //   function(done) {
-    //     var tenant = "1";
-    //     var newRecord = {
-    //       'message': 'new record!'
-    //     }
-    //     Collection
-    //       .tenant(tenant)
-    //       .create(newRecord)
-    //       .exec(function(err, result) {
-    //         console.log(err, result);
-    //         assert(!err, 'no error');
-    //
-    //         Collection
-    //           .tenant(tenant)
-    //           .find({}, function(err, results) {
-    //             assert(!err, 'no error');
-    //             assert(results.length === 2, 'tenant-' +
-    //               tenant + ' has 2 records');
-    //             assert(results[1].message === result.message,
-    //               'message of record[1] is same as result from created record'
-    //             );
-    //             assert(results[1].message === db['tenant-' +
-    //                 tenant]['tests'][1].message,
-    //               'records are from the tenant-2 database'
-    //             );
-    //             assert(results[1].message === newRecord.message,
-    //               'new record has same message');
-    //             done();
-    //           });
-    //       });
-    //
-    //   });
+      // it(
+      //   'should create a record for specified tenant-1',
+      //   function(done) {
+      //     var tenant = "1";
+      //     var newRecord = {
+      //       'message': 'new record!'
+      //     }
+      //     Collection
+      //       .tenant(tenant)
+      //       .create(newRecord)
+      //       .exec(function(err, result) {
+      //         console.log(err, result);
+      //         assert(!err, 'no error');
+      //
+      //         Collection
+      //           .tenant(tenant)
+      //           .find({}, function(err, results) {
+      //             assert(!err, 'no error');
+      //             assert(results.length === 2, 'tenant-' +
+      //               tenant + ' has 2 records');
+      //             assert(results[1].message === result.message,
+      //               'message of record[1] is same as result from created record'
+      //             );
+      //             assert(results[1].message === db['tenant-' +
+      //                 tenant]['tests'][1].message,
+      //               'records are from the tenant-2 database'
+      //             );
+      //             assert(results[1].message === newRecord.message,
+      //               'new record has same message');
+      //             done();
+      //           });
+      //       });
+      //
+      //   });
 
-    it('should find records for specified tenant', function(done) {
+      it('should find records for specified tenant', function(done) {
 
-      Collection
-        .tenant("2")
-        .find({})
-        .exec(function(err, results) {
-          assert(!err, 'no error');
-          assert(results.length === 1, 'tenant-2 has 1 record');
-          assert(results[0].message === db['tenant-2']['tests'][0]
-            .message, 'records are from the tenant-2 database');
-          done();
-        });
+        Collection
+          .tenant("2")
+          .find({})
+          .exec(function(err, results) {
+            assert(!err, 'no error');
+            assert(results.length === 1,
+              'tenant-2 has 1 record');
+            assert(results[0].message === db['tenant-2'][
+                'tests'
+              ][0]
+              .message,
+              'records are from the tenant-2 database');
+            done();
+          });
 
-    });
-
-    it('should find records for multiple tenant requests', function(
-      done) {
-
-      var pending = 0;
-      var completionCallback = function() {
-        pending--;
-        if (pending === 0) {
-          done();
-        }
-      }
-      pending = 2;
-
-      // 1
-      Collection
-        .tenant(1)
-        .find({})
-        .exec(function(err, results) {
-          assert(!err, 'no error');
-          assert(results.length === 1,
-            'tenant-1 has 1 record');
-          assert(results[0].message === db['tenant-1'][
-              'tests'
-            ][0].message,
-            'records are from the tenant-1 database');
-          completionCallback();
-        });
-
-      // 2
-      Collection
-        .tenant("2")
-        .find({})
-        .exec(function(err, results) {
-          assert(!err, 'no error');
-          assert(results.length === 1, 'tenant-2 has 1 record');
-          assert(results[0].message === db['tenant-2']['tests'][0]
-            .message, 'records are from the tenant-2 database');
-          completionCallback();
-        });
-
-
-    });
-
-    it('should error from improper usage', function(done) {
-
-      // Setup test
-      var pending = 0;
-      var completionCallback = function() {
-        pending--;
-        if (pending === 0) {
-          done();
-        }
-      }
-      pending = 2;
-
-      // Create promise and do not execute it immediately
-      // This can be okay, however you should *always*
-      // be sure to `exec` the deferred function before
-      // calling an async function and giving the opportunity
-      // for other code to execute before this resolves
-      // the proper TenantCollection.
-      var promise1 = Collection
-        .tenant("1")
-        .find({});
-
-      // BAD: Async call
-      // Give control back to Node.js and allow it to run other code first,
-      // before this `exec` is called
-      process.nextTick(function() {
-        // This is executed after Tenant="2" code was executed
-        promise1.exec(function(err, results) {
-          // This executed after the code below
-          // So this Collection is now a TenantCollection for Tenant="2"
-          //   console.log(err, results);
-          assert(err instanceof Error);
-          //   assert(!err, 'no error');
-          //   assert(results.length === 1,
-          //     'tenant-1 has 1 record');
-          //   assert(results[0].message === db['tenant-1'][
-          //       'tests'
-          //     ][0].message,
-          //     'records are from the tenant-1 database');
-          completionCallback();
-        });
       });
 
-      // Proper usage
-      Collection
-        .tenant("2")
-        .find({})
-        .exec(function(err, results) {
-          // Tenant is 2
-          // Same as callback-style, the Colllection is now a `TenantCollection` and will remain correctly scoped to the tenant
-          //   console.log(err, results);
-          assert(!err, 'no error');
-          assert(results.length === 1, 'tenant-2 has 1 record');
-          assert(results[0].message === db['tenant-2']['tests'][0]
-            .message, 'records are from the tenant-2 database');
-          completionCallback();
-        });
 
-    });
+
+    }); // End Promise-Styl Tests
 
   });
 });

--- a/test/integration/Collection.multiTenant.js
+++ b/test/integration/Collection.multiTenant.js
@@ -1,0 +1,215 @@
+var Waterline = require('../../lib/waterline'),
+  assert = require('assert');
+  var _ = require('lodash');
+
+describe('Waterline Collection', function() {
+  var Collection, status = 0;
+
+  var db = {
+      'tenant-1': {
+          'tests': [{'message':'it worked1!'}]
+      },
+      'tenant-2': {
+          'tests': [{'message':'it worked1!'}]
+      }
+  }
+
+  before(function(done) {
+
+    var adapter_1 = (function() {
+        var connections = {};
+
+        var adapter = {
+          identity: 'foo',
+          registerConnection: function(connection, collections, cb) {
+            // console.log('registerConnection1', connection, connections);
+
+            // Validate arguments
+            if(!connection.identity) return cb(new Error("Missing identity"));
+            if(connections[connection.identity]) return cb(new Error("Duplicate Identity "+connection.identity));
+
+            // Always ensure the schema key is set to something. This should be remapped in the
+            // .describe() method later on.
+            Object.keys(collections).forEach(function(coll) {
+                collections[coll].schema = collections[coll].definition;
+            });
+
+            // Store the connection
+            connections[connection.identity] = {
+                config: connection,
+                collections: collections,
+                connection: {}
+            };
+
+            status++;
+            cb();
+          },
+          find: function(connectionName, collectionName, options, cb) {
+            //   console.log('Find1', connectionName, collectionName, options, this);
+            //   console.log(connections);
+              var connectionObject = connections[connectionName];
+              var collection = connectionObject.collections[collectionName];
+              var config = connectionObject.config;
+            //   console.log('find1 connection', connectionObject);
+            //   console.log('find1 config', config);
+            //   console.log('find1 collection', collection);
+            //   console.log('find1 collection.tableName', collection.tableName);
+              var records = db[config.database][collection.tableName];
+            //   console.log('find1 records', records);
+              return cb(null, records);
+          }
+      };
+      return adapter;
+    })();
+
+    var adapter_2 = {
+      identity: 'bar',
+      registerConnection: function(connection, collections, cb) {
+        //   console.log('registerConnection2', connection, collections);
+          status++;
+          cb();
+      },
+      find: function(connectionName, collectionName, options, cb) {
+        //   console.log('Find2', connectionName, collectionName, options, this);
+          var connectionObject = connections[connectionName];
+          var collection = connectionObject.collections[collectionName];
+        //   console.log('find2 connection', connection);
+          return cb(null, [options]);
+      }
+    };
+
+    var Model = Waterline.Collection.extend({
+      attributes: {
+          message: 'string'
+      },
+      connection: ['my_foo'],
+      tableName: 'tests'
+    });
+
+    var waterline = new Waterline();
+    waterline.loadCollection(Model);
+
+    var connections = {
+      'my_foo': {
+        adapter: 'foo',
+        host: 'localhost',
+        port: 12345,
+        database: 'default_database',
+        isMultiTenant: true,
+        defaultTenant: false, // false, <string>, or <number>
+        getTenant: function(req, cb) {
+          return cb(req.params.tenant);
+        },
+        configForTenant: function(tenantId, config, cb) {
+        //   console.log('getTenantConfig', tenantId, config);
+          // Validate Tenant
+          tenantId = parseInt(tenantId);
+          if (tenantId >= 1 && tenantId < 10) {
+            config.database = "tenant-" + tenantId;
+            return cb(null, config);
+          } else {
+            return cb(new Error("Invalid tenant " + tenantId + "!"));
+          }
+        }
+      }
+      ,'my_bar': {
+        adapter: 'bar',
+        database: 'default_database',
+        isMultiTenant: false // Optional: default is falsy
+      }
+    };
+
+    waterline.initialize({
+      adapters: {
+        'foo': adapter_1,
+        'bar': adapter_2
+      },
+      connections: connections
+    }, function(err, colls) {
+      if (err) return done(err);
+      Collection = colls.collections.tests;
+      done();
+    });
+
+  });
+
+  describe('with Multitenancy', function() {
+
+    it('should have setup correctly', function() {
+      assert(status == 2);
+    });
+
+    // it('should error complaining no specified tenant', function(done) {
+    //
+    //   Collection
+    //   .find({})
+    //   .exec(function(err, result) {
+    //     //   console.log('find result', err.details, result);
+    //       assert(err instanceof Error);
+    //     //   assert(err.toString(), 'Tenant is required to be specified in operation.', 'tenant is missing as expected');
+    //       done();
+    //   });
+    //
+    // });
+
+    it('should find records for specified tenant-1', function(done) {
+
+      Collection
+        .tenant("1", function(err, TenantCollection) {
+          // Now you have a Tenant-specific Collection!
+          TenantCollection
+            .find({})
+            .exec(function(err, results) {
+              assert(results.length === 1, 'tenant-1 has 1 record');
+              assert(results[0].message === db['tenant-1']['tests'][0].message, 'records are from the tenant-1 database');
+              done();
+            });
+        });
+
+    });
+
+    it('should find records for specified tenant-2', function(done) {
+
+        Collection
+        .tenant("2", function(err, TenantCollection) {
+            // Now you have a Tenant-specific Collection!
+            TenantCollection
+            .find({})
+            .exec(function(err, results) {
+                assert(results.length === 1, 'tenant-2 has 1 record');
+                assert(results[0].message === db['tenant-2']['tests'][0].message, 'records are from the tenant-2 database');
+                done();
+            });
+        });
+
+    });
+
+    // it('should create a record for specified tenant-1', function(done) {
+    //     var tenant = "1";
+    //     Collection
+    //     .tenant(tenant, function(err, TenantCollection) {
+    //         // Now you have a Tenant-specific Collection!
+    //         TenantCollection
+    //         .create({})
+    //         .exec(function(err, results) {
+    //             assert(results.length === 1, 'tenant-'+tenant+' has 1 record');
+    //             assert(results[0].message === db['tenant-'+tenant]['tests'][0].message, 'records are from the tenant-2 database');
+    //             done();
+    //         });
+    //     });
+    //
+    // });
+
+    // it('should find records for specified tenant', function(done) {
+    //
+    //   Collection
+    //     .tenant("1")
+    //     .find({})
+    //     .exec(function(err, result) {
+    //       console.log(err, result);
+    //       done();
+    //     });
+    // });
+
+  });
+});

--- a/test/integration/Collection.multiTenant.js
+++ b/test/integration/Collection.multiTenant.js
@@ -68,108 +68,118 @@ describe('Waterline Collection', function() {
           status++;
           cb();
         },
-        getRecords: function(connectionName, collectionName) {
-          //   console.log('Find1', connectionName, collectionName, options, this);
-          //   console.log(connections);
-          var connectionObject = connections[
-            connectionName];
-          var collection = connectionObject.collections[
-            collectionName];
-          var config = connectionObject.config;
-          //   console.log('find1 connection', connectionObject);
-          //   console.log('find1 config', config);
-          //   console.log('find1 collection', collection);
-          //   console.log('find1 collection.tableName', collection.tableName);
-          db[config.database] = db[config.database] || []
-          var c = db[config.database];
-          //   console.log('col', c);
-          c[collection.tableName] = c[collection.tableName] || [];
-          var records = c[collection.tableName];
-          return records;
-        },
-        find: function(connectionName, collectionName, options,
-          cb) {
-          var self = this;
-
+        getRecords: function(connectionName, collectionName, cb) {
           // Force to be async
           process.nextTick(function() {
-            var records = self.getRecords(connectionName,
-              collectionName);
-            //   console.log('find1 records', records);
-            return cb(null, records);
 
+            //   console.log('Find1', connectionName, collectionName, options, this);
+            //   console.log(connections);
+            var connectionObject = connections[
+              connectionName];
+            var collection = connectionObject.collections[
+              collectionName];
+            var config = connectionObject.config;
+            //   console.log('find1 connection', connectionObject);
+            //   console.log('find1 config', config);
+            //   console.log('find1 collection', collection);
+            //   console.log('find1 collection.tableName', collection.tableName);
+            if (!config.database) {
+              return cb(new Error("No database configured."));
+            }
+            db[config.database] = db[config.database] || {};
+            var c = db[config.database];
+            //   console.log('col', c);
+            c[collection.tableName] = c[collection.tableName] || [];
+            var records = c[collection.tableName];
+            return cb(null, records);
           });
+        },
+        find: function(connectionName, collectionName,
+          options,
+          cb) {
+          var self = this;
+          self.getRecords(connectionName,
+            collectionName,
+            function(err, records) {
+              //   console.log('find1 records', records);
+              return cb(err, records);
+            });
         },
         findOne: function(connectionName, collectionName,
           criteria,
           cb) {
           //   console.log('update criteria', criteria, typeof criteria.where.id);
           var self = this;
-          // Force to be async
-          process.nextTick(function() {
-            var records = self.getRecords(connectionName,
-              collectionName);
-            var index = -1;
-            if (criteria && criteria.where && criteria.where
-              .id !== null && typeof criteria.where.id ===
-              "number") {
-              index = criteria.where.id;
-            } else {
-              index = records.indexOf(criteria.where)
-            }
-            if (index > -1) {
-              var record = records[index];
-              return cb(null, record);
-            }
-            //   console.log('create1 records', records);
-            return cb(null, null);
-          });
+          self.getRecords(connectionName,
+            collectionName,
+            function(err, records) {
+              if (err) {
+                return cb(err);
+              }
+              var index = -1;
+              if (criteria && criteria.where && criteria.where
+                .id !== null && typeof criteria.where.id ===
+                "number") {
+                index = criteria.where.id;
+              } else {
+                index = records.indexOf(criteria.where)
+              }
+              if (index > -1) {
+                var record = records[index];
+                return cb(null, record);
+              }
+              //   console.log('create1 records', records);
+              return cb(null, null);
+            });
         },
         count: function(connectionName, collectionName, options,
           cb) {
           var self = this;
-          // Force to be async
-          process.nextTick(function() {
-            var records = self.getRecords(connectionName,
-              collectionName);
-            return cb(null, records.length);
-          });
+          self.getRecords(connectionName,
+            collectionName,
+            function(err, records) {
+              return cb(err, records.length);
+            });
         },
         create: function(connectionName, collectionName, data,
           cb) {
           var self = this;
-          // Force to be async
-          process.nextTick(function() {
-            var records = self.getRecords(connectionName,
-              collectionName);
-            records.push(data);
-            //   console.log('create1 records', records);
-            return cb(null, data);
-          });
+          self.getRecords(connectionName,
+            collectionName,
+            function(err, records) {
+              if (err) {
+                return cb(err);
+              }
+              records.push(data);
+              // console.log('create1 records', records);
+              return cb(null, data);
+            });
         },
         destroy: function(connectionName, collectionName,
           criteria,
           cb) {
           //   console.log('destroy criteria', criteria, typeof criteria.where.id);
           var self = this;
-          // Force to be async
-          process.nextTick(function() {
-            var records = self.getRecords(connectionName,
-              collectionName);
-            var index = -1;
-            if (criteria && criteria.where && criteria.where
-              .id !== null && typeof criteria.where.id ===
-              "number") {
-              index = criteria.where.id;
-            } else {
-              index = records.indexOf(criteria.where)
-            }
-            if (index > -1) {
-              records.splice(index, 1);
-            }
-            //   console.log('create1 records', records);
-            return cb(null, records);
-          });
+          self.getRecords(connectionName,
+            collectionName,
+            function(err, records) {
+              if (err) {
+                return cb(err);
+              }
+              var index = -1;
+              if (criteria && criteria.where && criteria.where
+                .id !== null && typeof criteria.where.id ===
+                "number") {
+                index = criteria.where.id;
+              } else {
+                index = records.indexOf(criteria.where)
+              }
+              if (index > -1) {
+                records.splice(index, 1);
+              }
+              //   console.log('create1 records', records);
+              return cb(null, records);
+            });
         },
         update: function(connectionName, collectionName,
           criteria,
@@ -177,27 +187,29 @@ describe('Waterline Collection', function() {
           cb) {
           //   console.log('update criteria', criteria, typeof criteria.where.id);
           var self = this;
-          // Force to be async
-          process.nextTick(function() {
-            var records = self.getRecords(connectionName,
-              collectionName);
-            var index = -1;
-            if (criteria && criteria.where && criteria.where
-              .id !== null && typeof criteria.where.id ===
-              "number") {
-              index = criteria.where.id;
-            } else {
-              index = records.indexOf(criteria.where)
-            }
-            if (index > -1) {
-              var record = records[index];
-              _.merge(record, data);
-              return cb(null, record);
-            } else {
-              //   console.log('create1 records', records);
-              return cb(null, null);
-            }
-          });
+          self.getRecords(connectionName,
+            collectionName,
+            function(err, records) {
+              if (err) {
+                return cb(err);
+              }
+              var index = -1;
+              if (criteria && criteria.where && criteria.where
+                .id !== null && typeof criteria.where.id ===
+                "number") {
+                index = criteria.where.id;
+              } else {
+                index = records.indexOf(criteria.where)
+              }
+              if (index > -1) {
+                var record = records[index];
+                _.merge(record, data);
+                return cb(null, record);
+              } else {
+                //   console.log('create1 records', records);
+                return cb(null, null);
+              }
+            });
         }
 
       };
@@ -351,7 +363,6 @@ describe('Waterline Collection', function() {
 
       });
 
-
       it('should findOne record for specified tenant-1', function(
         done) {
 
@@ -488,6 +499,139 @@ describe('Waterline Collection', function() {
 
       });
 
+
+      it('should find records for specified tenant', function(done) {
+
+        Collection
+          .tenant("2")
+          .find({})
+          .exec(function(err, results) {
+            assert(!err, 'no error');
+            assert(results.length === 1,
+              'tenant-2 has 1 record');
+            assert(results[0].message === db['tenant-2'][
+                'tests'
+              ][0]
+              .message,
+              'records are from the tenant-2 database');
+            done();
+          });
+
+      });
+
+      it('should findOne record for specified tenant-1', function(
+        done) {
+
+        Collection
+          .tenant("1")
+          .findOne(0)
+          .exec(function(err, result) {
+            assert(!err, 'no error');
+            assert(result,
+              'tenant-1 has record');
+            assert(result.message === db['tenant-1'][
+                'tests'
+              ][0].message,
+              'record is from the tenant-1 database'
+            );
+            done();
+          });
+
+      });
+
+
+      it('should count records for specified tenant-1', function(
+        done) {
+
+        Collection
+          .tenant("1")
+          .count({})
+          .exec(function(err, count) {
+            assert(!err, 'no error');
+            assert(count === 1,
+              'tenant-1 has 1 record');
+            done();
+          });
+
+      });
+
+
+      it('should destroy record for specified tenant-1', function(
+        done) {
+
+        Collection
+          .tenant("1")
+          .destroy(0)
+          .exec(function(err, records) {
+            // console.log(err, records);
+            assert(!err, 'no error');
+            assert(records.length === 0,
+              'tenant-1 has no records');
+            done();
+          });
+
+      });
+
+      it('should update record for specified tenant-1', function(
+        done) {
+        var data = {
+          'message': 'it updated 1!'
+        };
+        Collection
+          .tenant("1")
+          .update(0, data)
+          .exec(function(err, records) {
+            // console.log(err, records);
+            assert(!err, 'no error');
+            assert(records, 'has records');
+            assert(records.length === 1,
+              'tenant-1 has 1 record');
+            assert(records[0].message === data.message,
+              'message was updated!');
+            done();
+          });
+
+      });
+
+
+      it(
+        'should create a record for specified tenant-1',
+        function(done) {
+          var tenant = "1";
+          var newRecord = {
+            'message': 'new record!'
+          }
+          Collection
+            .tenant(tenant)
+            .create(newRecord)
+            .exec(function(err, result) {
+            //   console.log(err, result);
+              assert(!err, 'no error');
+            //   console.log(JSON.stringify(db));
+              Collection
+                .tenant(tenant)
+                .find({}, function(err, results) {
+                //   console.log(err, results);
+                  assert(!err, 'no error');
+                  assert(results.length === 2, 'tenant-' +
+                    tenant + ' has 2 records');
+                  assert(results[1].message === result.message,
+                    'message of record[1] is same as result from created record'
+                  );
+                  assert(results[1].message === db['tenant-' +
+                      tenant]['tests'][1].message,
+                    'records are from the tenant-2 database'
+                  );
+                  assert(results[1].message === newRecord.message,
+                    'new record has same message');
+                  done();
+                });
+            });
+
+        });
+
+
+
       it('should find records for multiple tenant requests',
         function(
           done) {
@@ -534,6 +678,7 @@ describe('Waterline Collection', function() {
 
 
         });
+
 
 
       it('should error from improper usage', function(done) {
@@ -600,63 +745,8 @@ describe('Waterline Collection', function() {
 
       });
 
-      // it(
-      //   'should create a record for specified tenant-1',
-      //   function(done) {
-      //     var tenant = "1";
-      //     var newRecord = {
-      //       'message': 'new record!'
-      //     }
-      //     Collection
-      //       .tenant(tenant)
-      //       .create(newRecord)
-      //       .exec(function(err, result) {
-      //         console.log(err, result);
-      //         assert(!err, 'no error');
-      //
-      //         Collection
-      //           .tenant(tenant)
-      //           .find({}, function(err, results) {
-      //             assert(!err, 'no error');
-      //             assert(results.length === 2, 'tenant-' +
-      //               tenant + ' has 2 records');
-      //             assert(results[1].message === result.message,
-      //               'message of record[1] is same as result from created record'
-      //             );
-      //             assert(results[1].message === db['tenant-' +
-      //                 tenant]['tests'][1].message,
-      //               'records are from the tenant-2 database'
-      //             );
-      //             assert(results[1].message === newRecord.message,
-      //               'new record has same message');
-      //             done();
-      //           });
-      //       });
-      //
-      //   });
 
-      it('should find records for specified tenant', function(done) {
-
-        Collection
-          .tenant("2")
-          .find({})
-          .exec(function(err, results) {
-            assert(!err, 'no error');
-            assert(results.length === 1,
-              'tenant-2 has 1 record');
-            assert(results[0].message === db['tenant-2'][
-                'tests'
-              ][0]
-              .message,
-              'records are from the tenant-2 database');
-            done();
-          });
-
-      });
-
-
-
-    }); // End Promise-Styl Tests
+    }); // End Promise-Style Tests
 
   });
 });

--- a/test/integration/Collection.multiTenant.js
+++ b/test/integration/Collection.multiTenant.js
@@ -342,6 +342,17 @@ describe('Waterline Collection', function() {
 
       });
 
+      it(
+        'should error trying to find records for specified invalid tenant-100',
+        function(
+          done) {
+          Collection
+            .tenant("100", function(err, TenantCollection) {
+              assert(err instanceof Error);
+              done();
+            });
+        });
+
       it('should count records for specified tenant-1', function(
         done) {
 
@@ -496,6 +507,17 @@ describe('Waterline Collection', function() {
 
       });
 
+      it(
+        'should error trying to find records for specified invalid tenant-100',
+        function(
+          done) {
+          Collection
+            .tenant("100")
+            .find(function(err, TenantCollection) {
+              assert(err instanceof Error);
+              done();
+            });
+        });
 
       it('should find records for specified tenant', function(done) {
 
@@ -602,13 +624,13 @@ describe('Waterline Collection', function() {
             .tenant(tenant)
             .create(newRecord)
             .exec(function(err, result) {
-            //   console.log(err, result);
+              //   console.log(err, result);
               assert(!err, 'no error');
-            //   console.log(JSON.stringify(db));
+              //   console.log(JSON.stringify(db));
               Collection
                 .tenant(tenant)
                 .find({}, function(err, results) {
-                //   console.log(err, results);
+                  //   console.log(err, results);
                   assert(!err, 'no error');
                   assert(results.length === 2, 'tenant-' +
                     tenant + ' has 2 records');


### PR DESCRIPTION
## About

Support [Multitenancy](http://en.wikipedia.org/wiki/Multitenancy) by using *dynamically* loaded Tenant-specific collections and their corresponding connections.

### Example App with Multitenancy

See https://github.com/Glavin001/sails-multitenancy-example

### How It Works

The call to `Collection.tenant` will return a tenant-specific collection. This collection has a scoped `identity` for each `tenant` and the tenant name could be a number of string.
For instance, Collection with identity `test` would becoming `test<tenant:1>` for `Test.tenant(1)`.

The Tenant-specific Collection also has it's own Tenant-specific Connection with an analogous naming convention: `connectionName<tenant:tenantId>`.

These new Tenant-specific collections and connections are loaded dynamically, on-demand, at runtime. This means that you:
1) do not require waiting to load all `X` number of connections for all of your tenants, and
2) do not even have to know at server startup what tenants are available. They could even be loaded from a database upon request, without reloading your server!
 
### Related Issues

See #286 and https://github.com/balderdashy/sails-mongo/issues/130 and https://github.com/balderdashy/sails/issues/1857

## Usage

### Configure Connection

```javascript
      'my_foo': {
        adapter: 'foo',
        host: 'localhost',
        port: 12345,
        database: 'default_database',

        // === New ===
        isMultiTenant: true, // Enable Multi-Tenancy feature
        defaultTenant: false, // false, <string>, or <number>
        getTenant: function(req, cb) { // For Sailsjs
          return cb(req.params.tenant);
        },
        configForTenant: function(tenantId, config, cb) { // For Waterline
          // Validate Tenant
          tenantId = parseInt(tenantId);
          if (tenantId >= 1 && tenantId < 10) {
            config.database = "tenant-" + tenantId;
            return cb(null, config);
          } else {
            // 
            return cb(new Error("Invalid tenant " + tenantId + "!"));
          }
        }

      }
```

### `.tenant` API

#### Currently Supported

- [x] Callback-style

```javascript
      Collection
        .tenant("1", function(err, TenantCollection) {
          // Now you have a Tenant-specific Collection!
          TenantCollection
            .find({})
            .exec(function(err, results) {
              assert(results.length === 1, 'tenant-1 has 1 record');
              assert(results[0].message === db['tenant-1']['tests'][0].message, 'records are from the tenant-1 database');
              done();
            });
        });
```

- Promise-style, using
  - [x] Operations
    - Used by `find`ers
  - [x] Deferred
    - Used by `count`, `create`, `destroy`, `update`

```javascript
      Collection
        .tenant("1")
        .find({})
        .exec(function(err, result) {
          console.log(err, result);
          done();
        });
```


## Tests: 
See https://github.com/Glavin001/waterline/blob/multi-tenant/lib/waterline/query/dql/tenant.js

- [x] Callback-style API
  - [x] find
  - [x] findOne
  - [x] count
  - [x] create
  - [x] destroy
  - [x] update
- [x] Promise-style API (`Operation`/`Deferred`)
  - [x] find
  - [x] findOne
  - [x] count
  - [x] create
  - [x] destroy
  - [x] update
 
### TODO:

- [x] Use existing Tenant connection, if previously loaded
- [x] Use existing Tenant Collection, if previously loaded
- [x] Remove debugging `console.log`
- Add support for Promise-style API (see above)
- Add support to Sailsjs Blueprints for using this Multi-Tenancy feature
  - Sailsjs would use the `.getTenant(req, callback)` as defined in the configuration
- [x] Improve documentation
- [ ] Joins/associations across multiple multi-tenant Collections
  - Apply the same tenant to both, if either have multi-tenant enabled
- [ ] Allow for the `Adapter` to change between Tenants
  - See https://github.com/Glavin001/waterline/blob/multi-tenant/lib/waterline/connections/index.js#L67 and https://github.com/Glavin001/waterline/blob/multi-tenant/lib/waterline/query/dql/tenant.js#L182