### PR TITLE
Do not sync nested collections from Model#save.

### DIFF
--- a/lib/waterline/model/lib/associationMethods/update.js
+++ b/lib/waterline/model/lib/associationMethods/update.js
@@ -37,8 +37,6 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
 
   // Clone values so they can be mutated
   var _values = _.cloneDeep(values);
-
-
   
   // For any nested model associations (objects not collection arrays) that were not changed,
   // lets set the value to just the foreign key so that an update query is not performed on the
@@ -56,7 +54,7 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
     }
   
     // If the key was changed, keep it expanded
-    if (mutatedModels.indexOf(key) !== -1) return;
+    if(mutatedModels.indexOf(key) !== -1) return;
 
     // Reduce it down to a foreign key value
     var vals = {};
@@ -67,7 +65,7 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
     var reduced = nestedOperations.reduceAssociations(collection.identity, collection.waterline.schema, vals);
     _values = _.merge(_values, reduced);
   });
-
+  
   // Update the collection with the new values
   collection.update(criteria, _values, cb);
 };

--- a/lib/waterline/model/lib/associationMethods/update.js
+++ b/lib/waterline/model/lib/associationMethods/update.js
@@ -38,14 +38,25 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
   // Clone values so they can be mutated
   var _values = _.cloneDeep(values);
 
+
+  
   // For any nested model associations (objects not collection arrays) that were not changed,
   // lets set the value to just the foreign key so that an update query is not performed on the
   // associatied model.
   var keys = _.keys(_values);
   keys.forEach(function(key) {
 
+    // Nix any collection attributes so that they do not get sync'd during the update process.
+    // One reason for this is that the result set is not guaranteed to be complete,
+    // so the sync could exclude items.
+    if (attributes[key] && hop(attributes[key], 'collection') && attributes[key].collection) {
+      
+      delete _values[key];
+      return;
+    }
+  
     // If the key was changed, keep it expanded
-    if(mutatedModels.indexOf(key) !== -1) return;
+    if (mutatedModels.indexOf(key) !== -1) return;
 
     // Reduce it down to a foreign key value
     var vals = {};

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -22,7 +22,7 @@ var noop = function() {};
  */
 
 module.exports = function(context, proto, cb) {
-
+  
   var deferred;
 
   if(typeof cb !== 'function') {


### PR DESCRIPTION
Should fix critical bug #858.  After looking at more radical change in PR #861 to remove nested operation sync on update, @particlebanana suggested just targeting the issue from the model.  This passes all adapter tests that sails-memory currently passes using the waterline master branch and all vanilla waterline tests.

The approach is simply to remove attributes that are collections prior to passing the cloned model values to `ParentCollection.update`.