### PR TITLE
Remove toJSON function from objects being returned from toJSON, to preve...

### DIFF
--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -107,21 +107,22 @@ module.exports = function(context, mixins) {
   // If any of the attributes are protected, the default toJSON method should
   // remove them.
   var protectedAttributes = _.compact(_.map(context._attributes, function(attr, key) {return attr.protected ? key : undefined;}));
-  if (protectedAttributes.length) {
-    prototypeFns.toJSON = function() {
-      var obj = this.toObject();
+
+  prototypeFns.toJSON = function() {
+    var obj = this.toObject();
+
+    if (protectedAttributes.length) {
       _.each(protectedAttributes, function(key) {
         delete obj[key];
       });
-      return obj;
-    };
-  }
-  // Otherwise just return the raw object
-  else {
-    prototypeFns.toJSON = function() {
-      return this.toObject();
-    };
-  }
+    }
+
+    // Remove toJSON from the result, to prevent infinite recursion with
+    // msgpack or other recursive object transformation tools.
+    obj.toJSON = null;
+
+    return obj;
+  };
 
   var prototype = _.extend(prototypeFns, mixins);
 


### PR DESCRIPTION
...nt infinite recursion with msgpack or other recursive object transformation tools

Trying to serialize a model with something like msgpack.encode will kill the application with infinite recursion because it will do something like:

```js
function encode(data) {
  ...

  if ('function' === typeof data.toJSON) {
    encode(data.toJSON());
  }
}
```

but waterline models' default toJSON function returns an object which also has a toJSON function. This PR removes the toJSON method from objects returned from toJSON (and refactors the default toJSON function to DRY it up a bit).