### PR TITLE
createEach: use the output of async.map

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -45,30 +45,14 @@ module.exports = {
 
     var errStr = _validateValues(_.cloneDeep(valuesList));
     if(errStr) return usageError(errStr, usage, cb);
-
-    var records = [];
-
-    function create(value, next) {
-
-      // Handle undefined values
-      if(value === undefined) {
-        setImmediate(function() {
-          return next();
-        });
-      }
-
-      // Create will take care of cloning values so original isn't mutated
-      self.create(value, function(err, record) {
-        if(err) return next(err);
-        records.push(record);
-        next();
-      });
-    }
-
-    async.map(valuesList, create, function(err) {
-      if(err) return cb(err);
-      cb(null, records);
+    
+    // Handle undefined values
+    var filteredValues = _.filter(valuesList, function(value) {
+      return value !== undefined;
     });
+    
+    // Create will take care of cloning values so original isn't mutated
+    async.map(filteredValues, self.create.bind(self), cb);
   },
 
   /**


### PR DESCRIPTION
 instead of using helper array. to ensure the order is correct.

Supplement to #980, ensuring it passes the *.create() should return rows in the correct order when creating multiple rows* test.

cc: @devinivy, @kevinburkeshyp, @particlebanana, @brandonsimpson
