### PR TITLE
Nested create/updates with a custom pk fix

### DIFF
--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -127,7 +127,7 @@ Add.prototype.createAssociations = function(key, records, cb) {
       // If a custom PK was used on the associated collection and it's not
       // autoIncrementing, create the record. This allows nested
       // creates to work when custom PK's are used.
-      if(!relatedPK.autoIncrement && !associatedCollection.autoPK) {
+      if(!relatedPK || !relatedPK.autoIncrement && !associatedCollection.autoPK) {
         return self.createNewRecord(associatedCollection, schema, association, next);
       }
 

--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -114,6 +114,7 @@ Add.prototype.createAssociations = function(key, records, cb) {
   var attribute = this.collection._attributes[key];
   var collectionName = attribute.collection.toLowerCase();
   var associatedCollection = this.collection.waterline.collections[collectionName];
+  var relatedPK =  _.find(associatedCollection.attributes, { primaryKey: true });
   var schema = this.collection.waterline.schema[this.collection.identity].attributes[key];
 
   // Limit Adds to 10 at a time to prevent the connection pool from being exhausted
@@ -122,6 +123,13 @@ Add.prototype.createAssociations = function(key, records, cb) {
     // If an object was passed in it should be created.
     // This allows new records to be created through the association interface
     if(association !== null && typeof association === 'object' && Object.keys(association).length > 0) {
+
+      // If a custom PK was used on the associated collection and it's not
+      // autoIncrementing, create the record. This allows nested
+      // creates to work when custom PK's are used.
+      if(!relatedPK.autoIncrement && !associatedCollection.autoPK) {
+        return self.createNewRecord(associatedCollection, schema, association, next);
+      }
 
       // Check if the record contains a primary key, if so just link the values
       if(hasOwnProperty(association, associatedCollection.primaryKey)) {

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -98,8 +98,9 @@ function processValues(values) {
   var _values = _.cloneDeep(values);
   var associations = nestedOperations.valuesParser.call(this, this.identity, this.waterline.schema, values);
 
-  // Replace associated models with their foreign key values if available
-  values = nestedOperations.reduceAssociations.call(this, this.identity, this.waterline.schema, values);
+  // Replace associated models with their foreign key values if available.
+  // Unless the association has a custom primary key (we want to create the object)
+  values = nestedOperations.reduceAssociations.call(this, this.identity, this.waterline.schema, values, 'create');
 
   // Cast values to proper types (handle numbers as strings)
   values = this._cast.run(values);

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -76,8 +76,9 @@ function prepareArguments(criteria, values) {
   var _values = _.cloneDeep(values);
   var associations = nestedOperations.valuesParser.call(this, this.identity, this.waterline.schema, values);
 
-  // Replace associated models with their foreign key values if available
-  values = nestedOperations.reduceAssociations.call(this, this.identity, this.waterline.schema, values);
+  // Replace associated models with their foreign key values if available.
+  // Unless the association has a custom primary key (we want to create the object)
+  values = nestedOperations.reduceAssociations.call(this, this.identity, this.waterline.schema, values, 'update');
 
   // Cast values to proper types (handle numbers as strings)
   values = this._cast.run(values);

--- a/lib/waterline/utils/nestedOperations/create.js
+++ b/lib/waterline/utils/nestedOperations/create.js
@@ -28,6 +28,11 @@ module.exports = function(parentModel, values, associations, cb) {
 
     if(!modelName) return;
 
+    // Grab the relation's PK
+    var related = self.waterline.collections[modelName];
+    var relatedPK = _.find(related.attributes, { primaryKey: true });
+
+    // Get the attribute's name
     var pk = self.waterline.collections[modelName].primaryKey;
 
     var optValues = values[association];
@@ -41,9 +46,15 @@ module.exports = function(parentModel, values, associations, cb) {
       if(!_.isPlainObject(val)) return parentModel[association].add(val);
 
       // If value is an object, check if a primary key is defined
-      if(hasOwnProperty(val, pk)) return parentModel[association].add(val[pk]);
-
-      parentModel[association].add(val);
+      // If a custom PK was used and it's not autoIncrementing and the record
+      // is being created then go ahead and don't reduce it. This allows nested
+      // creates to work when custom PK's are used.
+      if(relatedPK.autoIncrement && related.autoPK && hasOwnProperty(val, pk)) {
+        return parentModel[association].add(val[pk]);
+      }
+      else {
+        parentModel[association].add(val);
+      }
     });
   });
 

--- a/lib/waterline/utils/nestedOperations/reduceAssociations.js
+++ b/lib/waterline/utils/nestedOperations/reduceAssociations.js
@@ -53,7 +53,7 @@ module.exports = function(model, schema, values, method) {
     // If a custom PK was used and it's not autoIncrementing and the record
     // is being created then go ahead and don't reduce it. This allows nested
     // creates to work when custom PK's are used.
-    if(!relatedPK.autoIncrement && !related.autoPK && method && method == 'create') {
+    if(!relatedPK.autoIncrement && !related.autoPK && method && (method == 'create' || method == 'update')) {
       return;
     }
 

--- a/lib/waterline/utils/nestedOperations/reduceAssociations.js
+++ b/lib/waterline/utils/nestedOperations/reduceAssociations.js
@@ -19,7 +19,8 @@ var util = require('util');
  */
 
 
-module.exports = function(model, schema, values) {
+module.exports = function(model, schema, values, method) {
+  var self = this;
 
   Object.keys(values).forEach(function(key) {
 
@@ -34,7 +35,6 @@ module.exports = function(model, schema, values) {
         return;
       }
     }
-
     // Check that this user-specified value is not NULL
     if(values[key] === null) return;
 
@@ -44,8 +44,23 @@ module.exports = function(model, schema, values) {
     if (typeof attribute !== 'object') return;
 
     if(!hop(values[key], attribute.on)) return;
+
+    // Look and see if the related model has a custom primary key AND that
+    // the intended method is "create"
+    var related = self.waterline.collections[attribute.references];
+    var relatedPK = _.find(related.attributes, { primaryKey: true });
+
+    // If a custom PK was used and it's not autoIncrementing and the record
+    // is being created then go ahead and don't reduce it. This allows nested
+    // creates to work when custom PK's are used.
+    if(!relatedPK.autoIncrement && !related.autoPK && method && method == 'create') {
+      return;
+    }
+
+    // Otherwise reduce the association like normal
     var fk = values[key][attribute.on];
     values[key] = fk;
+
   });
 
   return values;

--- a/lib/waterline/utils/nestedOperations/update.js
+++ b/lib/waterline/utils/nestedOperations/update.js
@@ -95,7 +95,10 @@ function queueOperations(parents, association, operation, values) {
   if(!modelName) return;
 
   var collection = self.waterline.collections[modelName];
-  var modelPk = collection.primaryKey;
+
+  // Grab the relation's PK
+  var relatedPK = _.find(collection.attributes, { primaryKey: true });
+  var relatedPkName = collection.primaryKey;
 
   // If this is a join table, we can just queue up operations on the parent
   // for this association.
@@ -119,27 +122,36 @@ function queueOperations(parents, association, operation, values) {
     // the schema attribute and check if this is a collection or model attribute. If it's
     // a collection attribute lets update the child record and if it's a model attribute,
     // update the child and set the parent's foreign key value to the new primary key.
-    if(!hop(val, modelPk)) {
+    //
+    // If a custom PK was used and it's not autoIncrementing add the record. This
+    // allows nested creates to work when custom PK's are used.
+    if(!relatedPK.autoIncrement && !collection.autoPK) {
+      operation.add.push(val);
+      return;
+    }
+
+    // If it's missing a PK queue up an add
+    if(!hop(val, relatedPkName)) {
       operation.add.push(val);
       return;
     }
 
     // Build up the criteria that will be used to update the child record
     var criteria = {};
-    criteria[modelPk] = val[modelPk];
+    criteria[relatedPkName] = val[relatedPkName];
 
     // Queue up the update operation
     operation.update.push({ model: modelName, criteria: criteria, values: val });
 
     // Check if the parents foreign key needs to be updated
     if(!hop(attribute, 'foreignKey')) {
-      operation.add.push(val[modelPk]);
+      operation.add.push(val[relatedPkName]);
       return;
     }
 
     // Set the new foreign key value for each parent
     parents.forEach(function(parent) {
-      parent[association] = val[modelPk];
+      parent[association] = val[relatedPkName];
     });
 
   });


### PR DESCRIPTION
This should fix #519 and #675. The issue was that when doing nested operations if the primaryKey was used then it assumed that the record already existed and would not try and create it. This was obviously a problem when you have non auto-incrementing primary keys where you need to specify the value.

Nested operations aren't my favorite thing but we should make what's there work. So what this does is check if the attribute is not auto-incrementing and that default autoPK flag is set to false and it's a create  or update method. If so it will let nested updates do it's thing. Otherwise it works as before and will just link the records together.

If someone else wouldn't mind giving this a quick test that would be great. @RWOverdijk would be great to test on mongo!