### PR TITLE
Extend types through the adapter using dbType

### DIFF
--- a/lib/waterline/core/index.js
+++ b/lib/waterline/core/index.js
@@ -84,11 +84,13 @@ Core._initialize = function(options) {
   }
 
   var reservedAttributes = adapterInfo.reservedAttributes || {};
+  var defaultValidations = this.defaults.validations || {};
+  var adapterTypes = adapterInfo.types || {};
 
   // Initialize internal objects from attributes
   this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes);
   this._cast.initialize(this._schema.schema);
-  this._validator.initialize(_validations, this.types, this.defaults.validations);
+  this._validator.initialize(_validations, this.types, adapterTypes, defaultValidations);
 
   // Set the collection's primaryKey attribute
   Object.keys(schemaAttributes).forEach(function(key) {

--- a/lib/waterline/core/schema.js
+++ b/lib/waterline/core/schema.js
@@ -90,6 +90,12 @@ Schema.prototype.objectAttribute = function(attrName, value) {
         // Allow validation types in attributes and transform them to strings
         attr.type = ~types.indexOf(value[key]) ? value[key] : 'string';
         break;
+        
+      // Set schema[attribute].dbType
+      case 'dbType':
+        // Allow custom adapter validation types in attributes
+        attr.dbType = value[key];
+        break;
 
       // Set schema[attribute].defaultsTo
       case 'defaultsTo':

--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -53,8 +53,13 @@ var Validator = module.exports = function(adapter) {
  * }
  */
 
-Validator.prototype.initialize = function(attrs, types, defaults) {
+Validator.prototype.initialize = function(attrs, types, adapterTypes, defaults) {
   var self = this;
+
+  if(!defaults){
+    defaults = adapterTypes;
+    adapterTypes = undefined;
+  }
 
   defaults = defaults || {};
 
@@ -66,6 +71,10 @@ Validator.prototype.initialize = function(attrs, types, defaults) {
   if(defaults.ignoreProperties && Array.isArray(defaults.ignoreProperties)) {
     this.reservedProperties = this.reservedProperties.concat(defaults.ignoreProperties);
   }
+  
+  // add adapter type definitions to anchor
+  adapterTypes = adapterTypes || {};
+  anchor.define(adapterTypes);
 
   // add custom type definitions to anchor
   types = types || {};

--- a/lib/waterline/utils/schema.js
+++ b/lib/waterline/utils/schema.js
@@ -58,6 +58,11 @@ schema.normalizeAttributes = function(attrs) {
     if(attributes[key].type && typeof attributes[key].type !== 'undefined') {
       attributes[key].type = attributes[key].type.toLowerCase();
     }
+    
+    // Ensure dbType is lower case
+    if(hasOwnProperty(attrs[key], 'dbType')) {
+      attributes[key].dbType = attributes[key].dbType.toLowerCase();
+    }
 
     // Ensure Collection property is lowercased
     if(hasOwnProperty(attrs[key], 'collection')) {

--- a/test/integration/Collection.validations.js
+++ b/test/integration/Collection.validations.js
@@ -45,7 +45,13 @@ describe('Waterline Collection', function() {
           },
           
           age: {
-            type: 'age'
+            type: 'integer',
+            dbType: 'customDbType'
+          },
+          
+          address: {
+            type: 'string',
+            dbType: 'geoString'
           }
         }
       });
@@ -61,7 +67,7 @@ describe('Waterline Collection', function() {
       // Fixture Adapter Def
       var adapterDef = { 
         create: function(con, col, values, cb) { return cb(null, values); },
-        types: { age: function(val){ return !isNaN(val) && val > 0; } }
+        types: { customdbtype: function(val){ return !isNaN(val) && val > 0; } }
       };
       waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
         if(err) done(err);
@@ -143,10 +149,17 @@ describe('Waterline Collection', function() {
     });
 
     it('should error with invalid input for adapter custom type', function(done) {
-      User.create({ name: 'foo', sex: 'male', age: 'ten' }, function(err, user) {
+      User.create({ name: 'foo', sex: 'male', age: -5 }, function(err, user) {
         assert(!user);
         assert(err.ValidationError);
-        assert(err.ValidationError.age[0].rule === 'age');
+        assert.equal(err.ValidationError.age[0].rule, 'customdbtype');
+        done();
+      });
+    });
+    
+    it('should support dbType even if adapter doesn\'t have a validation rule for it', function(done) {
+      User.create({ name: 'foo', sex: 'male', address: 'N 30° 19\' 7.14"' }, function(err, user) {
+        assert(!err, err);
         done();
       });
     });

--- a/test/integration/Collection.validations.js
+++ b/test/integration/Collection.validations.js
@@ -42,6 +42,10 @@ describe('Waterline Collection', function() {
 
           password: {
             type: 'password'
+          },
+          
+          age: {
+            type: 'age'
           }
         }
       });
@@ -55,7 +59,10 @@ describe('Waterline Collection', function() {
       };
 
       // Fixture Adapter Def
-      var adapterDef = { create: function(con, col, values, cb) { return cb(null, values); }};
+      var adapterDef = { 
+        create: function(con, col, values, cb) { return cb(null, values); },
+        types: { age: function(val){ return !isNaN(val) && val > 0; } }
+      };
       waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
         if(err) done(err);
         User = colls.collections.user;
@@ -124,6 +131,22 @@ describe('Waterline Collection', function() {
         assert(!user);
         assert(err.ValidationError);
         assert(err.ValidationError.password[0].rule === 'password');
+        done();
+      });
+    });
+    
+    it('should support adapter custom type with valid age', function(done) {
+      User.create({ name: 'foo', sex: 'male', age: 10 }, function(err, user) {
+        assert(!err, err);
+        done();
+      });
+    });
+
+    it('should error with invalid input for adapter custom type', function(done) {
+      User.create({ name: 'foo', sex: 'male', age: 'ten' }, function(err, user) {
+        assert(!user);
+        assert(err.ValidationError);
+        assert(err.ValidationError.age[0].rule === 'age');
         done();
       });
     });

--- a/test/unit/core/core.schema/schema.object.js
+++ b/test/unit/core/core.schema/schema.object.js
@@ -18,6 +18,10 @@ describe('Core Schema', function() {
           phone: {
             type: 'STRING',
             defaultsTo: '555-555-5555'
+          },
+          address: {
+            type: 'STRING',
+            dbType: 'geoString'
           }
         }
       });
@@ -40,6 +44,7 @@ describe('Core Schema', function() {
     it('should set internal schema attributes', function() {
       assert(person._schema.schema.first_name);
       assert(person._schema.schema.last_name);
+      assert(person._schema.schema.address);
     });
 
     it('should lowercase attribute types', function() {
@@ -48,6 +53,10 @@ describe('Core Schema', function() {
 
     it('should set defaultsTo value', function() {
       assert(person._schema.schema.phone.defaultsTo === '555-555-5555');
+    });
+    
+    it('should lowercase attribute dbType', function() {
+      assert.equal(person._schema.schema.address.dbType, 'geostring');
     });
   });
 


### PR DESCRIPTION
Fixes #819 and follows on the discussion in PR #977. This is also an alternative to PR #832. Do note this breaks the tests because it requires anchor changes, details below.

In similar fashion to Custom Types (PR #72) used in the model definition, this PR introduces the option to extend waterline's types in the adapter following the same format as Custom Types / [anchor rules](https://github.com/balderdashy/anchor/blob/master/lib/match/rules.js). For an adapter to make use of this it only requires to have a field named `types` in its adapter.js, example:
``` javascript
// adapter.js
// ...
  types: { 
    mydbspecialnumberformat: function(val){ return !isNaN(val); } 
  }
  // in similar fashion to `type` the key must be lower case
```

Now, in the model definition the user would be able to use:
```javascript
// some model definition
// ...
attributes: {
  spaceDistance: {
    type: "float",
    dbType: "myDbSpecialNumberFormat"
  }
}
```

### Comparison to previous PRs

Compared to PR #977 this change has the advantage of being transparent for adapters not providing validations for a given `dbType` while allowing that adapter to use the `type` as a fallback.

Compared to #832 this change has the advantages of being more similar to Custom Types format and it includes validations which #832 does not.

### Tasks

Please note, this PR depends on balderdashy/anchor#77 being merged and published. Hence the tasks to merge this are:
- [x] Review (and merge) balderdashy/anchor#77;
- [x] Publish anchor to npm;
- [x] Review (and merge) balderdashy/waterline-schema#26
- [x] Publish waterline-schema to npm;
- [ ] Re-run this PR tests and make sure they pass;
- [ ] Update waterline package.json to use the latest versions of anchor and waterline-schema;
- [ ] Merge this.

cc: @shekhei, @devinivy, @GaryLCoxJr, @tjwebb, @particlebanana 