### PR TITLE
The 'node-switchback' NPM module is now simply 'switchback'.

### DIFF
--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var util = require('./helpers');
 var hop = util.object.hasOwnProperty;
-var switchback = require('node-switchback');
+var switchback = require('switchback');
 var errorify = require('../error');
 var WLUsageError = require('../error/WLUsageError');
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bluebird": "~2.3.4",
     "deep-diff": "~0.3.0",
     "lodash": "~2.4.1",
-    "node-switchback": "~0.1.0",
+    "switchback": "~1.1.0",
     "prompt": "~0.2.12",
     "waterline-criteria": "~0.11.0",
     "waterline-schema": "~0.1.17"


### PR DESCRIPTION
On console there are:
```
npm WARN deprecated node-switchback@0.1.2: The 'node-switchback' NPM module is now simply 'switchback'.
```
And then I fixed that.
