### PR TITLE
Add adapter tests to waterline core...

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   },
   "devDependencies": {
     "mocha": "~2.1.0",
-    "should": "~4.4.0"
+    "sails-memory": "^0.10.3",
+    "should": "~4.4.0",
+    "waterline-adapter-tests": "^0.10.8"
   },
   "keywords": [
     "mvc",
@@ -47,7 +49,7 @@
   "repository": "git://github.com/balderdashy/waterline.git",
   "main": "./lib/waterline",
   "scripts": {
-    "test": "mocha test --recursive",
+    "test": "mocha test/integration test/structure test/support test/unit --recursive; node test/adapter/runner.js",
     "prepublish": "npm prune",
     "browserify": "rm -rf .dist && mkdir .dist && browserify lib/waterline.js -s Waterline | uglifyjs > .dist/waterline.min.js"
   },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "devDependencies": {
     "mocha": "~2.1.0",
-    "sails-memory": "^0.10.3",
+    "sails-memory": "balderdashy/sails-memory",
     "should": "~4.4.0",
-    "waterline-adapter-tests": "^0.10.8"
+    "waterline-adapter-tests": "balderdashy/waterline-adapter-tests"
   },
   "keywords": [
     "mvc",

--- a/test/adapter/runner.js
+++ b/test/adapter/runner.js
@@ -1,0 +1,88 @@
+/**
+ * Test runner dependencies
+ */
+var util = require('util');
+var mocha = require('mocha');
+
+var adapterName = 'sails-memory';
+var TestRunner = require('waterline-adapter-tests');
+var Adapter = require(adapterName);
+
+
+
+// Grab targeted interfaces from this adapter's `package.json` file:
+var package = {};
+var interfaces = [];
+try {
+    package = require('../../node_modules/' + adapterName + '/package.json');
+    interfaces = package['waterlineAdapter'].interfaces;
+}
+catch (e) {
+    throw new Error(
+    '\n'+
+    'Could not read supported interfaces from "sails-adapter"."interfaces"'+'\n' +
+    'in this adapter\'s `package.json` file ::' + '\n' +
+    util.inspect(e)
+    );
+}
+
+
+
+
+
+console.info('Testing `' + package.name + '`, a Sails adapter.');
+console.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
+console.info('( ' + interfaces.join(', ') + ' )');
+console.log();
+console.log('Latest draft of Waterline adapter interface spec:');
+console.info('https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md');
+console.log();
+
+
+
+
+/**
+ * Integration Test Runner
+ *
+ * Uses the `waterline-adapter-tests` module to
+ * run mocha tests against the specified interfaces
+ * of the currently-implemented Waterline adapter API.
+ */
+new TestRunner({
+
+    // Load the adapter module.
+    adapter: Adapter,
+
+    // Default adapter config to use.
+    config: {
+        schema: false
+    },
+
+    // The set of adapter interfaces to test against.
+    // (grabbed these from this adapter's package.json file above)
+    interfaces: interfaces,
+    
+    // Mocha options
+    // reference: https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically
+    mocha: {
+      reporter: 'spec'
+    },
+    
+    // Most databases implement 'semantic' and 'queryable'.
+    // 
+    // As of Sails/Waterline v0.10, the 'associations' interface
+    // is also available.  If you don't implement 'associations',
+    // it will be polyfilled for you by Waterline core.  The core
+    // implementation will always be used for cross-adapter / cross-connection
+    // joins.
+    // 
+    // In future versions of Sails/Waterline, 'queryable' may be also
+    // be polyfilled by core.
+    // 
+    // These polyfilled implementations can usually be further optimized at the
+    // adapter level, since most databases provide optimizations for internal
+    // operations.
+    // 
+    // Full interface reference:
+    // https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md
+});


### PR DESCRIPTION
... to ensure changes in waterline don't break adapters.

Back in issue #862 @particlebanana [said](https://github.com/balderdashy/waterline/issues/862#issuecomment-83643605):
> All features need to work across all our adapters.

Which I totally agree BUT currently the waterline core code doesn't **automatically** run against any adapters. As a quick way to find out if a waterline change breaks the adapters I suggest running waterline against the `sails-memory` integration tests on every build. In my machine this only makes the tests run for 2-3 seconds longer.

Another added benefit is that waterline core code coverage increases:

Coverage | Before | After
------------ | ------------- | -------------
Statements | 78.61% ( 2933/3731 ) | 84.4% ( 3149/3731 )
Branches | 67.87% ( 1335/1967 ) | 74.78% ( 1471/1967 )
Functions | 84.3% ( 521/618 ) | 89.64% ( 554/618 )
Lines | 83.12% ( 2778/3342 ) | 88.96% ( 2973/3342 )

Note: for now the adapter tests are always returning 0 because "Semantic Interface .find() should escape attribute names to prevent SQL injection attacks" test is broken in `sails-memory`. When this is properly fixed I'll change the integration test to return error.

Note2: We probably should also have some sort of automated build that would run tests agains every official adapter, maybe in the waterline-adapter-tests?

**EDIT:** changed "sails-memory" and "waterline-adapter-tests" dependencies to use the latest github versions. This is to cover the case where a developer is making intentional API changes to waterline-core. This way, as long as "sails-memory" and "waterline-adapter-tests" github versions are on pair the tests won't break.