### PR TITLE
Adapter Tests: waterline-adapter-tests using wrong WL dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+ROOT=$(shell pwd)
+
+test: test-unit test-integration
+
+test-unit:
+	@echo "\nRunning unit tests..."
+	@NODE_ENV=test mocha test/integration test/structure test/support test/unit --recursive
+
+test-integration:
+	@echo "\nRunning integration tests..."
+	rm -rf node_modules/waterline-adapter-tests/node_modules/waterline;
+	ln -s $(ROOT) node_modules/waterline-adapter-tests/node_modules/waterline;
+	@NODE_ENV=test node test/adapter/runner.js
 
 coverage:
 	@echo "\n\nRunning coverage report..."

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "repository": "git://github.com/balderdashy/waterline.git",
   "main": "./lib/waterline",
   "scripts": {
-    "test": "mocha test/integration test/structure test/support test/unit --recursive; node test/adapter/runner.js",
+    "test": "make test",
     "prepublish": "npm prune",
     "browserify": "rm -rf .dist && mkdir .dist && browserify lib/waterline.js -s Waterline | uglifyjs > .dist/waterline.min.js",
     "coverage": "make coverage"


### PR DESCRIPTION
In #896 we introduced adapter tests to be ran by waterline core test suite, but they have a minor flaw where waterline-adapter-tests is actually using waterline stable (0.10.x) instead of edge which is the aim of the tests.

This can easily be confirmed by checking the last master build log, where the "findOrCreateEach" test error ir still present even after being fixed: [previous build log #L1769](https://travis-ci.org/balderdashy/waterline/jobs/56325009#L1769).

The new build log shows (correctly) that error is now gone: [PR build log #L1768](https://travis-ci.org/balderdashy/waterline/jobs/56413696#L1768).