### PR TITLE
update helper.js due to many-to-many associations fails on update

### DIFF
--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -276,7 +276,8 @@ Add.prototype.createManyToMany = function(collection, attribute, pk, cb) {
 
   // Grab the associated collection's primaryKey
   var collectionAttributes = this.collection.waterline.schema[attribute.collection.toLowerCase()];
-  var associationKey = collectionAttributes.attributes[attribute.on].via;
+  var associationKey = collectionAttributes.attributes[attribute.on];
+  associationKey = associationKey ? associationKey.via : this.findAssociationKey(collectionAttributes);
 
   if(!associationKey) return cb(new Error('No Primary Key set on the child record you ' +
     'are trying to associate the record with! Try setting an attribute as a primary key or ' +

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sails",
     "sails.js"
   ],
-  "repository": "git://github.com/balderdashy/waterline.git",
+  "repository": "git://github.com/restricted/waterline.git",
   "main": "./lib/waterline",
   "scripts": {
     "test": "mocha test --recursive",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sails",
     "sails.js"
   ],
-  "repository": "git://github.com/restricted/waterline.git",
+  "repository": "git://github.com/balderdashy/waterline.git",
   "main": "./lib/waterline",
   "scripts": {
     "test": "mocha test --recursive",


### PR DESCRIPTION
When to be updated object contains many-to-many associations and its empty array then waterline helper fails with:
return hop.call(obj, prop);
TypeError: Cannot convert null to object at hasOwnProperty (native)