### PR TITLE
Use correct foreign collection during nested update creation/link step.

### DIFF
--- a/lib/waterline/utils/nestedOperations/update.js
+++ b/lib/waterline/utils/nestedOperations/update.js
@@ -510,7 +510,12 @@ function createNewRecords(parent, recordsToCreate, cb) {
   // For each association, run the createRecords function
   // in the model context.
   function mapAssociations(association, next) {
-    var model = self.waterline.collections[association];
+    
+    // First, pull the model attribute's referenced (foreign) collection
+    var attribute = self.waterline.schema[self.identity].attributes[association];
+    var referencedCollection = attribute.references;
+    
+    var model = self.waterline.collections[referencedCollection];
     var records = recordsToCreate[association];
 
     function createRunner(record, nextRecord) {


### PR DESCRIPTION
Ref #533 and #930.

I think this is the correct fix for the problem referenced in issues above.  This should resolve the bugs caught in the adjusted adapter tests (https://github.com/balderdashy/waterline-adapter-tests/pull/44).

I'd call this fairly high priority for evaluating.  Happy to answer questions about the problem at hand and this solution.