### PR TITLE
createEach: use async.map instead of async.eachSeries to improve performance

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -65,7 +65,7 @@ module.exports = {
       });
     }
 
-    async.eachSeries(valuesList, create, function(err) {
+    async.map(valuesList, create, function(err) {
       if(err) return cb(err);
       cb(null, records);
     });


### PR DESCRIPTION
In #795, the `async.each` was replaced by `async.eachSeries` to ensure order of creation and make tests pass (for community adapters?), this however introduces a performance penalty which in my opinion and others is not worth:

@tjwebb in https://github.com/balderdashy/sails-postgresql/issues/128#issuecomment-68575680
> `.eachSeries` will slow things down, though, since each create will then be done sequentially. Should the order really matter, here?

@kevinburkeshyp in https://github.com/balderdashy/sails-postgresql/issues/128#issuecomment-95970705:
> would `async.map` help? 

@devinivy in https://github.com/balderdashy/waterline-adapter-tests/pull/27#issuecomment-96682857:
> I also would like to see `Async#map` being used as @dmarcelino mentioned.

### Pros and cons
Using [`async.map`](https://github.com/caolan/async#maparr-iterator-callback) instead of `async.eachSeries` will ensure `.create([])` returns its results in order (issues balderdashy/sails-postgresql#128 and balderdashy/waterline-adapter-tests#27) without limiting performance. For situations where creation order is sensitive users can still chain independent `create()` commands in an `async.eachSeries` calls.

### Tests
Lastly, regarding breaking tests, me and @devinivy have been fixing them in the waterline-adapter-tests (examples: balderdashy/waterline-adapter-tests#43, balderdashy/waterline-adapter-tests#52). I think it's best to fix the tests than to restrain waterline performance.

cc: @imevs, @particlebanana, @devinivy, @tjwebb, @brandonsimpson, @kevinburkeshyp, @atiertant