### PR TITLE
Deprecate findOrCreateEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Each of the following basic methods are available by default on a Collection ins
 In addition you also have the following helper methods:
 
   - createEach
-  - findOrCreateEach
+  - findOrCreateEach (*DEPRECATED*)
   - findOrCreate
   - findOneLike
   - findLike


### PR DESCRIPTION
According to http://stackoverflow.com/questions/27573734/how-do-i-use-findorcreateeach-in-waterline-sailsjs findOrCreateEach is deprecated.

Also I am not finding much about `findOneLike` or `findLike`. Are these deprecated as well?