### PR TITLE
897: if the adapter tests fail return code 1 so the automated build fails

### DIFF
--- a/test/adapter/runner.js
+++ b/test/adapter/runner.js
@@ -68,6 +68,11 @@ new TestRunner({
       reporter: 'spec'
     },
     
+    mochaChainableMethods: {},
+    
+    // Return code 1 if any test failed
+    failOnError: true
+    
     // Most databases implement 'semantic' and 'queryable'.
     // 
     // As of Sails/Waterline v0.10, the 'associations' interface


### PR DESCRIPTION
This is to avoid the case where the tests are broken but the build passes.

Part of issue #897.