### PR TITLE
Allowing types to be defined in each adapter

### DIFF
--- a/lib/waterline/adapter/index.js
+++ b/lib/waterline/adapter/index.js
@@ -33,5 +33,6 @@ _.extend(
   require('./aggregateQueries'),
   require('./setupTeardown'),
   require('./sync'),
-  require('./stream')
+  require('./stream'),
+  require('./types')
 );

--- a/lib/waterline/adapter/types.js
+++ b/lib/waterline/adapter/types.js
@@ -1,0 +1,6 @@
+module.exports = {
+  supportsType: function(type) {
+    var adapter = this.connections[connName]._adapter;
+    return adapter.supportsType && adapter.supportsType(type);
+  }
+};

--- a/lib/waterline/adapter/types.js
+++ b/lib/waterline/adapter/types.js
@@ -1,6 +1,7 @@
+var _ = require('lodash');
 module.exports = {
   supportsType: function(type) {
     var adapter = this.connections[connName]._adapter;
-    return adapter.supportsType && adapter.supportsType(type);
+    return _.isFunction(adapter.supportsType) && adapter.supportsType(type);
   }
 };

--- a/lib/waterline/core/index.js
+++ b/lib/waterline/core/index.js
@@ -86,7 +86,7 @@ Core._initialize = function(options) {
   var reservedAttributes = adapterInfo.reservedAttributes || {};
 
   // Initialize internal objects from attributes
-  this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes);
+  this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes, adapterInfo);
   this._cast.initialize(this._schema.schema);
   this._validator.initialize(_validations, this.types, this.defaults.validations);
 

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -49,7 +49,7 @@ var Schema = module.exports = function(context) {
  * @param {Boolean} hasSchema
  */
 
-Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes) {
+Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes, adapter) {
   var self = this;
 
   // Build normal attributes
@@ -79,7 +79,7 @@ Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes) {
  * @return {Object}
  */
 
-Schema.prototype.objectAttribute = function(attrName, value) {
+Schema.prototype.objectAttribute = function(attrName, value, adapter) {
   var attr = {};
 
   for(var key in value) {
@@ -88,7 +88,7 @@ Schema.prototype.objectAttribute = function(attrName, value) {
       // Set schema[attribute].type
       case 'type':
         // Allow validation types in attributes and transform them to strings
-        attr.type = ~types.indexOf(value[key]) ? value[key] : require('../adapter').supportsType(value[key]) ? value[key] : 'string';
+        attr.type = ~types.indexOf(value[key]) ? value[key] : (adapter && adapter.supportsType && adapter.supportsType(value[key])) ? value[key] : 'string';
         break;
 
       // Set schema[attribute].defaultsTo

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -55,7 +55,7 @@ Schema.prototype.initialize = function(attrs, hasSchema, reservedAttributes, ada
   // Build normal attributes
   Object.keys(attrs).forEach(function(key) {
     if(hasOwnProperty(attrs[key], 'collection')) return;
-    self.schema[key] = self.objectAttribute(key, attrs[key]);
+    self.schema[key] = self.objectAttribute(key, attrs[key], adapter);
   });
 
   // Build Reserved Attributes

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -88,7 +88,7 @@ Schema.prototype.objectAttribute = function(attrName, value) {
       // Set schema[attribute].type
       case 'type':
         // Allow validation types in attributes and transform them to strings
-        attr.type = ~types.indexOf(value[key]) ? value[key] : 'string';
+        attr.type = ~types.indexOf(value[key]) ? value[key] : require('../adapter').supportsType(value[key]) ? value[key] : 'string';
         break;
 
       // Set schema[attribute].defaultsTo

--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -69,7 +69,6 @@ var Model = module.exports = function(attrs, options) {
     return output ? util.inspect(output) : self;
   };
 
-
   return this;
 };
 


### PR DESCRIPTION
Continuing #827 here, original text:

> I do think this is quite important, there are cases where supported types might be a bit different with each adapter.
> 
> With this change, this will allow each adapter to extend and create their own supported types.
> 
> Although this might mean that it becomes more difficult to have models that supports all sorts of different adapters, the chances of the models changing adapter is rather low, this change can make waterline more extensive :)