### PR TITLE
Fixed time validation issue (on the waterline side).

### DIFF
--- a/lib/waterline/core/typecast.js
+++ b/lib/waterline/core/typecast.js
@@ -216,7 +216,7 @@ Cast.prototype.time = function time(value){
   }
 
   if(_value.isValid()){
-    return _value.toISOString();
+    return _value.format("hh:mm:ss A");
   }
   else
     return value;

--- a/lib/waterline/core/typecast.js
+++ b/lib/waterline/core/typecast.js
@@ -6,6 +6,7 @@ var types = require('../utils/types'),
     utils = require('../utils/helpers'),
     hasOwnProperty = utils.object.hasOwnProperty,
     _ = require('lodash');
+    var moment = require('moment');
 
 /**
  * Cast Types
@@ -87,9 +88,12 @@ Cast.prototype.run = function(values) {
         break;
 
       case 'date':
-      case 'time':
       case 'datetime':
         values[key] = self.date(values[key]);
+        break;
+
+      case 'time':
+        values[key] = self.time(values[key]);
         break;
 
       case 'boolean':
@@ -194,6 +198,28 @@ Cast.prototype.boolean = function boolean(value) {
   if(value === true || value === false) return value;
 
   return false;
+};
+
+/**
+ * Cast Time Values
+ * @param  {String|Date} value
+ * @return {ISO 8601 Time String}
+ * @api private
+ */
+Cast.prototype.time = function time(value){
+  var _value;
+  if (value.__proto__ == Date.prototype) {
+    _value = moment(value);
+  }
+  else {
+    _value = moment(value);
+  }
+
+  if(_value.isValid()){
+    return _value.toISOString();
+  }
+  else
+    return value;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "bluebird": "^2.9",
     "deep-diff": "~0.3.0",
     "lodash": "~2.4.1",
-    "switchback": "~1.1.0",
+    "moment": "^2.9.0",
     "prompt": "~0.2.12",
+    "switchback": "~1.1.0",
     "waterline-criteria": "~0.11.0",
     "waterline-schema": "~0.1.17"
   },


### PR DESCRIPTION
Added a typecast for time that parses a time (e.g. 1:00:00 PM), etc. Returns this in a standardized time format understood by databases (MySQL, Postgres, and others), which is "hh:mm:ss a", where a is AM/PM. However, the MAIN issue is in the anchor library used by waterline, and I am submitting a pull request there as well.

Moment.js is needed for this fix (its parsing capabilities are far higher than Date's).