### PR TITLE
Cross adapter fix

### DIFF
--- a/lib/waterline/core/index.js
+++ b/lib/waterline/core/index.js
@@ -101,7 +101,9 @@ Core._initialize = function(options) {
   this._transformer = new Transformer(schemaAttributes, this.waterline.schema);
 
   // Transform Schema
-  this._schema.schema = this._transformer.serialize(this._schema.schema);
+  // This limits the serialization to one level because it could inadvertently replace important properties
+  // if there are conflicting column names (such as type)
+  this._schema.schema = this._transformer.serialize(this._schema.schema, 1);
 
   // Build up a dictionary of which methods run on which connection
   this.adapterDictionary = new Dictionary(_.cloneDeep(this.connections), this.connection);

--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -74,12 +74,15 @@ Transformation.prototype.initialize = function(attributes, tables) {
  * @return {Object}
  */
 
-Transformation.prototype.serialize = function(attributes) {
+Transformation.prototype.serialize = function(attributes, maxDepth) {
   var self = this,
       values = _.clone(attributes);
+	  
+  if(!maxDepth) maxDepth = 0;
 
-  function recursiveParse(obj) {
-
+  function recursiveParse(obj, depth, maxDepth) {
+    if(maxDepth != 0 && depth >= maxDepth) return;
+	
     // Return if no object
     if(!obj) return;
 
@@ -99,7 +102,7 @@ Transformation.prototype.serialize = function(attributes) {
       if(!hasOwnProperty(obj, property)) return;
 
       // Recursively parse `OR` criteria objects to transform keys
-      if(Array.isArray(obj[property]) && property === 'or') return recursiveParse(obj[property]);
+      if(Array.isArray(obj[property]) && property === 'or') return recursiveParse(obj[property], depth + 1, maxDepth);
 
       // If Nested Object call function again passing the property as obj
       if((toString.call(obj[property]) !== '[object Date]') && (_.isPlainObject(obj[property]))) {
@@ -109,10 +112,10 @@ Transformation.prototype.serialize = function(attributes) {
           obj[self._transformations[property]] = _.clone(obj[property]);
           delete obj[property];
 
-          return recursiveParse(obj[self._transformations[property]]);
+          return recursiveParse(obj[self._transformations[property]], depth + 1, maxDepth);
         }
 
-        return recursiveParse(obj[property]);
+        return recursiveParse(obj[property], depth + 1, maxDepth);
       }
 
       // Check if property is a transformation key
@@ -125,7 +128,7 @@ Transformation.prototype.serialize = function(attributes) {
   }
 
   // Recursivly parse attributes to handle nested criteria
-  recursiveParse(values);
+  recursiveParse(values, 0, maxDepth);
 
   return values;
 };

--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -120,7 +120,9 @@ Transformation.prototype.serialize = function(attributes, maxDepth) {
 
       // Check if property is a transformation key
       if(hasOwnProperty(self._transformations, property)) {
-
+		if (property == 'type') {
+			console.log('Replacing type at depth ' + depth);
+		}
         obj[self._transformations[property]] = obj[property];
         delete obj[property];
       }

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -340,14 +340,29 @@ module.exports = {
         // Unserialize each of the results before attempting any join logic on them
         var unserializedModels = [];
 
-        if(results) {
-          results.forEach(function(result) {
-            unserializedModels.push(self._transformer.unserialize(result));
-          });
-        }
-
-        var models = [];
         var joins = criteria.joins ? criteria.joins : [];
+		
+        // Unserialize each of the results before attempting any join logic on them
+        var unserializedModels = [];
+        results.forEach(function(result) {
+			// Preserve any joined properties, since they may be clobbered by the unserialization
+			var preservedProperties = {};
+			joins.forEach(function(join) {
+				if(!hasOwnProperty(join, 'alias')) return;
+				
+				var joinKey = join.alias;
+				preservedProperties[joinKey] = result[joinKey];
+			});
+			
+			var unserializedModel = self._transformer.unserialize(result);
+			_.forIn(preservedProperties, function(value, key) {
+				unserializedModel[key] = value;
+			});
+			
+			unserializedModels.push(unserializedModel);
+        });
+		
+        var models = [];
         var data = new Joins(joins, unserializedModels, self.identity, self._schema.schema, self.waterline.collections);
 
         // NOTE:

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -101,7 +101,7 @@ module.exports = {
         // out of the top level where query so that searchs by primary key still work.
         var tmpCriteria = _.cloneDeep(criteria.where);
         if(!tmpCriteria) tmpCriteria = {};
-
+		
         criteria.joins.forEach(function(join) {
           if(!hasOwnProperty(join, 'alias')) return;
 
@@ -134,27 +134,41 @@ module.exports = {
             res[alias] = sorter(res[alias], c.sort);
           });
         });
-
+		
         returnResults(results);
       });
 
       function returnResults(results) {
-
         if(!results) return cb();
 
         // Normalize results to an array
         if(!Array.isArray(results) && results) results = [results];
 
+        var joins = criteria.joins ? criteria.joins : [];
+		
         // Unserialize each of the results before attempting any join logic on them
         var unserializedModels = [];
         results.forEach(function(result) {
-          unserializedModels.push(self._transformer.unserialize(result));
+			// Preserve any joined properties, since they may be clobbered by the unserialization
+			var preservedProperties = {};
+			joins.forEach(function(join) {
+				if(!hasOwnProperty(join, 'alias')) return;
+				
+				var joinKey = join.alias;
+				preservedProperties[joinKey] = result[joinKey];
+			});
+			
+			var unserializedModel = self._transformer.unserialize(result);
+			_.forIn(preservedProperties, function(value, key) {
+				unserializedModel[key] = value;
+			});
+			
+			unserializedModels.push(unserializedModel);
         });
-
+		
         var models = [];
-        var joins = criteria.joins ? criteria.joins : [];
         var data = new Joins(joins, unserializedModels, self.identity, self._schema.schema, self.waterline.collections);
-
+		
         // If `data.models` is invalid (not an array) return early to avoid getting into trouble.
         if (!data || !data.models || !data.models.forEach) {
           return cb(new Error('Values returned from operations set are not an array...'));
@@ -164,7 +178,7 @@ module.exports = {
         data.models.forEach(function(model) {
           models.push(new self._model(model, data.options));
         });
-
+		
         cb(null, models[0]);
       }
     });

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -155,6 +155,9 @@ module.exports = {
 				if(!hasOwnProperty(join, 'alias')) return;
 				
 				var joinKey = join.alias;
+				
+				if(!hasOwnProperty(result, joinKey)) return;
+				
 				preservedProperties[joinKey] = result[joinKey];
 			});
 			
@@ -351,6 +354,9 @@ module.exports = {
 				if(!hasOwnProperty(join, 'alias')) return;
 				
 				var joinKey = join.alias;
+				
+				if(!hasOwnProperty(result, joinKey)) return;
+				
 				preservedProperties[joinKey] = result[joinKey];
 			});
 			

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -211,7 +211,7 @@ Operations.prototype._stageOperations = function _stageOperations(connections) {
       // Look into the previous operations and see if this is a child of any of them
       var child = false;
       localOpts.forEach(function(localOpt) {
-        if(localOpt.join.child !== join.parent) return;
+        if(localOpt.join.child !== join.parent || localOpt.child) return;
         localOpt.child = operation;
         child = true;
       });
@@ -395,7 +395,7 @@ Operations.prototype._runOperation = function _runOperation(collectionName, meth
 
   // Find the connection object to run the operation
   var collection = this.context.waterline.collections[collectionName];
-
+  
   // Run the operation
   collection.adapter[method](criteria, cb);
 
@@ -420,7 +420,7 @@ Operations.prototype._execChildOpts = function _execChildOpts(parentResults, cb)
   // based on the results returned from the parent operation.
   this._buildChildOpts(parentResults, function(err, opts) {
     if(err) return cb(err);
-
+	
     // Run the generated operations in parallel
     async.each(opts, function(item, next) {
       self._collectChildResults(item, next);

--- a/lib/waterline/query/integrator/populate.js
+++ b/lib/waterline/query/integrator/populate.js
@@ -82,6 +82,9 @@ module.exports = function populate (options) {
       memo.push(childRow);
       return memo;
     }, []);
+	
+	// This prevents unserialization later from trashing the join
+	delete parentRow[fkToChild];
 
     return parentRow;
   });

--- a/lib/waterline/query/integrator/populate.js
+++ b/lib/waterline/query/integrator/populate.js
@@ -82,9 +82,6 @@ module.exports = function populate (options) {
       memo.push(childRow);
       return memo;
     }, []);
-	
-	// This prevents unserialization later from trashing the join
-	delete parentRow[fkToChild];
 
     return parentRow;
   });


### PR DESCRIPTION
This fixes issue #847, or at least some cases for it.  This prevents generated child operations from being overwritten when building up the operations list.