### PR TITLE
860: return error on findOne(undefined).populate()

### DIFF
--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -55,8 +55,10 @@ module.exports = {
 
     // If there was something defined in the criteria that would return no results, don't even
     // run the query and just return an empty result set.
-    if(criteria === false) {
-      return cb(null, null);
+    if(criteria === false || criteria.where === null) {
+      // Build Default Error Message
+      var err = '.findOne() requires a criteria. If you want the first record try .find().limit(1)';
+      return cb(err);
     }
 
     // Build up an operations set

--- a/test/unit/query/associations/belongsTo.js
+++ b/test/unit/query/associations/belongsTo.js
@@ -77,6 +77,16 @@ describe('Collection Query', function() {
         done();
       });
     });
+    
+    
+    it('should return error if criteria is undefined', function(done) {
+      Car.findOne()
+      .populate('driver')
+      .exec(function(err, values) {
+        assert(err, 'An Error is expected');
+        done();
+      });
+    });
 
   });
 });


### PR DESCRIPTION
Fixes #860.

`findOne(undefined)` returns an error but `findOne(undefined).populate()` does not. This PR makes both uses of `.findOne()` consistent by always throwing error.
