### PR TITLE
Update: query/aggregate.js

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -65,7 +65,7 @@ module.exports = {
       });
     }
 
-    async.each(valuesList, create, function(err) {
+    async.eachSeries(valuesList, create, function(err) {
       if(err) return cb(err);
       cb(null, records);
     });


### PR DESCRIPTION
createEach method: changing async.each to async.eachSeries. 

This allows to insert records in the same order as we expect. Also a lot of integraion tests from https://github.com/balderdashy/waterline-adapter-tests expect this behaviour.