### PR TITLE
867: `required: false` prevents all other validators from running fix

### DIFF
--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -135,11 +135,6 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
       if(value === null || value === '') return cb();
     }
 
-    // if required is set to 'false', don't enforce as required rule
-    if (curValidation.hasOwnProperty('required')&&!curValidation.required) {
-        return cb();
-    }
-
     // If Boolean and required manually check
     if(curValidation.required && curValidation.type === 'boolean' && (typeof value !== 'undefined' && value !== null)) {
       if(value.toString() == 'true' || value.toString() == 'false') return cb();

--- a/test/unit/validations/validations.required.js
+++ b/test/unit/validations/validations.required.js
@@ -17,7 +17,11 @@ describe('validations', function() {
           type: 'boolean',
           required: true
         },
-        age: { type: 'integer' }
+        age: { type: 'integer' },
+        email: {
+          type: 'email',
+          required: false
+        }
       };
 
       validator = new Validator();
@@ -56,6 +60,29 @@ describe('validations', function() {
     it('should NOT error if all required values are set', function(done) {
       validator.validate({ name: 'Foo Bar', employed: true, age: 27 }, function(errors) {
         assert(!errors);
+        done();
+      });
+    });
+
+    it('should NOT error if required is false and values are valid', function(done) {
+      validator.validate({ name: 'Foo Bar', employed: true, email: 'email@example.com' }, function(errors) {
+        assert(!errors);
+        done();
+      });
+    });
+    
+    it('should NOT error if required is false and value is not present', function(done) {
+      validator.validate({ name: 'Foo Bar', employed: true }, function(errors) {
+        assert(!errors);
+        done();
+      });
+    });
+    
+    it('should error if required is false and value is invalid', function(done) {
+      validator.validate({ name: 'Frederick P. Frederickson', employed: true, email: 'not email' }, function(errors) {
+        assert(errors);
+        assert(errors.email);
+        assert.equal(errors.email[0].rule, 'email');
         done();
       });
     });


### PR DESCRIPTION
Fixes #867.

In the below case the e-mail validation does not run.

``` javascript
    attributes: {
        secondaryEmail: {
            required: false,
            email: true // this validation will not execute
        }
    }
```

The issue was traced to [validations.js#L138-L141](https://github.com/balderdashy/waterline/blob/master/lib/waterline/core/validations.js#L138-L141):
``` javascript
    // if required is set to 'false', don't enforce as required rule
    if (curValidation.hasOwnProperty('required')&&!curValidation.required) {
        return cb();
    }
```

This PR adds a failing test, 2 regressions tests and fixes this issue.