### PR TITLE
Make shallow copy of criteria array for findOne

### DIFF
--- a/lib/waterline/adapter/dql.js
+++ b/lib/waterline/adapter/dql.js
@@ -132,7 +132,12 @@ module.exports = {
    * @return {[type]}            [description]
    */
   findOne: function(criteria, cb) {
-
+    
+    //make shallow copy of criteria so original does not get modified
+    if (Array.isArray(criteria) || _.isObject(criteria)) {
+      criteria = _.clone(criteria);
+    }
+    
     // Normalize Arguments
     cb = normalize.callback(cb);
 

--- a/lib/waterline/adapter/dql.js
+++ b/lib/waterline/adapter/dql.js
@@ -5,7 +5,6 @@
 var normalize = require('../utils/normalize');
 var schema = require('../utils/schema');
 var hasOwnProperty = require('../utils/helpers').object.hasOwnProperty;
-var _ = require('lodash');
 
 
 /**
@@ -133,9 +132,7 @@ module.exports = {
   findOne: function(criteria, cb) {
     
     //make shallow copy of criteria so original does not get modified
-    if (Array.isArray(criteria) || _.isObject(criteria)) {
-      criteria = _.clone(criteria);
-    }
+    criteria = _.clone(criteria);
     
     // Normalize Arguments
     cb = normalize.callback(cb);

--- a/lib/waterline/adapter/dql.js
+++ b/lib/waterline/adapter/dql.js
@@ -5,6 +5,7 @@
 var normalize = require('../utils/normalize');
 var schema = require('../utils/schema');
 var hasOwnProperty = require('../utils/helpers').object.hasOwnProperty;
+var _ = require('lodash');
 
 
 /**

--- a/lib/waterline/adapter/dql.js
+++ b/lib/waterline/adapter/dql.js
@@ -5,8 +5,7 @@
 var normalize = require('../utils/normalize');
 var schema = require('../utils/schema');
 var hasOwnProperty = require('../utils/helpers').object.hasOwnProperty;
-
-
+var _ = require('lodash');
 
 
 /**


### PR DESCRIPTION
Again, fixing a bug as discussed with @devinivy and @dmarcelino .

@devinivy I tried adding the shallow copy at the place you suggested first: https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/finders/basic.js#L35, but that did haven no affect in my code. Adding it here fixes the issue!