### PR TITLE
Decreased processing time by making queries which involve population more efficient

### DIFF
--- a/lib/waterline/model/lib/internalMethods/defineAssociations.js
+++ b/lib/waterline/model/lib/internalMethods/defineAssociations.js
@@ -38,7 +38,7 @@ var Define = module.exports = function(context, proto) {
     value: {}
   });
 
-  var attributes = _.cloneDeep(context._attributes) || {};
+  var attributes = context._attributes || {};
   var collections = this.collectionKeys(attributes);
   var models = this.modelKeys(attributes);
 
@@ -69,7 +69,7 @@ Define.prototype.collectionKeys = function(attributes) {
   // Find any collection keys
   for(var attribute in attributes) {
     if(!hasOwnProperty(attributes[attribute], 'collection')) continue;
-    collections.push(attribute);
+    collections.push(_.cloneDeep(attribute));
   }
 
   return collections;
@@ -89,7 +89,7 @@ Define.prototype.modelKeys = function(attributes) {
   // Find any collection keys
   for(var attribute in attributes) {
     if(!hasOwnProperty(attributes[attribute], 'model')) continue;
-    models.push({ key: attribute, val: attributes[attribute] });
+    models.push({ key: _.cloneDeep(attribute), val: _.cloneDeep(attributes[attribute]) });
   }
 
   return models;

--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -38,21 +38,27 @@ var Model = module.exports = function(attrs, options) {
   // Cast things that need to be cast
   this._cast(attrs);
 
-  // Build association getters and setters
-  this._defineAssociations();
+  // Check to see if associations are necessary for this record
+  if (! options.showJoins) {
 
-  // Attach attributes to the model instance
-  for(var key in attrs) {
-    this[key] = attrs[key];
-
-    if(this.associationsCache.hasOwnProperty(key)) {
-      this.associationsCache[key] = _.cloneDeep(attrs[key]);
-    }
+    // Build association getters and setters
+    this._defineAssociations();
   }
+    // Attach attributes to the model instance
+    for(var key in attrs) {
+      this[key] = attrs[key];
 
-  // Normalize associations
-  this._normalizeAssociations();
+      // Populate the associationsCache only if joins are needed and this property is an association
+      if(! options.showJoins && this.associationsCache.hasOwnProperty(key)) {
+        this.associationsCache[key] = _.cloneDeep(attrs[key]);
+      }
+    }
 
+  if (! options.showJoins) {
+
+    // Normalize associations
+    this._normalizeAssociations();
+  }
 
   /**
    * Log output

--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -39,8 +39,7 @@ var Model = module.exports = function(attrs, options) {
   this._cast(attrs);
 
   // Check to see if associations are necessary for this record
-  if (! options.showJoins) {
-
+  if (! options.ignoreAssociations) {
     // Build association getters and setters
     this._defineAssociations();
   }
@@ -48,13 +47,13 @@ var Model = module.exports = function(attrs, options) {
     for(var key in attrs) {
       this[key] = attrs[key];
 
-      // Populate the associationsCache only if joins are needed and this property is an association
-      if(! options.showJoins && this.associationsCache.hasOwnProperty(key)) {
+      // Populate the associationsCache only if they are needed and this property is an association
+      if(! options.ignoreAssociations && this.associationsCache.hasOwnProperty(key)) {
         this.associationsCache[key] = _.cloneDeep(attrs[key]);
       }
     }
 
-  if (! options.showJoins) {
+  if (! options.ignoreAssociations) {
 
     // Normalize associations
     this._normalizeAssociations();

--- a/lib/waterline/query/finders/joins.js
+++ b/lib/waterline/query/finders/joins.js
@@ -178,7 +178,7 @@ Joins.prototype.modelize = function modelize(value) {
         if(joinKey) {
           collection = self.collections[joinKey];
           val = collection._transformer.unserialize(val);
-          model = new collection._model(val, { showJoins: false });
+          model = new collection._model(val, { showJoins: false, ignoreAssociations: true  });
           return records.push(model);
         }
 
@@ -186,7 +186,7 @@ Joins.prototype.modelize = function modelize(value) {
         // the proper model from the collections.
         collection = self.collections[usedInJoin.join.child];
         val = collection._transformer.unserialize(val);
-        model = new collection._model(val, { showJoins: false });
+        model = new collection._model(val, { showJoins: false, ignoreAssociations: true  });
         return records.push(model);
       });
 
@@ -199,7 +199,7 @@ Joins.prototype.modelize = function modelize(value) {
     // it directly on the attribute
     collection = self.collections[joinKey];
     value[key] = collection._transformer.unserialize(value[key]);
-    value[key] = new collection._model(value[key], { showJoins: false });
+    value[key] = new collection._model(value[key], { showJoins: false, ignoreAssociations: true });
   });
 
   return value;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waterline",
   "description": "An ORM for Node.js and the Sails framework",
-  "version": "0.10.18",
+  "version": "0.10.19-alpha",
   "homepage": "http://github.com/balderdashy/waterline",
   "contributors": [
     {


### PR DESCRIPTION
This PR includes two simple changes which vastly improved the performance for queries which populate records with associations to other models which also have associations:
- Avoiding _.cloneDeep of the model's attributes definition for each of the records which should be populated, and instead using _.cloneDeep only the attributes which are associations.
- Avoiding "instrumenting" the model records for associations, if those records were retrieved only to populate the main records which were queried (so the associations wouldn't be used anyway).

These changes have decreased the processing time on my tests of querying a model which populates three associations to models which also have associations to around than 30% of what it was before.