### PR TITLE
Add stack and message properties to waterline errors

### DIFF
--- a/lib/waterline/error/WLError.js
+++ b/lib/waterline/error/WLError.js
@@ -138,6 +138,15 @@ WLError.prototype.toString = function () {
   return util.format('[Error (%s) %s]', this.code, this.reason, this.details);
 };
 
+WLError.prototype.__defineGetter__('message', function(){
+  //return this.reason;
+  return this.toString();
+});
+
+WLError.prototype.__defineGetter__('stack', function(){
+  return util.format('Error (%s) :: %s\n%s', this.code, this.reason, this.rawStack);
+});
+
 
 
 module.exports = WLError;

--- a/test/unit/error/WLError.test.js
+++ b/test/unit/error/WLError.test.js
@@ -47,6 +47,17 @@ describe('lib/error', function () {
       var err = errorify();
       assert(err instanceof WLError);
     });
-
   });
+
+  describe('lib/error/WLError.js', function() {
+    it('should have a stack property, like Error', function() {
+      var err = errorify();
+      assert(err.stack)
+    });
+    it('should have a message property, like Error', function() {
+      var err = errorify();
+      assert(err.message)
+    })
+  })
+
 });


### PR DESCRIPTION
Fix for #865.  Makes waterline errors behave more like Error.  In particular, mocha tests which throw waterline errors will now report the error stack instead of just reporting nothing.