### PR TITLE
fixed findOrCreate and added more tests.

### DIFF
--- a/lib/waterline/adapter/aggregateQueries.js
+++ b/lib/waterline/adapter/aggregateQueries.js
@@ -43,7 +43,7 @@ module.exports = {
 
     if(!hasOwnProperty(adapter, 'create')) return cb(new Error(err));
 
-    async.forEachSeries(valuesList, function (values, cb) {
+    async.eachSeries(valuesList, function (values, cb) {
       adapter.create(connName, self.collection, values, function(err, row) {
         if(err) return cb(err);
         results.push(row);
@@ -80,16 +80,17 @@ module.exports = {
 
     // Build a list of models
     var models = [];
+    var i = 0;
 
-    async.forEachSeries(valuesList, function (values, cb) {
+    async.eachSeries(valuesList, function (values, cb) {
       if (!_.isObject(values)) return cb(new Error('findOrCreateEach: Unexpected value in valuesList.'));
 
       // Check that each of the criteria keys match:
       // build a criteria query
       var criteria = {};
-      attributesToCheck.forEach(function (attrName) {
+      for(attrName in attributesToCheck) {
         criteria[attrName] = values[attrName];
-      });
+      }
 
       return self.findOrCreate.call(self, criteria, values, function (err, model) {
         if(err) return cb(err);

--- a/lib/waterline/adapter/aggregateQueries.js
+++ b/lib/waterline/adapter/aggregateQueries.js
@@ -88,7 +88,9 @@ module.exports = {
       // Check that each of the criteria keys match:
       // build a criteria query
       var criteria = {};
-      for(attrName in attributesToCheck) {
+      //Assuming here that criteria attributes are alway an array of objects
+      //which it should be for findOrCreateEach/multi-findOrCreate
+      for(attrName in attributesToCheck[i]) {
         criteria[attrName] = values[attrName];
       }
 

--- a/lib/waterline/adapter/ddl/alter/index.js
+++ b/lib/waterline/adapter/ddl/alter/index.js
@@ -144,7 +144,7 @@ module.exports = function(cb) {
 
     async.auto({
       newAttributes        : function (done_newAttributes) {
-        async.forEachSeries(_.keys(newAttributes), function (attrName, nextAttr_) {
+        async.eachSeries(_.keys(newAttributes), function (attrName, nextAttr_) {
           var attrDef = newAttributes[attrName];
           AdderAdapter.addAttribute(AdderConnection, collectionID, attrName, attrDef, nextAttr_);
         }, done_newAttributes);

--- a/lib/waterline/query/composite.js
+++ b/lib/waterline/query/composite.js
@@ -31,7 +31,7 @@ module.exports = {
 
     // If no criteria is specified, bail out with a vengeance.
     var usage = utils.capitalize(this.identity) + '.findOrCreate([criteria], values, callback)';
-    if(typeof cb == 'function' && !criteria) {
+    if(typeof cb == 'function' && && (!criteria || criteria.length === 0)) {
       return usageError('No criteria option specified!', usage, cb);
     }
 

--- a/lib/waterline/query/composite.js
+++ b/lib/waterline/query/composite.js
@@ -31,7 +31,7 @@ module.exports = {
 
     // If no criteria is specified, bail out with a vengeance.
     var usage = utils.capitalize(this.identity) + '.findOrCreate([criteria], values, callback)';
-    if(typeof cb == 'function' && && (!criteria || criteria.length === 0)) {
+    if(typeof cb == 'function' && (!criteria || criteria.length === 0)) {
       return usageError('No criteria option specified!', usage, cb);
     }
 

--- a/lib/waterline/query/composite.js
+++ b/lib/waterline/query/composite.js
@@ -37,6 +37,8 @@ module.exports = {
 
     // Normalize criteria
     criteria = normalize.criteria(criteria);
+    // If no values were specified, use criteria
+    if (!values) values = criteria.where ? criteria.where : criteria;
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {

--- a/test/unit/query/query.findOrCreate.js
+++ b/test/unit/query/query.findOrCreate.js
@@ -59,7 +59,7 @@ describe('Collection Query', function() {
       });
 
       it('should work with multiple objects', function(done) {
-        query.findOrCreate([{ name: 'Foo Bar' }, { name: 'Makis'} ]).exec(function(err, status) {
+        query.findOrCreate([{ name: 'Foo Bar' }, { name: 'Makis'}]).exec(function(err, status) {
           assert(status[0].name === 'Foo Bar');
           assert(status[1].name === 'Makis');
           done();

--- a/test/unit/query/query.findOrCreate.js
+++ b/test/unit/query/query.findOrCreate.js
@@ -51,6 +51,21 @@ describe('Collection Query', function() {
         });
       });
 
+      it('should set default values with exec', function(done) {
+        query.findOrCreate({ name: 'Foo Bar' }).exec(function(err, status) {
+          assert(status.name === 'Foo Bar');
+          done();
+        });
+      });
+
+      it('should work with multiple objects', function(done) {
+        query.findOrCreate([{ name: 'Foo Bar' }, { name: 'Makis'} ]).exec(function(err, status) {
+          assert(status[0].name === 'Foo Bar');
+          assert(status[1].name === 'Makis');
+          done();
+        });
+      });
+
       it('should add timestamps', function(done) {
         query.findOrCreate({ name: 'Foo Bar' }, {}, function(err, status) {
           assert(status.createdAt);


### PR DESCRIPTION
When I had `Topic.findOrCreate({ researchId:  meta.id, text: meta.text }).exec()` as well as `Topic.findOrCreate([{ researchId:  meta.id, text: meta.text }, { researchId:  'bladi', text:  'kaaa' }]).exec()` in my app with https://github.com/balderdashy/sails-disk it just did not work properly.

Fixed that, added some more tests and changed `forEachSeries` to `eachSeries` since that seems to be the preferred name (now?) by the library https://github.com/caolan/async#eachseriesarr-iterator-callback