### PR TITLE
Added ability to specify what to populate on save()

### DIFF
--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -30,8 +30,8 @@ module.exports = function(context, mixins) {
       return new defaultMethods.toObject(context, this);
     },
 
-    save: function(cb) {
-      return new defaultMethods.save(context, this, cb);
+    save: function(cb, options) {
+      return new defaultMethods.save(context, this, cb, options);
     },
 
     destroy: function(cb) {

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -33,8 +33,8 @@ module.exports = function(context, proto, cb, options) {
     deferred = defer();
   }
 
-  options = options || optDefaults;
   cb = cb || noop;
+  options = _.defaults(options, optDefaults) || optDefaults;
 
   /**
    * TO-DO:
@@ -190,12 +190,10 @@ module.exports = function(context, proto, cb, options) {
 
     // Build up a new query and re-populate specified associations
     var query = context.findOne(criteria);
-    var populate = options.hasOwnProperty('populate') ?
-      options.populate : optDefaults.populate;
 
-    if (populate) {
-      if (populate.constructor === Array) {
-        populate.forEach(function(pop) {
+    if (options.populate) {
+      if (options.populate.constructor === Array) {
+        options.populate.forEach(function(pop) {
           query.populate(pop.key, pop.query);
         });
       }

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -7,6 +7,9 @@ var removeAssociation = require('../associationMethods/remove');
 var hop = require('../../../utils/helpers').object.hasOwnProperty;
 var defer = require('../../../utils/defer');
 var noop = function() {};
+var optDefaults = {
+  populate: true
+};
 
 /**
  * Model.save()
@@ -29,6 +32,7 @@ module.exports = function(context, proto, cb) {
     deferred = defer();
   }
 
+  options = options || optDefaults;
   cb = cb || noop;
 
   /**
@@ -183,11 +187,23 @@ module.exports = function(context, proto, cb) {
     var criteria = {};
     criteria[PK] = obj[PK];
 
-    // Build up a new query and re-populate everything
+    // Build up a new query and re-populate specified associations
     var query = context.findOne(criteria);
-    populations.forEach(function(pop) {
-      query.populate(pop);
-    });
+    var populate = options.hasOwnProperty('populate') ?
+      options.populate : optDefaults.populate;
+
+    if (populate) {
+      if (populate.constructor === Array) {
+        populate.forEach(function(pop) {
+          query.populate(pop.key, pop.query);
+        });
+      }
+      else {
+        populations.forEach(function(pop) {
+          query.populate(pop);
+        });
+      }
+    }
 
     query.exec(function(err, data) {
       if(err) {

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -20,11 +20,12 @@ var optDefaults = {
  * @param {Object} context
  * @param {Object} proto
  * @param {Function} callback
+ * @param {Object} options
  * @return {Promise}
  * @api public
  */
 
-module.exports = function(context, proto, cb) {
+module.exports = function(context, proto, cb, options) {
   
   var deferred;
 


### PR DESCRIPTION
I noticed that every time I called `.save()` on my models with large association lists, I was waiting seconds for it to finish. In fact, as the association list grew (i.e. posts for a user in a social network setting), performance degraded rapidly. This small feature addition allows an optional `options` parameter to be passed to `.save()`, so the new function header is: 

    model.save(cb, options);

This will allow for more options to be passed to the function in the future, if necessary. Specific to this pull request is the addition of the `populate` key.

The value can be an array of objects that contain details about the association you want to populate:

    // This will only populate the given associations 
    var pOpts = [
        {
            key: 'followers',
            query: {
                name: 'Mike',
                limit: 5
            }
        },
        {
            key: 'stream'
        }
    ];

    model.save(cb, { populate: pOpts });

Or the value can be a boolean, where `true` will populate all associations and `false` will populate none:

    // This will not populate any associations
    var pOpts = false;
    model.save(cb, { populate: pOpts });

The default value is `true` so existing code will not be affected by this change. If someone gets to writing the tests before I do, that would be fantastic (I am not familiar with this testing platform and it may take me some time to get to it). Let me know if anything should be changed!

Thanks,
Nate Kibler