### PR TITLE
Use custom auto-attributes if specified in the model

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -241,8 +241,13 @@ function _validate(record, cb) {
     if(err) return cb(err);
 
     // Automatically add updatedAt and createdAt (if enabled)
-    if (self.autoCreatedAt) record.createdAt = new Date();
-    if (self.autoUpdatedAt) record.updatedAt = new Date();
+    if (self.autoCreatedAt) {
+      record[self.autoCreatedAt] = new Date();
+    }
+
+    if (self.autoUpdatedAt) {
+      record[self.autoUpdatedAt] = new Date();
+    }
 
     cb();
   });

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -191,16 +191,19 @@ function beforeCallbacks(valuesObject, cb) {
  */
 
 function createValues(valuesObject, cb) {
-
   var self = this;
 
   // Automatically add updatedAt and createdAt (if enabled)
-  if(self.autoCreatedAt && !valuesObject.values.createdAt) {
-    valuesObject.values.createdAt = new Date();
+  if(self.autoCreatedAt) {
+    if(!valuesObject.values[self.autoCreatedAt]) {
+      valuesObject.values[self.autoCreatedAt] = new Date();
+    }
   }
 
-  if(self.autoUpdatedAt && !valuesObject.values.updatedAt) {
-    valuesObject.values.updatedAt = new Date();
+  if(self.autoUpdatedAt) {
+    if(!valuesObject.values[self.autoUpdatedAt]) {
+      valuesObject.values[self.autoUpdatedAt] = new Date();
+    }
   }
 
   // Transform Values

--- a/test/unit/query/query.create.js
+++ b/test/unit/query/query.create.js
@@ -108,7 +108,7 @@ describe('Collection Query', function() {
 
     });
 
-    describe('override auto values', function() {
+    describe('override and disable auto values', function() {
       var query;
 
       before(function(done) {
@@ -152,6 +152,58 @@ describe('Collection Query', function() {
         query.create({}, function(err, status) {
           assert(!status.createdAt);
           assert(!status.updatedAt);
+          done();
+        });
+      });
+    });
+
+    describe('override auto values with custom names', function() {
+      var query;
+
+      before(function(done) {
+
+        var waterline = new Waterline();
+        var Model = Waterline.Collection.extend({
+          identity: 'user',
+          connection: 'foo',
+
+          autoCreatedAt: "customCreatedAt",
+          autoUpdatedAt: "customUpdatedAt",
+
+          attributes: {
+            name: {
+              type: 'string',
+              defaultsTo: 'Foo Bar'
+            },
+            doSomething: function() {}
+          }
+        });
+
+        waterline.loadCollection(Model);
+
+        // Fixture Adapter Def
+        var adapterDef = { create: function(con, col, values, cb) { return cb(null, values); }};
+
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+          if(err) return done(err);
+          query = colls.collections.user;
+          done();
+        });
+      });
+
+      it('should add timestamps with a custom name', function(done) {
+        query.create({}, function(err, status) {
+          console.log(err,status);
+          assert(!status.createdAt);
+          assert(!status.updatedAt);
+          assert(status.customCreatedAt);
+          assert(status.customUpdatedAt);
           done();
         });
       });


### PR DESCRIPTION
This pullrequest goes along with the one I did for water-line schema [here](https://github.com/balderdashy/waterline-schema/pull/23) and implements #754 

It allows users to specify custom names for the automatic timestamp attributes, they just need to pass a string instead of `true` or `fals`e. 

Let me know if it is fine like this and I will update the documentation accordingly.

The Travis build will fail while [the PR on waterline-schema](https://github.com/balderdashy/waterline-schema/pull/23) is not merged, because my tests will not succeed, but all the older tests remain intact

Edit by @dmarcelino: Pending tasks:
- [x] Merge PR balderdashy/waterline-schema#23;
- [x] Bump waterline-schema version and release it;
- [x] Update waterline's [package.json](https://github.com/balderdashy/waterline/blob/master/package.json#L29) to use latest waterline-schema version;
- [ ] Merge docs balderdashy/waterline-docs#60.