### PR TITLE
Take criteria as creation values for findOrCreate

### DIFF
--- a/lib/waterline/query/composite.js
+++ b/lib/waterline/query/composite.js
@@ -37,6 +37,10 @@ module.exports = {
 
     // Normalize criteria
     criteria = normalize.criteria(criteria);
+    //take the criteria as the creation values, if not specified otherwise
+    if (typeof values === 'undefined' || values === null) {
+      values = criteria.where;
+    }
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {


### PR DESCRIPTION
When I started using findOrCreate I was quite surprised that `Topic.findOrCreate({ researchId:  meta.id, text: meta.text }).exec()` created an empty model. I think it is a much more common use-case to want to create the exact same model you are searching for.

Edit: Not sure if https://github.com/balderdashy/waterline/blob/master/lib/waterline/adapter/compoundQueries.js needs to be updated as well? In my test-cases that got never called. Why are there these two separate functions?