### PR TITLE
#937: saves on populated models

### DIFF
--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -38,26 +38,21 @@ var Model = module.exports = function(attrs, options) {
   // Cast things that need to be cast
   this._cast(attrs);
 
-  // Check to see if associations are necessary for this record
-  if (! options.ignoreAssociations) {
-    // Build association getters and setters
-    this._defineAssociations();
-  }
-    // Attach attributes to the model instance
-    for(var key in attrs) {
-      this[key] = attrs[key];
+  // Build association getters and setters
+  this._defineAssociations();
 
-      // Populate the associationsCache only if they are needed and this property is an association
-      if(! options.ignoreAssociations && this.associationsCache.hasOwnProperty(key)) {
-        this.associationsCache[key] = _.cloneDeep(attrs[key]);
-      }
+  // Attach attributes to the model instance
+  for(var key in attrs) {
+    this[key] = attrs[key];
+
+    if(this.associationsCache.hasOwnProperty(key)) {
+      this.associationsCache[key] = _.cloneDeep(attrs[key]);
     }
-
-  if (! options.ignoreAssociations) {
-
-    // Normalize associations
-    this._normalizeAssociations();
   }
+
+  // Normalize associations
+  this._normalizeAssociations();
+
 
   /**
    * Log output

--- a/lib/waterline/query/finders/joins.js
+++ b/lib/waterline/query/finders/joins.js
@@ -178,7 +178,7 @@ Joins.prototype.modelize = function modelize(value) {
         if(joinKey) {
           collection = self.collections[joinKey];
           val = collection._transformer.unserialize(val);
-          model = new collection._model(val, { showJoins: false, ignoreAssociations: true  });
+          model = new collection._model(val, { showJoins: false });
           return records.push(model);
         }
 
@@ -186,7 +186,7 @@ Joins.prototype.modelize = function modelize(value) {
         // the proper model from the collections.
         collection = self.collections[usedInJoin.join.child];
         val = collection._transformer.unserialize(val);
-        model = new collection._model(val, { showJoins: false, ignoreAssociations: true  });
+        model = new collection._model(val, { showJoins: false });
         return records.push(model);
       });
 
@@ -199,7 +199,7 @@ Joins.prototype.modelize = function modelize(value) {
     // it directly on the attribute
     collection = self.collections[joinKey];
     value[key] = collection._transformer.unserialize(value[key]);
-    value[key] = new collection._model(value[key], { showJoins: false, ignoreAssociations: true });
+    value[key] = new collection._model(value[key], { showJoins: false });
   });
 
   return value;


### PR DESCRIPTION
Fix for #937: partially revert PR #924 to ensure `.save()` works on populated models.

Tests: balderdashy/waterline-adapter-tests#46.