### PR TITLE
#169: normalizes uppercase when sort passed as object

### DIFF
--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -245,6 +245,11 @@ var normalize = module.exports = {
 
       // normalize ASC/DESC notation
       Object.keys(criteria.sort).forEach(function(attr) {
+        
+        if(_.isString(criteria.sort[attr])) {
+          criteria.sort[attr] = criteria.sort[attr].toLowerCase();
+        }
+        
         if(criteria.sort[attr] === 'asc') criteria.sort[attr] = 1;
         if(criteria.sort[attr] === 'desc') criteria.sort[attr] = -1;
       });

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -233,11 +233,6 @@ var normalize = module.exports = {
         // Set default sort to asc
         parts[1] = parts[1] ? parts[1].toLowerCase() : 'asc';
 
-        // Throw error on invalid sort order
-        if(parts[1] !== 'asc' && parts[1] !== 'desc') {
-          throw new WLUsageError('Invalid sort criteria :: ' + criteria.sort);
-        }
-
         // Expand criteria.sort into object
         criteria.sort = {};
         criteria.sort[parts[0]] = parts[1];
@@ -248,6 +243,11 @@ var normalize = module.exports = {
         
         if(_.isString(criteria.sort[attr])) {
           criteria.sort[attr] = criteria.sort[attr].toLowerCase();
+          
+          // Throw error on invalid sort order
+          if(criteria.sort[attr] !== 'asc' && criteria.sort[attr] !== 'desc') {
+            throw new WLUsageError('Invalid sort criteria :: ' + criteria.sort);
+          }
         }
         
         if(criteria.sort[attr] === 'asc') criteria.sort[attr] = 1;

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -38,6 +38,18 @@ describe("Normalize utility", function() {
     });
     
     describe("sort object", function() {
+      it("should throw error on invalid order", function() {
+        var error;
+
+        try {
+          normalize.criteria({ sort: { name: "up" } });
+        } catch(e) {
+          error = e;
+        }
+
+        assert(typeof error !== 'undefined');
+      });
+      
       it("should properly normalize valid sort", function() {
         var criteria = normalize.criteria({ sort: { name: "asc" } });
         assert(criteria.sort.name === 1);

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -29,6 +29,24 @@ describe("Normalize utility", function() {
 
         assert(criteria.sort.name === -1);
       });
+      
+      it("should properly normalize valid sort with upper case", function() {
+        var criteria = normalize.criteria({ sort: "name DESC" });
+
+        assert(criteria.sort.name === -1);
+      });
+    });
+    
+    describe("sort object", function() {
+      it("should properly normalize valid sort", function() {
+        var criteria = normalize.criteria({ sort: { name: "asc" } });
+        assert(criteria.sort.name === 1);
+      });
+      
+      it("should properly normalize valid sort with upper case", function() {
+        var criteria = normalize.criteria({ sort: { name: "DESC" } });
+        assert(criteria.sort.name === -1);
+      });
     });
 
   });


### PR DESCRIPTION
Issue #169.

Adds support for upper case `ASC` and `DESC` when sort criteria is passed as an object.