### PR TITLE
Adds code coverage script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+
+coverage:
+	@echo "\n\nRunning coverage report..."
+	rm -rf coverage
+	./node_modules/istanbul/lib/cli.js cover --report none --dir coverage/core ./node_modules/.bin/_mocha \
+		test/integration test/structure test/support test/unit -- --recursive
+	./node_modules/istanbul/lib/cli.js cover --report none --dir coverage/adapter test/adapter/runner.js
+	./node_modules/istanbul/lib/cli.js report
+
+
+.PHONY: coverage

--- a/README.md
+++ b/README.md
@@ -553,3 +553,12 @@ All tests are written with [mocha](http://visionmedia.github.com/mocha/) and sho
 ``` bash
   $ npm test
 ```
+
+## Coverage
+
+To generate the code coverage report, run:
+
+``` bash
+  $ npm run coverage
+```
+And have a look at `coverage/lcov-report/index.html`.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "waterline-schema": "~0.1.17"
   },
   "devDependencies": {
+    "istanbul": "^0.3.11",
     "mocha": "~2.1.0",
     "sails-memory": "balderdashy/sails-memory",
     "should": "~4.4.0",
@@ -51,7 +52,8 @@
   "scripts": {
     "test": "mocha test/integration test/structure test/support test/unit --recursive; node test/adapter/runner.js",
     "prepublish": "npm prune",
-    "browserify": "rm -rf .dist && mkdir .dist && browserify lib/waterline.js -s Waterline | uglifyjs > .dist/waterline.min.js"
+    "browserify": "rm -rf .dist && mkdir .dist && browserify lib/waterline.js -s Waterline | uglifyjs > .dist/waterline.min.js",
+    "coverage": "make coverage"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
Runs code coverage reports with `npm run coverage`.

@particlebanana, I highly suggest setting up waterline in https://codeclimate.com or similar. If you do so, let me know and I'll configure waterline to send code coverage reports to codeclimate on every build and add a badge with coverage to the README, such as this: [![Test Coverage](https://codeclimate.com/github/appscot/sails-orientdb/badges/coverage.svg)](https://codeclimate.com/github/appscot/sails-orientdb)