### PR TITLE
Allowing types to be defined in each adapter

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ The current build status, immediate-term plans, and future goals of this reposit
 >
 > Before editing this file, please check out [How To Contribute to ROADMAP.md](https://gist.github.com/mikermcneil/bdad2108f3d9a9a5c5ed)- it's a quick read :)
 >
-> Also take a second to check that your feature request is relevant to Waterlin core and not one of its dependencies (e.g. waterline-schema, one of its adapters, etc.)  If you aren't sure, feel free to send the PR here and someone will make sure it finds its way to the right place.
+> Also take a second to check that your feature request is relevant to Waterline core and not one of its dependencies (e.g. waterline-schema, one of its adapters, etc.)  If you aren't sure, feel free to send the PR here and someone will make sure it finds its way to the right place.
 
 
 

--- a/lib/waterline/adapter/index.js
+++ b/lib/waterline/adapter/index.js
@@ -33,5 +33,6 @@ _.extend(
   require('./aggregateQueries'),
   require('./setupTeardown'),
   require('./sync'),
-  require('./stream')
+  require('./stream'),
+  require('./types')
 );

--- a/lib/waterline/adapter/types.js
+++ b/lib/waterline/adapter/types.js
@@ -1,0 +1,6 @@
+module.exports = {
+  supportsType: function(type) {
+    var adapter = this.connections[connName]._adapter;
+    return adapter.supportsType && adapter.supportsType(type);
+  }
+};

--- a/lib/waterline/core/index.js
+++ b/lib/waterline/core/index.js
@@ -86,7 +86,7 @@ Core._initialize = function(options) {
   var reservedAttributes = adapterInfo.reservedAttributes || {};
 
   // Initialize internal objects from attributes
-  this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes);
+  this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes, adapterInfo);
   this._cast.initialize(this._schema.schema);
   this._validator.initialize(_validations, this.types, this.defaults.validations);
 

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -49,7 +49,7 @@ var Schema = module.exports = function(context) {
  * @param {Boolean} hasSchema
  */
 
-Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes) {
+Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes, adapter) {
   var self = this;
 
   // Build normal attributes
@@ -79,7 +79,7 @@ Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes) {
  * @return {Object}
  */
 
-Schema.prototype.objectAttribute = function(attrName, value) {
+Schema.prototype.objectAttribute = function(attrName, value, adapter) {
   var attr = {};
 
   for(var key in value) {
@@ -88,7 +88,7 @@ Schema.prototype.objectAttribute = function(attrName, value) {
       // Set schema[attribute].type
       case 'type':
         // Allow validation types in attributes and transform them to strings
-        attr.type = ~types.indexOf(value[key]) ? value[key] : require('../adapter').supportsType(value[key]) ? value[key] : 'string';
+        attr.type = ~types.indexOf(value[key]) ? value[key] : (adapter && adapter.supportsType && adapter.supportsType(value[key])) ? value[key] : 'string';
         break;
 
       // Set schema[attribute].defaultsTo

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -55,7 +55,7 @@ Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes, ada
   // Build normal attributes
   Object.keys(attrs).forEach(function(key) {
     if(hasOwnProperty(attrs[key], 'collection')) return;
-    self.schema[key] = self.objectAttribute(key, attrs[key]);
+    self.schema[key] = self.objectAttribute(key, attrs[key], adapter);
   });
 
   // Build Reserved Attributes

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -88,7 +88,7 @@ Schema.prototype.objectAttribute = function(attrName, value) {
       // Set schema[attribute].type
       case 'type':
         // Allow validation types in attributes and transform them to strings
-        attr.type = ~types.indexOf(value[key]) ? value[key] : 'string';
+        attr.type = ~types.indexOf(value[key]) ? value[key] : require('../adapter').supportsType(value[key]) ? value[key] : 'string';
         break;
 
       // Set schema[attribute].defaultsTo

--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -38,6 +38,14 @@ module.exports = function(context, mixins) {
       return new defaultMethods.destroy(context, this, cb);
     },
 
+    dirty: function(attribute) {
+      return defaultMethods.dirty(context, this, attribute);
+    },
+
+    clean: function(attribute) {
+      defaultMethods.dirty.clean(context, this, attribute);
+    },
+
     _defineAssociations: function() {
       new internalMethods.defineAssociations(context, this);
     },

--- a/lib/waterline/model/lib/defaultMethods/dirty.js
+++ b/lib/waterline/model/lib/defaultMethods/dirty.js
@@ -1,0 +1,40 @@
+var _ = require('lodash');
+var diff = require('deep-diff').diff;
+
+/**
+ * Model.dirty()
+ *
+ * Returns whether the given attribute has changed since instantiation.
+ *
+ * @param {Object} context
+ * @param {Object} proto
+ * @param {Object} attributes
+ * @return bool
+ * @api public
+ */
+module.exports = function(context, proto, attribute) {
+    var comp = diff(proto._originalValues[attribute], proto[attribute]);
+
+    return typeof comp !== 'undefined';
+};
+
+/**
+ * Model.clean()
+ *
+ * Resets the "dirty" state.
+ *
+ * @param {Object} context
+ * @param {Object} proto
+ * @param {Object} attributes
+ * @return void
+ * @api public
+ */
+module.exports.clean = function (context, proto, attribute) {
+    if (typeof attribute === 'undefined') {
+        for (var key in proto) {
+            proto._originalValues[key] = _.cloneDeep(proto[key]);
+        }
+    } else {
+        proto._originalValues[attribute] = _.cloneDeep(proto[attribute]);
+    }
+};

--- a/lib/waterline/model/lib/defaultMethods/index.js
+++ b/lib/waterline/model/lib/defaultMethods/index.js
@@ -6,5 +6,6 @@
 module.exports = {
   toObject: require('./toObject'),
   destroy: require('./destroy'),
-  save: require('./save')
+  save: require('./save'),
+  dirty: require('./dirty')
 };

--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -41,9 +41,17 @@ var Model = module.exports = function(attrs, options) {
   // Build association getters and setters
   this._defineAssociations();
 
+  // List of original attributes of the object, so we know what is dirty!
+  Object.defineProperty(this, '_originalValues', {
+    enumerable: false,
+    value: {}
+  });
+
   // Attach attributes to the model instance
   for(var key in attrs) {
     this[key] = attrs[key];
+    // Add a copy of the attribute to the cache.
+    this._originalValues[key] = _.cloneDeep(attrs[key]);
 
     if(this.associationsCache.hasOwnProperty(key)) {
       this.associationsCache[key] = _.cloneDeep(attrs[key]);

--- a/test/unit/model/dirty.js
+++ b/test/unit/model/dirty.js
@@ -1,0 +1,43 @@
+var assert = require('assert'),
+    belongsToFixture = require('../../support/fixtures/model/context.belongsTo.fixture'),
+    Model = require('../../../lib/waterline/model');
+
+describe('model dirty', function() {
+
+  /////////////////////////////////////////////////////
+  // TEST SETUP
+  ////////////////////////////////////////////////////
+
+  var fixture, model;
+
+  before(function() {
+    fixture = belongsToFixture();
+    model = new Model(fixture);
+  });
+
+
+  /////////////////////////////////////////////////////
+  // TEST METHODS
+  ////////////////////////////////////////////////////
+
+  it('works with basic values', function() {
+    var person = new model();
+    assert(person.dirty('foo') === false);
+    person.foo = 'lala';
+    assert(person.dirty('foo') === true);
+    person.foo = undefined;
+    assert(person.dirty('foo') === false);
+  });
+
+  it('cleans correctly', function() {
+    var person = new model();
+    person.foo = 'lala';
+    assert(person.dirty('foo') === true);
+    person.clean();
+    assert(person.dirty('foo') === false);
+    person.foo = 'asdf';
+    assert(person.dirty('foo') === true);
+    person.foo = 'lala';
+    assert(person.dirty('foo') === false);
+  });
+});


### PR DESCRIPTION
I do think this is quite important, there are cases where supported types might be a bit different with each adapter.

With this change, this will allow each adapter to extend and create their own supported types.

Although this might mean that it becomes more difficult to have models that supports all sorts of different adapters, the chances of the models changing adapter is rather low, this change can make waterline more extensive :)