### PR TITLE
Fixes #812, moving destroy of related objects only if matching conditions

### DIFF
--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -93,9 +93,11 @@ module.exports = function(criteria, cb) {
 
         if(mappedValues.length > 0) {
           criteria[refKey] = mappedValues;
+          collection.destroy(criteria).exec(next);
+        } else {
+          return next();
         }
 
-        collection.destroy(criteria).exec(next);
       }
 
       async.each(relations, destroyJoinTableRecords, function(err) {


### PR DESCRIPTION
I'm not sure if it covers all cases, but this fixes the issue about deleting related objects when removing a model with an invalid condition