### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,12 +59,7 @@
   "engines": {
     "node": "*"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/balderdashy/waterline/blob/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/balderdashy/waterline/issues/new"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/