### PR TITLE
Disallow destroy to wipe junction table records.

### DIFF
--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -87,17 +87,18 @@ module.exports = function(criteria, cb) {
         // If no refKey return, this could leave orphaned join table values but it's better
         // than crashing.
         if(!refKey) return next();
-
+        
+        // An array of ids
         var mappedValues = result.map(function(vals) { return vals[pk]; });
+        
+        // Require some id condition for destroying records, otherwise could drop all records in table.
+        if (mappedValues.length == 0) return next();
+        
+        // At this point refKey and mappedValues are guaranteed to exist.
         var criteria = {};
+        criteria[refKey] = mappedValues;
 
-        if(mappedValues.length > 0) {
-          criteria[refKey] = mappedValues;
-          collection.destroy(criteria).exec(next);
-        } else {
-          return next();
-        }
-
+        collection.destroy(criteria).exec(next);
       }
 
       async.each(relations, destroyJoinTableRecords, function(err) {


### PR DESCRIPTION
Potentially closes #799, #812, #815 – please try this out, as this is a critical area of code.
Also, this should require a new test case.