### PR TITLE
Enable adapter/integration feature cross-adapter tests 

### DIFF
--- a/test/adapter/runner.js
+++ b/test/adapter/runner.js
@@ -13,9 +13,11 @@ var Adapter = require(adapterName);
 // Grab targeted interfaces from this adapter's `package.json` file:
 var package = {};
 var interfaces = [];
+var features = [];
 try {
     package = require('../../node_modules/' + adapterName + '/package.json');
     interfaces = package['waterlineAdapter'].interfaces;
+    features = package.waterlineAdapter.features;
 }
 catch (e) {
     throw new Error(
@@ -61,6 +63,10 @@ new TestRunner({
     // The set of adapter interfaces to test against.
     // (grabbed these from this adapter's package.json file above)
     interfaces: interfaces,
+  
+    // The set of adapter features to test against.
+    // (grabbed these from this adapter's package.json file above)
+    features: features,
     
     // Mocha options
     // reference: https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically


### PR DESCRIPTION
To make use of the new cross-adapter tests introduced by balderdashy/waterline-adapter-tests#64.

This also increases coverage.