### PR TITLE
fixing many to many deletes

### DIFF
--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -74,6 +74,8 @@ module.exports = function(criteria, cb) {
         break;
       }
 
+      var transformedValues = _.map(result, self._transformer.unserialize.bind(self._transformer))
+
       function destroyJoinTableRecords(item, next) {
         var collection = self.waterline.collections[item];
         var refKey;
@@ -88,7 +90,14 @@ module.exports = function(criteria, cb) {
         // than crashing.
         if(!refKey) return next();
 
-        var mappedValues = result.map(function(vals) { return vals[pk]; });
+        // Make sure we don't return any undefined pks
+        var mappedValues = transformedValues.reduce(function(memo, vals) {
+          if (vals[pk]) { 
+            memo.push(vals[pk]); 
+          }
+          return memo; 
+        }, []);
+
         var criteria = {};
 
         if(mappedValues.length > 0) {

--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -92,7 +92,7 @@ module.exports = function(criteria, cb) {
 
         // Make sure we don't return any undefined pks
         var mappedValues = transformedValues.reduce(function(memo, vals) {
-          if (vals[pk]) { 
+          if (vals[pk] !== undefined) {
             memo.push(vals[pk]); 
           }
           return memo; 

--- a/test/integration/model/association.destroy.manyToMany.js
+++ b/test/integration/model/association.destroy.manyToMany.js
@@ -1,0 +1,112 @@
+var Waterline = require('../../../lib/waterline'),
+    _ = require('lodash'),
+    assert = require('assert');
+
+describe('Model', function() {
+  describe('associations Many To Many', function() {
+    describe('.destroy()', function() {
+
+      /////////////////////////////////////////////////////
+      // TEST SETUP
+      ////////////////////////////////////////////////////
+
+      var collections = {};
+      var prefDestroyCall;
+
+      before(function(done) {
+        var waterline = new Waterline();
+
+        var User = Waterline.Collection.extend({
+          connection: 'my_foo',
+          tableName: 'person',
+          attributes: {
+            id : {
+              primaryKey : true,
+              columnName : 'CUSTOM_ID'
+            },
+            preferences: {
+              collection: 'preference',
+              via: 'people',
+              dominant: true
+            }
+          }
+        });
+
+        var Preference = Waterline.Collection.extend({
+          connection: 'my_foo',
+          tableName: 'preference',
+          attributes: {
+            id : {
+              primaryKey : true,
+              columnName : 'CUSTOM_ID'
+            },
+            foo: 'string',
+            people: {
+              collection: 'person',
+              via: 'preferences'
+            }
+          }
+        });
+
+        waterline.loadCollection(User);
+        waterline.loadCollection(Preference);
+
+        var _values = [
+          { id: 1, preference: [{ foo: 'bar' }, { foo: 'foobar' }] },
+          { id: 2, preference: [{ foo: 'a' }, { foo: 'b' }] },
+        ];
+
+        var i = 1;
+
+        var adapterDef = {
+          find: function(con, col, criteria, cb) {
+            if(col === 'person_preference') return cb(null, []);
+            cb(null, _values);
+          },
+          destroy: function(con, col, criteria, cb) {
+            if(col === 'person_preferences__preference_people') {
+              prefDestroyCall = criteria;
+            }
+            return cb(null, [{
+              'CUSTOM_ID' : 1,
+              'preference'  : [ { foo: 'bar' }, { foo: 'foobar' } ]
+            }]);
+          },
+          update: function(con, col, criteria, values, cb) {
+            return cb(null, values);
+          },
+          create: function(con, col, values, cb) {
+            return cb(null, values);
+          },
+        };
+
+        var connections = {
+          'my_foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+          if(err) done(err);
+          collections = colls.collections;
+
+          done();
+        });
+      });
+
+
+      /////////////////////////////////////////////////////
+      // TEST METHODS
+      ////////////////////////////////////////////////////
+
+      it('should obey column names in many to many destroy', function(done) {
+        collections.person.destroy(1).exec(function(err, results) {
+          var expected = { where: { person_preferences: [ 1 ] } }
+          assert.deepEqual(prefDestroyCall, expected);
+          done();
+        });
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
Destroy will fail to create a valid sql query in many to many relationships with custom primary key column names.  The resulting query will include undefined columns

```
IN (undefined, undefined, undefined)
```