### PR TITLE
FindoOrCreate arrays of object fix

### DIFF
--- a/lib/waterline/adapter/aggregateQueries.js
+++ b/lib/waterline/adapter/aggregateQueries.js
@@ -84,14 +84,20 @@ module.exports = {
 
     async.eachSeries(valuesList, function (values, cb) {
       if (!_.isObject(values)) return cb(new Error('findOrCreateEach: Unexpected value in valuesList.'));
-
+      console.log('eachSeries iterator', i);
+      console.log('eachSeries iterator', attributesToCheck[i]);
       // Check that each of the criteria keys match:
       // build a criteria query
       var criteria = {};
-      
-      attributesToCheck.forEach(function (attrName) {
+
+      Object.keys(attributesToCheck[i]).forEach(function (attrName, i) {
+        console.log('attrName', attrName);
         criteria[attrName] = values[attrName];
       });
+
+      console.log('criteria', criteria);
+      console.log('values', values);
+      i++;
 
       return self.findOrCreate.call(self, criteria, values, function (err, model) {
         if(err) return cb(err);

--- a/lib/waterline/adapter/aggregateQueries.js
+++ b/lib/waterline/adapter/aggregateQueries.js
@@ -84,20 +84,20 @@ module.exports = {
 
     async.eachSeries(valuesList, function (values, cb) {
       if (!_.isObject(values)) return cb(new Error('findOrCreateEach: Unexpected value in valuesList.'));
-      console.log('eachSeries iterator', i);
-      console.log('eachSeries iterator', attributesToCheck[i]);
       // Check that each of the criteria keys match:
       // build a criteria query
       var criteria = {};
 
-      Object.keys(attributesToCheck[i]).forEach(function (attrName, i) {
-        console.log('attrName', attrName);
-        criteria[attrName] = values[attrName];
-      });
-
-      console.log('criteria', criteria);
-      console.log('values', values);
-      i++;
+      if (_.isObject(attributesToCheck[i])) {
+        Object.keys(attributesToCheck[i]).forEach(function (attrName) {
+          criteria[attrName] = values[attrName];
+        });
+        i++;
+      } else {
+        attributesToCheck.forEach(function (attrName) {
+          criteria[attrName] = values[attrName];
+        });
+      }
 
       return self.findOrCreate.call(self, criteria, values, function (err, model) {
         if(err) return cb(err);

--- a/lib/waterline/adapter/aggregateQueries.js
+++ b/lib/waterline/adapter/aggregateQueries.js
@@ -57,12 +57,22 @@ module.exports = {
 
   // If an optimized findOrCreateEach exists, use it, otherwise use an asynchronous loop with create()
   findOrCreateEach: function(attributesToCheck, valuesList, cb) {
-    var self = this,
-        connName,
-        adapter;
+    var self = this;
+    var connName;
+    var adapter;
 
     // Normalize Arguments
     cb = normalize.callback(cb);
+
+    var isObjectArray = false;
+
+    if (_.isObject(attributesToCheck[0])) {
+      if (attributesToCheck.length > 1 &&
+        attributesToCheck.length !== valuesList.length) {
+        return cb(new Error('findOrCreateEach: The two passed arrays have to be of the same length.'));
+      }
+      isObjectArray = true;
+    }
 
     // Clone sensitive data
     attributesToCheck = _.clone(attributesToCheck);
@@ -88,11 +98,17 @@ module.exports = {
       // build a criteria query
       var criteria = {};
 
-      if (_.isObject(attributesToCheck[i])) {
-        Object.keys(attributesToCheck[i]).forEach(function (attrName) {
-          criteria[attrName] = values[attrName];
-        });
-        i++;
+      if (isObjectArray) {
+        if (_.isObject(attributesToCheck[i])) {
+          Object.keys(attributesToCheck[i]).forEach(function (attrName) {
+            criteria[attrName] = values[attrName];
+          });
+          if (attributesToCheck.length > 1) {
+            i++;
+          }
+        } else {
+          return cb(new Error('findOrCreateEach: Element ' + i + ' in attributesToCheck is not an object.' ));
+        }
       } else {
         attributesToCheck.forEach(function (attrName) {
           criteria[attrName] = values[attrName];

--- a/test/unit/query/query.findOrCreate.js
+++ b/test/unit/query/query.findOrCreate.js
@@ -59,7 +59,9 @@ describe('Collection Query', function() {
       });
 
       it('should work with multiple objects', function(done) {
-        query.findOrCreate([{ name: 'Foo Bar' }, { name: 'Makis'}]).exec(function(err, status) {
+        query.findOrCreate([{ name: 'Foo Bar New' }, { name: 'Makis'}]).exec(function(err, status) {
+          console.log('err', err);
+          console.log('status', status);
           assert(status[0].name === 'Foo Bar');
           assert(status[1].name === 'Makis');
           done();

--- a/test/unit/query/query.findOrCreate.js
+++ b/test/unit/query/query.findOrCreate.js
@@ -59,9 +59,7 @@ describe('Collection Query', function() {
       });
 
       it('should work with multiple objects', function(done) {
-        query.findOrCreate([{ name: 'Foo Bar New' }, { name: 'Makis'}]).exec(function(err, status) {
-          console.log('err', err);
-          console.log('status', status);
+        query.findOrCreate([{ name: 'Foo Bar' }, { name: 'Makis'}]).exec(function(err, status) {
           assert(status[0].name === 'Foo Bar');
           assert(status[1].name === 'Makis');
           done();


### PR DESCRIPTION
This is as discussed in https://github.com/balderdashy/waterline-adapter-tests/issues/38

For some reason the unit-test I created did not catch the bug that broke my app. This now fully supports the use case I am using and that is described in https://github.com/balderdashy/waterline-docs/blob/master/query-methods.md#findorcreate-search-criteria-values-callback-, which is passing arrays of objects.

I tested now against https://github.com/balderdashy/waterline-adapter-tests and with `sails-memory` only get 1 failing test that is unrelated to my change.

@dmarcelino could you review?