### PR TITLE
Calling adapter's createEach method, fixes #1007

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -51,8 +51,11 @@ module.exports = {
       return value !== undefined;
     });
     
+    //Sending to adapter's optimized createEach method
+    //Will fallback to normal create if adapter doesn't implement it.
+    self.adapter.createEach(filteredValues,cb);
     // Create will take care of cloning values so original isn't mutated
-    async.map(filteredValues, self.create.bind(self), cb);
+    //async.map(filteredValues, self.create.bind(self), cb);
   },
 
   /**

--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -51,9 +51,65 @@ module.exports = {
       return value !== undefined;
     });
     
-    //Sending to adapter's optimized createEach method
-    //Will fallback to normal create if adapter doesn't implement it.
-    self.adapter.createEach(filteredValues,cb);
+    // Validate each record in the array and if all are valid
+    // pass the array to the adapter's createEach method
+    var validateItem = function(item, next) {
+      _validate.call(self, item, next);
+    }
+
+
+    async.each(filteredValues, validateItem, function(err) {
+      if(err) return cb(err);
+
+      // Transform Values
+      var transformedValues = [];
+
+      filteredValues.forEach(function(value) {
+
+        // Transform values
+        value = self._transformer.serialize(value);
+
+        // Clean attributes
+        value = self._schema.cleanValues(value);
+        transformedValues.push(value);
+      });
+
+      // Set values array to the transformed array
+      filteredValues = transformedValues;
+
+      // Pass attributes to adapter definition
+      self.adapter.createEach(filteredValues, function(err, values) {
+        if(err) return cb(err);
+
+        // Unserialize Values
+        var unserializedValues = [];
+
+        values.forEach(function(value) {
+          value = self._transformer.unserialize(value);
+          unserializedValues.push(value);
+        });
+
+        // Set values array to the transformed array
+        values = unserializedValues;
+
+        // Run AfterCreate Callbacks
+        async.each(values, function(item, next) {
+          callbacks.afterCreate(self, item, next);
+        }, function(err) {
+          if(err) return cb(err);
+
+          var models = [];
+
+          // Make each result an instance of model
+          values.forEach(function(value) {
+            models.push(new self._model(value));
+          });
+
+          cb(null, models);
+        });
+      });
+    });
+    
     // Create will take care of cloning values so original isn't mutated
     //async.map(filteredValues, self.create.bind(self), cb);
   },

--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -57,12 +57,14 @@ module.exports = {
     var processItem = function(item, next) {
       _process.call(self, item, next);
     }
+    
+    self.processedValues = [];
 
     async.each(filteredValues, processItem, function(err) {
       if(err) return cb(err);
 
       // Pass attributes to adapter definition
-      self.adapter.createEach(filteredValues, function(err, values) {
+      self.adapter.createEach(self.processedValues, function(err, values) {
         if(err) return cb(err);
 
         // Unserialize Values
@@ -309,6 +311,8 @@ function _process(values, cb) {
     
       // Clean attributes
       valuesObject.values = self._schema.cleanValues(valuesObject.values);
+      
+      self.processedValues.push(valuesObject.values);
   
       cb();
     });

--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -51,31 +51,13 @@ module.exports = {
       return value !== undefined;
     });
     
-    // Validate each record in the array and if all are valid
-    // pass the array to the adapter's createEach method
-    var validateItem = function(item, next) {
-      _validate.call(self, item, next);
+    // process each item, their associations and beforeCreate callbacks
+    var processItem = function(item, next) {
+      _process.call(self, item, next);
     }
 
-
-    async.each(filteredValues, validateItem, function(err) {
+    async.each(filteredValues, processItem, function(err) {
       if(err) return cb(err);
-
-      // Transform Values
-      var transformedValues = [];
-
-      filteredValues.forEach(function(value) {
-
-        // Transform values
-        value = self._transformer.serialize(value);
-
-        // Clean attributes
-        value = self._schema.cleanValues(value);
-        transformedValues.push(value);
-      });
-
-      // Set values array to the transformed array
-      filteredValues = transformedValues;
 
       // Pass attributes to adapter definition
       self.adapter.createEach(filteredValues, function(err, values) {
@@ -110,8 +92,6 @@ module.exports = {
       });
     });
     
-    // Create will take care of cloning values so original isn't mutated
-    //async.map(filteredValues, self.create.bind(self), cb);
   },
 
   /**
@@ -289,4 +269,153 @@ function _validate(record, cb) {
 
     cb();
   });
+}
+
+
+/**
+ * Process item, it's associations and before callbacks
+ *
+ * @param {Object} values
+ * @param {Function} cb
+ * @api private
+ */
+
+function _process(values, cb) {
+  var self = this;
+  
+  // Process Values
+  var valuesObject = processValues.call(this, values);
+
+  // Create any of the belongsTo associations and set the foreign key values
+  createBelongsTo.call(this, valuesObject, function(err) {
+    if(err) return cb(err);
+
+    beforeCallbacks.call(self, valuesObject, function(err) {
+      if(err) return cb(err);
+
+      // Automatically add updatedAt and createdAt (if enabled)
+      if(self.autoCreatedAt && !valuesObject.values.createdAt) {
+        valuesObject.values.createdAt = new Date();
+      }
+    
+      if(self.autoUpdatedAt && !valuesObject.values.updatedAt) {
+        valuesObject.values.updatedAt = new Date();
+      }
+    
+      // Transform Values
+      valuesObject.values = self._transformer.serialize(valuesObject.values);
+    
+      // Clean attributes
+      valuesObject.values = self._schema.cleanValues(valuesObject.values);
+  
+      cb();
+    });
+  });
+}
+
+
+/**
+ * Process Values
+ *
+ * @param {Object} values
+ * @return {Object}
+ */
+
+function processValues(values) {
+
+  // Set Default Values if available
+  for(var key in this.attributes) {
+    if(!hop(values, key) && hop(this.attributes[key], 'defaultsTo')) {
+      var defaultsTo = this.attributes[key].defaultsTo;
+      values[key] = typeof defaultsTo === 'function' ? defaultsTo.call(values) : _.clone(defaultsTo);
+    }
+  }
+
+  // Pull out any associations in the values
+  var _values = _.cloneDeep(values);
+  var associations = nestedOperations.valuesParser.call(this, this.identity, this.waterline.schema, values);
+
+  // Replace associated models with their foreign key values if available
+  values = nestedOperations.reduceAssociations.call(this, this.identity, this.waterline.schema, values);
+
+  // Cast values to proper types (handle numbers as strings)
+  values = this._cast.run(values);
+
+  return { values: values, originalValues: _values, associations: associations };
+}
+
+/**
+ * Create BelongsTo Records
+ *
+ */
+
+function createBelongsTo(valuesObject, cb) {
+  var self = this;
+
+  async.each(valuesObject.associations.models, function(item, next) {
+
+    // Check if value is an object. If not don't try and create it.
+    if(!_.isPlainObject(valuesObject.values[item])) return next();
+
+    // Check for any transformations
+    var attrName = hop(self._transformer._transformations, item) ? self._transformer._transformations[item] : item;
+
+    var attribute = self._schema.schema[attrName];
+    var modelName;
+
+    if(hop(attribute, 'collection')) modelName = attribute.collection;
+    if(hop(attribute, 'model')) modelName = attribute.model;
+    if(!modelName) return next();
+
+    var model = self.waterline.collections[modelName];
+    var pkValue = valuesObject.originalValues[item][model.primaryKey];
+
+    var criteria = {};
+    criteria[model.primaryKey] = pkValue;
+
+    // If a pkValue if found, do a findOrCreate and look for a record matching the pk.
+    var query;
+    if(pkValue) {
+      query = model.findOrCreate(criteria, valuesObject.values[item]);
+    } else {
+      query = model.create(valuesObject.values[item]);
+    }
+
+    query.exec(function(err, val) {
+      if(err) return next(err);
+
+      // attach the new model's pk value to the original value's key
+      var pk = val[model.primaryKey];
+
+      valuesObject.values[item] = pk;
+      next();
+    });
+
+  }, cb);
+}
+
+/**
+ * Run Before* Lifecycle Callbacks
+ *
+ * @param {Object} valuesObject
+ * @param {Function} cb
+ */
+
+function beforeCallbacks(valuesObject, cb) {
+  var self = this;
+
+  async.series([
+
+    // Run Validation with Validation LifeCycle Callbacks
+    function(cb) {
+      callbacks.validate(self, valuesObject.values, false, cb);
+    },
+
+    // Before Create Lifecycle Callback
+    function(cb) {
+      callbacks.beforeCreate(self, valuesObject.values, cb);
+    }
+
+  ], cb);
+
 }

--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -9,6 +9,7 @@ var async = require('async'),
     normalize = require('../utils/normalize'),
     callbacks = require('../utils/callbacksRunner'),
     Deferred = require('./deferred'),
+    nestedOperations = require('../utils/nestedOperations'),
     hasOwnProperty = utils.object.hasOwnProperty,
     hop = utils.object.hasOwnProperty;
 

--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -9,7 +9,8 @@ var async = require('async'),
     normalize = require('../utils/normalize'),
     callbacks = require('../utils/callbacksRunner'),
     Deferred = require('./deferred'),
-    hasOwnProperty = utils.object.hasOwnProperty;
+    hasOwnProperty = utils.object.hasOwnProperty,
+    hop = utils.object.hasOwnProperty;
 
 module.exports = {
 

--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -53,7 +53,16 @@ module.exports = {
       return value !== undefined;
     });
     
-    // process each item, their associations and beforeCreate callbacks
+    // check if adapter implements createEach
+    // if it doesn't then don't process, just pass values to create method
+    if(!hasOwnProperty(self.adapter.dictionary, 'createEach')) {
+      // Create will take care of cloning values so original isn't mutated
+      async.map(filteredValues, self.create.bind(self), cb);
+      return;
+    }
+    
+    // Adapter implements createEach, so let's process each item, 
+    // their associations and beforeCreate callbacks
     var processItem = function(item, next) {
       _process.call(self, item, next);
     }

--- a/test/unit/query/query.createEach.adapterMethod.js
+++ b/test/unit/query/query.createEach.adapterMethod.js
@@ -62,7 +62,7 @@ describe('Collection Query', function() {
 
 
       it('should call adapters createEach method', function(done) {
-        query.createEach([{ name: 'bob' }, { name: 'foo'}], function(err, values) {
+        query.create([{ name: 'bob' }, { name: 'foo'}], function(err, values) {
           assert(!err);
           assert(values);
           assert.equal(values[0].name, 'bob');

--- a/test/unit/query/query.createEach.adapterMethod.js
+++ b/test/unit/query/query.createEach.adapterMethod.js
@@ -1,0 +1,72 @@
+var Waterline = require('../../../lib/waterline'),
+    assert = require('assert');
+
+describe('Collection Query', function() {
+
+  describe('.createEach()', function() {
+
+    describe('with adapter implemented createEach()', function() {
+      var query;
+
+      before(function(done) {
+
+        var waterline = new Waterline();
+        var Model = Waterline.Collection.extend({
+          identity: 'user',
+          connection: 'foo',
+          attributes: {
+            first:{
+              type: 'string',
+              defaultsTo: 'Foo'
+            },
+            second: {
+              type: 'string',
+              defaultsTo: 'Bar'
+            },
+            full: {
+              type: 'string',
+              defaultsTo: function() { return this.first + ' ' + this.second; }
+            },
+            name: {
+              type: 'string',
+              defaultsTo: 'Foo Bar'
+            },
+            arr: {
+              type: 'array',
+              defaultsTo: []
+            },
+            doSomething: function() {}
+          }
+        });
+
+        waterline.loadCollection(Model);
+
+        // Fixture Adapter Def
+        var adapterDef = { createEach: function(con, col, values, cb) { return cb(null, values); }};
+
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+          if(err) return done(err);
+          query = colls.collections.user;
+          done();
+        });
+      });
+
+
+      it('should call adapters createEach method', function(done) {
+        query.createEach([{},{}], function(err, values) {
+          assert(Array.isArray(values));
+          done();
+        });
+      });
+
+      
+    });
+
+  });
+});

--- a/test/unit/query/query.createEach.adapterMethod.js
+++ b/test/unit/query/query.createEach.adapterMethod.js
@@ -42,7 +42,10 @@ describe('Collection Query', function() {
         waterline.loadCollection(Model);
 
         // Fixture Adapter Def
-        var adapterDef = { createEach: function(con, col, values, cb) { return cb(null, values); }};
+        var adapterDef = { 
+          create: function(con, col, values, cb) { values.name = 'no name'; return cb(null, values); },
+          createEach: function(con, col, values, cb) { return cb(null, values); }
+        };
 
         var connections = {
           'foo': {
@@ -59,8 +62,11 @@ describe('Collection Query', function() {
 
 
       it('should call adapters createEach method', function(done) {
-        query.createEach([{},{}], function(err, values) {
-          assert(Array.isArray(values));
+        query.createEach([{ name: 'bob' }, { name: 'foo'}], function(err, values) {
+          assert(!err);
+          assert(values);
+          assert.equal(values[0].name, 'bob');
+          assert.equal(values[1].name, 'foo');
           done();
         });
       });


### PR DESCRIPTION
Sending createEach values to adapter's optimized .createEach() method
Will fallback to normal create if adapter doesn't implement .createEach()
This fixes #1007 