### PR TITLE
Extend types through the adapter

### DIFF
--- a/lib/waterline/core/index.js
+++ b/lib/waterline/core/index.js
@@ -84,11 +84,13 @@ Core._initialize = function(options) {
   }
 
   var reservedAttributes = adapterInfo.reservedAttributes || {};
+  var defaultValidations = this.defaults.validations || {};
+  var adapterTypes = adapterInfo.types || {};
 
   // Initialize internal objects from attributes
   this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes);
   this._cast.initialize(this._schema.schema);
-  this._validator.initialize(_validations, this.types, this.defaults.validations);
+  this._validator.initialize(_validations, this.types, adapterTypes, defaultValidations);
 
   // Set the collection's primaryKey attribute
   Object.keys(schemaAttributes).forEach(function(key) {

--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -53,8 +53,13 @@ var Validator = module.exports = function(adapter) {
  * }
  */
 
-Validator.prototype.initialize = function(attrs, types, defaults) {
+Validator.prototype.initialize = function(attrs, types, adapterTypes, defaults) {
   var self = this;
+
+  if(!defaults){
+    defaults = adapterTypes;
+    adapterTypes = undefined;
+  }
 
   defaults = defaults || {};
 
@@ -66,6 +71,10 @@ Validator.prototype.initialize = function(attrs, types, defaults) {
   if(defaults.ignoreProperties && Array.isArray(defaults.ignoreProperties)) {
     this.reservedProperties = this.reservedProperties.concat(defaults.ignoreProperties);
   }
+  
+  // add adapter type definitions to anchor
+  adapterTypes = adapterTypes || {};
+  anchor.define(adapterTypes);
 
   // add custom type definitions to anchor
   types = types || {};

--- a/test/integration/Collection.validations.js
+++ b/test/integration/Collection.validations.js
@@ -42,6 +42,10 @@ describe('Waterline Collection', function() {
 
           password: {
             type: 'password'
+          },
+          
+          age: {
+            type: 'age'
           }
         }
       });
@@ -55,7 +59,10 @@ describe('Waterline Collection', function() {
       };
 
       // Fixture Adapter Def
-      var adapterDef = { create: function(con, col, values, cb) { return cb(null, values); }};
+      var adapterDef = { 
+        create: function(con, col, values, cb) { return cb(null, values); },
+        types: { age: function(val){ return !isNaN(val) && val > 0; } }
+      };
       waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
         if(err) done(err);
         User = colls.collections.user;
@@ -124,6 +131,22 @@ describe('Waterline Collection', function() {
         assert(!user);
         assert(err.ValidationError);
         assert(err.ValidationError.password[0].rule === 'password');
+        done();
+      });
+    });
+    
+    it('should support adapter custom type with valid age', function(done) {
+      User.create({ name: 'foo', sex: 'male', age: 10 }, function(err, user) {
+        assert(!err, err);
+        done();
+      });
+    });
+
+    it('should error with invalid input for adapter custom type', function(done) {
+      User.create({ name: 'foo', sex: 'male', age: 'ten' }, function(err, user) {
+        assert(!user);
+        assert(err.ValidationError);
+        assert(err.ValidationError.age[0].rule === 'age');
         done();
       });
     });


### PR DESCRIPTION
Fixes #819 and is an alternative to PR #832.

In similar fashion to Custom Types (PR #72) used in the model definition, this PR introduces the option to extend waterline's types in the adapter following the same format as Custom Types / [anchor rules](https://github.com/balderdashy/anchor/blob/master/lib/match/rules.js). For an adapter to make use of this it only requires to have a field named `types` in its adapter.js, example:
``` javascript
  types: { 
    myDbSpecialNumberFormat: function(val){ return !isNaN(val); } 
  }
```

Now, in the model definition the user would be able to use:
```javascript
attributes: {
  spaceDistance: {
    type: "float",
    myDbSpecialNumberFormat: true
  }
}
```

Compared to #832 this change has the advantages of being more similar to Custom Types format and it includes validations which #832 does not.

cc: @shekhei, @devinivy, @GaryLCoxJr 