### PR TITLE
Fix schema cleanValues method to always remove associations.

### DIFF
--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -192,13 +192,19 @@ Schema.prototype.objectAttribute = function(attrName, value) {
  */
 
 Schema.prototype.cleanValues = function(values) {
+  
   var clone = {};
 
-  // Return if hasSchema === false
-  if(!this.hasSchema) return values;
-
-  for(var key in values) {
-    if(hasOwnProperty(this.schema, key)) clone[key] = values[key];
+  for (var key in values) {
+    
+    // The value can pass through if either the collection does have a schema and the key is in the schema,
+    // or otherwise if the collection is schemaless and the key does not represent an associated collection.
+    if ((this.hasSchema && hasOwnProperty(this.schema, key)) ||
+        (!this.hasSchema && !(hasOwnProperty(this.context._attributes, key) && hasOwnProperty(this.context._attributes[key], 'collection')))) {
+      
+      clone[key] = values[key];
+    }
+    
   }
 
   return clone;

--- a/test/unit/core/core.schema/schema.cleanValues.js
+++ b/test/unit/core/core.schema/schema.cleanValues.js
@@ -1,0 +1,99 @@
+var Waterline = require('../../../../lib/waterline'),
+    assert = require('assert');
+
+describe('Core Schema', function() {
+
+  describe('cleanValues method', function() {
+    var user;
+    var userschemaless;
+
+    before(function(done) {
+      var waterline = new Waterline();
+      
+      var UserSchema = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        schema: true,
+        attributes: {
+          name: {
+            type: 'string',
+            defaultsTo: 'Foo Bar'
+          },
+          age: {
+            type: 'integer',
+          },
+          schemalessFriends: {
+            collection: 'userschemaless',
+            via: 'schemaFriends'
+          }
+        }
+      });
+        
+      var UserSchemaless = Waterline.Collection.extend({
+        identity: 'userschemaless',
+        connection: 'foo',
+        schema: false,
+        attributes: {
+          name: {
+            type: 'string',
+            defaultsTo: 'Foo Bar'
+          },
+          age: {
+            type: 'integer',
+          },
+          schemaFriends: {
+            collection: 'user',
+            via: 'schemalessFriends'
+          }
+        }
+      });
+
+      waterline.loadCollection(UserSchema);
+      waterline.loadCollection(UserSchemaless);
+        
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: {} }, connections: connections }, function(err, colls) {
+        if(err) return done(err);
+        user = colls.collections.user;
+        userschemaless = colls.collections.userschemaless;
+        done();
+      });
+    });
+
+    it('when collection is schemaless, should only remove collection attributes.', function() {
+      
+      var rawValues = {
+        name: 'don-moe',
+        non: 'should be here',
+        schemaFriends: []
+      }
+      
+      var cleanValues = userschemaless._schema.cleanValues(rawValues);
+      
+      assert.equal(cleanValues.name, 'don-moe');
+      assert.equal(cleanValues.non, 'should be here');
+      assert.equal(cleanValues.schemaFriends, undefined);
+    });
+
+    it('when collection has schema, should clean attributes not in the schema, including collection attributes.', function() {
+
+      var rawValues = {
+        name: 'don-moe',
+        non: 'should be here',
+        schemalessFriends: []
+      }
+      
+      var cleanValues = user._schema.cleanValues(rawValues);
+      
+      assert.equal(cleanValues.name, 'don-moe');
+      assert.equal(cleanValues.non, undefined);
+      assert.equal(cleanValues.schemalessFriends, undefined);
+    });
+  });
+
+});


### PR DESCRIPTION
Should resolve the ever-pesky #429 and https://github.com/balderdashy/sails-mongo/issues/254 .  This ensures that association attributes that represent collections are always cleaned by the schema before sending values to the adapter during create and update.  This should allow `schema: false` to behave correctly.  I added unit tests here– if anyone would like to add integration tests to [waterline-adapter-tests](https://github.com/balderdashy/waterline-adapter-tests), that would be sweet!

CC: @dmarcelino @tjwebb @anasyb