### PR TITLE
Fix .findOrCreateEach() test failures

### DIFF
--- a/lib/waterline/adapter/aggregateQueries.js
+++ b/lib/waterline/adapter/aggregateQueries.js
@@ -88,11 +88,10 @@ module.exports = {
       // Check that each of the criteria keys match:
       // build a criteria query
       var criteria = {};
-      //Assuming here that criteria attributes are alway an array of objects
-      //which it should be for findOrCreateEach/multi-findOrCreate
-      for(attrName in attributesToCheck[i]) {
+      
+      attributesToCheck.forEach(function (attrName) {
         criteria[attrName] = values[attrName];
-      }
+      });
 
       return self.findOrCreate.call(self, criteria, values, function (err, model) {
         if(err) return cb(err);


### PR DESCRIPTION
This change aims to fix the the broken `.findOrCreateEach()` tests which are affecting most adapters.

Check balderdashy/waterline-adapter-tests#38 for more details.