### PR TITLE
validate() presentOnly parameter can be used to specify attributes to validate.

### DIFF
--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -126,7 +126,9 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
       } // Fall through to the default if the object is not an array
     default:
       // Any other truthy value.
-      validations = _.intersection(validations, Object.keys(values));
+      if (presentOnly) {
+        validations = _.intersection(validations, Object.keys(values));
+      }
   }
 
   function validate(validation, cb) {

--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -100,7 +100,8 @@ Validator.prototype.initialize = function(attrs, types, defaults) {
  * schema's validations using Anchor.
  *
  * @param {Object} values to check
- * @param {Boolean} presentOnly only validate present values
+ * @param {Boolean|String|String[]} presentOnly only validate present values (if `true`) or
+ * validate the specified attribute(s).
  * @param {Function} callback
  * @return Array of errors
  */
@@ -110,13 +111,22 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
       errors = {},
       validations = Object.keys(this.validations);
 
-  // Handle optional second arg
-  if(typeof presentOnly === 'function') {
-    cb = presentOnly;
-  }
-  // Use present values only or all validations
-  else if(presentOnly) {
-    validations = _.intersection(validations, Object.keys(values));
+  // Handle optional second arg AND Use present values only, specified values, or all validations
+  switch (typeof presentOnly) {
+    case 'function':
+      cb = presentOnly;
+      break;
+    case 'string':
+      validations = [presentOnly];
+      break;
+    case 'object':
+      if (Array.isArray(presentOnly)) {
+        validations = presentOnly;
+        break;
+      } // Fall through to the default if the object is not an array
+    default:
+      // Any other truthy value.
+      validations = _.intersection(validations, Object.keys(values));
   }
 
   function validate(validation, cb) {

--- a/lib/waterline/query/validate.js
+++ b/lib/waterline/query/validate.js
@@ -17,6 +17,7 @@ module.exports = {
     //Handle optional second arg
     if (typeof presentOnly === 'function') {
       cb = presentOnly;
+      presentOnly = false;
     }
 
     async.series([
@@ -38,7 +39,7 @@ module.exports = {
 
       // Run Validation
       function(cb) {
-        self._validator.validate(values, presentOnly === true, function(invalidAttributes) {
+        self._validator.validate(values, presentOnly, function(invalidAttributes) {
 
           // Create validation error here
           // (pass in the invalid attributes as well as the collection's globalId)

--- a/test/unit/core/core.validations.js
+++ b/test/unit/core/core.validations.js
@@ -126,7 +126,28 @@ describe('Core Validator', function() {
       });
     });
 
-    it('should validate present values only, thus not need required last_name', function(done) {
+    it('should validate all fields with presentOnly omitted or set to false', function(done) {
+      person._validator.validate({ city: 'Washington' }, function(err) {
+        assert(err);
+        assert(!err.first_name);
+        assert(err.last_name);
+        assert(err.last_name[0].rule === 'string');
+        assert(err.city);
+        assert(err.city[0].rule === 'maxLength');
+
+        person._validator.validate({ city: 'Washington' }, false, function(err) {
+          assert(err);
+          assert(!err.first_name);
+          assert(err.last_name);
+          assert(err.last_name[0].rule === 'string');
+          assert(err.city);
+          assert(err.city[0].rule === 'maxLength');
+          done();
+        });
+      });
+    });
+
+    it('should, for presentOnly === true, validate present values only, thus not need the required last_name', function(done) {
       person._validator.validate({ first_name: 'foo' }, true, function(err) {
         assert(!err);
         done();

--- a/test/unit/core/core.validations.js
+++ b/test/unit/core/core.validations.js
@@ -81,6 +81,10 @@ describe('Core Validator', function() {
             type: 'string',
             required: true,
             defaultsTo: 'Smith'
+          },
+          city: {
+            type: 'string',
+            maxLength: 7
           }
         }
       });
@@ -120,6 +124,46 @@ describe('Core Validator', function() {
         assert(err.last_name[1].rule === 'required');
         done();
       });
+    });
+
+    it('should validate present values only, thus not need required last_name', function(done) {
+      person._validator.validate({ first_name: 'foo' }, true, function(err) {
+        assert(!err);
+        done();
+      });
+    });
+
+    it('should validate only the specified value', function(done) {
+      person._validator.validate({ first_name: 'foo', last_name: 32, city: 'Washington' },
+        'first_name', function(err) {
+          assert(!err);
+
+          person._validator.validate({ first_name: 'foo', last_name: 32, city: 'Washington' },
+            'last_name', function(err) {
+              assert(err);
+              assert(err.last_name);
+              assert(err.last_name[0].rule === 'string');
+              assert(!err.city);
+              done();
+            });
+        });
+    });
+
+    it('should validate only the specified values', function(done) {
+      person._validator.validate({ first_name: 'foo', last_name: 32, city: 'Atlanta' },
+        ['first_name', 'city'], function(err) {
+          assert(!err);
+
+          person._validator.validate({ first_name: 'foo', last_name: 32, city: 'Washington' },
+            ['first_name', 'city'], function(err) {
+              assert(err);
+              assert(!err.first_name);
+              assert(!err.last_name);
+              assert(err.city);
+              assert(err.city[0].rule === 'maxLength');
+              done();
+            });
+        });
     });
 
   });


### PR DESCRIPTION
The static `validate()` method on the model provides the `presentOnly` parameter to indicate that only the provided subset of values should be validated. When desiring to validate only a single modified value this can become problematic if that value depends on other attributes in the model, since the values of those attributes wouldn't be present at the time. Adding those values in is not ideal since it will cause them to be validated as well and requires extra code.

While this might not be a big issue on a server I am investigating the use of Waterline on the client in an isomorphic app. When some attributes require async validation to the server it becomes a big problem if I can't validate one property at a time, but then the issue in the first paragraph may come into play with the current implementation.

My solution is to allow passing the name of a single attribute to validate, or an array of attribute names, on the same presentOnly parameter. This is backwards compatible, and also allows for a wide range of use cases since the entire set of values can be provided with just the specified value(s) validated.

I have added a complete suite of unit tests for my changes.