### PR TITLE
Hotfix/update on create

### DIFF
--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -26,6 +26,10 @@ module.exports = function(context, mixins) {
 
   var prototypeFns = {
 
+    getPrimaryKey : function () {
+      return context.primaryKey;
+    },
+
     toObject: function() {
       return new defaultMethods.toObject(context, this);
     },
@@ -38,12 +42,12 @@ module.exports = function(context, mixins) {
       return new defaultMethods.destroy(context, this, cb);
     },
 
-    dirty: function(attribute) {
-      return defaultMethods.dirty(context, this, attribute);
+    dirty: function(properties) {
+      return defaultMethods.dirty(context, this, properties);
     },
 
-    clean: function(attribute) {
-      defaultMethods.dirty.clean(context, this, attribute);
+    clean: function(properties) {
+      defaultMethods.dirty.clean(this, properties);
     },
 
     _defineAssociations: function() {

--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -38,6 +38,14 @@ module.exports = function(context, mixins) {
       return new defaultMethods.destroy(context, this, cb);
     },
 
+    dirty: function(attribute) {
+      return defaultMethods.dirty(context, this, attribute);
+    },
+
+    clean: function(attribute) {
+      defaultMethods.dirty.clean(context, this, attribute);
+    },
+
     _defineAssociations: function() {
       new internalMethods.defineAssociations(context, this);
     },

--- a/lib/waterline/model/lib/associationMethods/update.js
+++ b/lib/waterline/model/lib/associationMethods/update.js
@@ -23,7 +23,7 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
 
   var values = typeof proto.toObject === 'function' ? proto.toObject() : proto;
   var attributes = collection.waterline.schema[collection.identity].attributes;
-  var primaryKey = this.findPrimaryKey(attributes, values); // @todo test if `collection.primaryKey` also works.
+  var primaryKey = this.findPrimaryKey(attributes, values);
 
   if(!primaryKey) return cb(new Error('No Primary Key set to update the record with! ' +
     'Try setting an attribute as a primary key or include an ID property.'));

--- a/lib/waterline/model/lib/associationMethods/update.js
+++ b/lib/waterline/model/lib/associationMethods/update.js
@@ -37,7 +37,7 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
 
   // Clone values so they can be mutated
   var _values = _.cloneDeep(values);
-  
+
   // For any nested model associations (objects not collection arrays) that were not changed,
   // lets set the value to just the foreign key so that an update query is not performed on the
   // associatied model.
@@ -48,11 +48,11 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
     // One reason for this is that the result set is not guaranteed to be complete,
     // so the sync could exclude items.
     if (attributes[key] && hop(attributes[key], 'collection') && attributes[key].collection) {
-      
+
       delete _values[key];
       return;
     }
-  
+
     // If the key was changed, keep it expanded
     if(mutatedModels.indexOf(key) !== -1) return;
 
@@ -65,7 +65,11 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
     var reduced = nestedOperations.reduceAssociations(collection.identity, collection.waterline.schema, vals);
     _values = _.merge(_values, reduced);
   });
-  
+
+  if (!mutatedModels.length) {
+    return cb(null, proto);
+  }
+
   // Update the collection with the new values
   collection.update(criteria, _values, cb);
 };

--- a/lib/waterline/model/lib/associationMethods/update.js
+++ b/lib/waterline/model/lib/associationMethods/update.js
@@ -23,7 +23,7 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
 
   var values = typeof proto.toObject === 'function' ? proto.toObject() : proto;
   var attributes = collection.waterline.schema[collection.identity].attributes;
-  var primaryKey = this.findPrimaryKey(attributes, values);
+  var primaryKey = this.findPrimaryKey(attributes, values); // @todo test if `collection.primaryKey` also works.
 
   if(!primaryKey) return cb(new Error('No Primary Key set to update the record with! ' +
     'Try setting an attribute as a primary key or include an ID property.'));
@@ -40,7 +40,7 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
 
   // For any nested model associations (objects not collection arrays) that were not changed,
   // lets set the value to just the foreign key so that an update query is not performed on the
-  // associatied model.
+  // associated model.
   var keys = _.keys(_values);
   keys.forEach(function(key) {
 
@@ -65,10 +65,6 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
     var reduced = nestedOperations.reduceAssociations(collection.identity, collection.waterline.schema, vals);
     _values = _.merge(_values, reduced);
   });
-
-  if (!mutatedModels.length) {
-    return cb(null, proto);
-  }
 
   // Update the collection with the new values
   collection.update(criteria, _values, cb);

--- a/lib/waterline/model/lib/defaultMethods/dirty.js
+++ b/lib/waterline/model/lib/defaultMethods/dirty.js
@@ -1,40 +1,171 @@
 var _ = require('lodash');
-var diff = require('deep-diff').diff;
 
 /**
- * Model.dirty()
+ * Model.dirty([properties])
  *
- * Returns whether the given attribute has changed since instantiation.
+ * Returns the dirty properties of the model.
  *
- * @param {Object} context
- * @param {Object} proto
- * @param {Object} attributes
- * @return bool
+ * @param {Object}       context
+ * @param {Object}       current
+ * @param {Array|string} [properties] Property or array of properties to check. Defaults to all.
+ *
+ * @returns {boolean|object} false when clean, object of diff when dirty.
+ *
  * @api public
  */
-module.exports = function(context, proto, attribute) {
-    var comp = diff(proto._originalValues[attribute], proto[attribute]);
+module.exports = function (context, current, properties) {
+  var currentObject = current.toObject(),
+      original      = current._originalValues,
+      diffs         = {},
+      isDirty;
 
-    return typeof comp !== 'undefined';
-};
-
-/**
- * Model.clean()
- *
- * Resets the "dirty" state.
- *
- * @param {Object} context
- * @param {Object} proto
- * @param {Object} attributes
- * @return void
- * @api public
- */
-module.exports.clean = function (context, proto, attribute) {
-    if (typeof attribute === 'undefined') {
-        for (var key in proto) {
-            proto._originalValues[key] = _.cloneDeep(proto[key]);
-        }
-    } else {
-        proto._originalValues[attribute] = _.cloneDeep(proto[attribute]);
+  // Are we going to use all, or a subset of properties?
+  if (properties) {
+    // A subset... For dev simplicity, guarantee an array.
+    if (!Array.isArray(properties)) {
+      properties = [properties];
     }
+  } else {
+    // All properties.
+    properties = Object.getOwnPropertyNames(currentObject);
+  }
+
+  properties.forEach(function (key) {
+    var value = currentObject[key],
+        associationDiff;
+
+    // Key isn't set or has undefined value. So no diff.
+    if (typeof value === 'undefined') {
+      return;
+    }
+
+    // If the key doesn't exist at all on the original, it's a diff.
+    if (typeof original[key] === 'undefined') {
+      return diffs[key] = value;
+    }
+
+    // If it's an association, check the association for differences.
+    if ((_.isPlainObject(value) || _.isArray(value)) && current.associations[key]) {
+      associationDiff = diffAssociations(key, current, context);
+
+      // If the association property had a diff, add it to the diff object.
+      if (associationDiff) {
+        diffs[key] = associationDiff;
+      }
+    } else if (!_.isEqual(value, original[key])) { // If none of the above was true, compare by content.
+      diffs[key] = value;
+    }
+  });
+
+  isDirty = !_.isEmpty(diffs);
+
+  // The record is dirty. Add the PK if it exists. This is needed for update in assoc and harmless otherwise.
+  if (isDirty && current[context.primaryKey]) {
+    diffs[context.primaryKey] = current[context.primaryKey];
+  }
+
+  return isDirty ? diffs : false;
 };
+
+/**
+ * Model.clean([properties])
+ *
+ * Set the current state of the model as "clean". Primarily useful after calling `.update()`.
+ *
+ * @param {Object}       proto        The model
+ * @param {String|array} [properties] A specific property, or array of properties to mark as clean. Defaults to all.
+ *
+ * @returns {Object} the model instance.
+ * @api public
+ */
+module.exports.clean = function (current, properties) {
+  var currentObject = current.toObject();
+
+  // If there were no properties supplied, simply renew the entire _originalValues.
+  if (!properties) {
+    properties = Object.getOwnPropertyNames(currentObject);
+  }
+
+  // Guarantee array for dev simplicity.
+  if (!Array.isArray(properties)) {
+    properties = [properties];
+  }
+
+  properties.forEach(function (property) {
+
+    // Nothing to clean if property doesn't exist on currentObject.
+    if (!currentObject[property]) {
+      return;
+    }
+
+    // Regular value? Overwrite.
+    if (!current.associations[property]) {
+      return current._originalValues[property] = currentObject[property];
+    }
+
+    // Try calling child.clean()
+    if (typeof current[property].clean === 'function') {
+      return current[property].clean();
+    }
+
+    // Can't... So it must be a *2m assoc.
+    if (!Array.isArray(current[property])) {
+      return;
+    }
+
+    // Loop through children, and call clean.
+    current[property].forEach(function (assoc) {
+      typeof assoc.clean === 'function' && assoc.clean();
+    });
+  });
+
+  // All done.
+  return current;
+};
+
+/**
+ * Diff association.
+ *
+ * @param {String} associationKey
+ * @param {Object} parent
+ * @param {Object} context
+ *
+ * @returns {Array|false}
+ */
+function diffAssociations (associationKey, parent, context) {
+  var associations = parent[associationKey],
+      diffs        = [];
+
+  // Guarantee array for dev simplicity.
+  if (!Array.isArray(associations)) {
+    associations = [associations];
+  }
+
+  // Loop through all associations (o2o, or *2m doesn't matter.).
+  associations.forEach(function (association) {
+    var associationDiff;
+
+    // If this model isn't an instance, it's a diff by default (create or add).
+    if (typeof association !== 'object' || typeof association.dirty !== 'function') {
+      return diffs.push(association);
+    }
+
+    // Diff the association.
+    associationDiff = association.dirty();
+
+    // If the association didn't have a diff, return.
+    if (!associationDiff) {
+      return;
+    }
+
+    // Push diff to stack.
+    diffs.push(associationDiff);
+
+    // If the association has a property set for PK, set it on the diffed object (needed for proper update).
+    if (association[context.primaryKey]) {
+      associationDiff[context.primaryKey] = association[context.primaryKey];
+    }
+  });
+
+  return diffs.length ? diffs : false;
+}

--- a/lib/waterline/model/lib/defaultMethods/dirty.js
+++ b/lib/waterline/model/lib/defaultMethods/dirty.js
@@ -124,48 +124,64 @@ module.exports.clean = function (current, properties) {
 };
 
 /**
- * Diff association.
+ * Diff associations (collection).
  *
  * @param {String} associationKey
  * @param {Object} parent
  * @param {Object} context
  *
- * @returns {Array|false}
+ * @returns {Array|Object|false}
  */
 function diffAssociations (associationKey, parent, context) {
-  var associations = parent[associationKey],
-      diffs        = [];
+  var associations = parent[associationKey];
 
-  // Guarantee array for dev simplicity.
+  // If not array, diff as single association. All the single associations, all the single associations. Oh, oh, oh.
   if (!Array.isArray(associations)) {
-    associations = [associations];
+    return diffAssociation(associations, context);
   }
 
-  // Loop through all associations (o2o, or *2m doesn't matter.).
+  var diffs = [];
+
+  // Loop through all associations.
   associations.forEach(function (association) {
-    var associationDiff;
+    var diff = diffAssociation(association, context);
 
-    // If this model isn't an instance, it's a diff by default (create or add).
-    if (typeof association !== 'object' || typeof association.dirty !== 'function') {
-      return diffs.push(association);
-    }
-
-    // Diff the association.
-    associationDiff = association.dirty();
-
-    // If the association didn't have a diff, return.
-    if (!associationDiff) {
-      return;
-    }
-
-    // Push diff to stack.
-    diffs.push(associationDiff);
-
-    // If the association has a property set for PK, set it on the diffed object (needed for proper update).
-    if (association[context.primaryKey]) {
-      associationDiff[context.primaryKey] = association[context.primaryKey];
+    if (diff) {
+      diffs.push(diff);
     }
   });
 
   return diffs.length ? diffs : false;
+}
+
+/**
+ * Diff a single association.
+ *
+ * @param {Object} association
+ * @param {Object} context
+ *
+ * @returns {Object}
+ */
+function diffAssociation (association, context) {
+  var associationDiff;
+
+  // If this model isn't an instance, it's a diff by default (create or add).
+  if (typeof association !== 'object' || typeof association.dirty !== 'function') {
+    return association;
+  }
+
+  // Diff the association.
+  associationDiff = association.dirty();
+
+  // If the association didn't have a diff, return.
+  if (!associationDiff) {
+    return false;
+  }
+
+  // If the association has a property set for PK, set it on the diffed object (needed for proper update).
+  if (association[context.primaryKey]) {
+    associationDiff[context.primaryKey] = association[context.primaryKey];
+  }
+
+  return associationDiff;
 }

--- a/lib/waterline/model/lib/defaultMethods/dirty.js
+++ b/lib/waterline/model/lib/defaultMethods/dirty.js
@@ -1,0 +1,40 @@
+var _ = require('lodash');
+var diff = require('deep-diff').diff;
+
+/**
+ * Model.dirty()
+ *
+ * Returns whether the given attribute has changed since instantiation.
+ *
+ * @param {Object} context
+ * @param {Object} proto
+ * @param {Object} attributes
+ * @return bool
+ * @api public
+ */
+module.exports = function(context, proto, attribute) {
+    var comp = diff(proto._originalValues[attribute], proto[attribute]);
+
+    return typeof comp !== 'undefined';
+};
+
+/**
+ * Model.clean()
+ *
+ * Resets the "dirty" state.
+ *
+ * @param {Object} context
+ * @param {Object} proto
+ * @param {Object} attributes
+ * @return void
+ * @api public
+ */
+module.exports.clean = function (context, proto, attribute) {
+    if (typeof attribute === 'undefined') {
+        for (var key in proto) {
+            proto._originalValues[key] = _.cloneDeep(proto[key]);
+        }
+    } else {
+        proto._originalValues[attribute] = _.cloneDeep(proto[attribute]);
+    }
+};

--- a/lib/waterline/model/lib/defaultMethods/index.js
+++ b/lib/waterline/model/lib/defaultMethods/index.js
@@ -6,5 +6,6 @@
 module.exports = {
   toObject: require('./toObject'),
   destroy: require('./destroy'),
-  save: require('./save')
+  save: require('./save'),
+  dirty: require('./dirty')
 };

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -170,8 +170,8 @@ module.exports = function(context, proto, cb) {
     // Rebuild proper criteria object from the original query
     var PK = context.primaryKey;
 
-    if(!Array.isArray(results.updateRecord)) {
-      if (results.updateRecord) {
+    if(!results.updateRecord.length) {
+      if (!Array.isArray(results.updateRecord)) {
         return cb (null, results.updateRecord);
       }
 

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -21,7 +21,7 @@ var noop = function() {};
  * @api public
  */
 
-module.exports = function(context, proto, cb, associationsOnly) {
+module.exports = function(context, proto, cb) {
 
   var deferred;
 

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -31,55 +31,32 @@ module.exports = function(context, proto, cb) {
 
   cb = cb || noop;
 
+  var dirtyProperties = proto.dirty(),
+      mutatedModels   = [];
+
+  _.forIn(proto.associations, function (value, key) {
+    if (dirtyProperties[key]) {
+      mutatedModels.push(key);
+    }
+  });
+
   /**
-   * TO-DO:
-   * This should all be wrapped in a transaction. That's coming next but for the meantime
-   * just hope we don't get in a nasty state where the operation fails!
+   * @todo This should all be wrapped in a transaction. That's coming next but for the meantime
+   * @todo just hope we don't get in a nasty state where the operation fails!
    */
-
-  var mutatedModels = [];
-
   async.auto({
+    updateRecord: function(next) {
+      if (false === dirtyProperties) {
+        return next();
+      }
 
-    // Compare any populated model values to their current state.
-    // If they have been mutated then the values will need to be synced.
-    compareModelValues: function(next) {
-      var modelKeys = Object.keys(proto.associationsCache);
-
-      async.each(modelKeys, function(key, nextKey) {
-
-        if(!hop(proto, key) || proto[key] === undefined) return nextKey();
-
-        var currentVal = proto[key];
-        var previousVal = proto.associationsCache[key];
-
-        // Normalize previousVal to an object
-        if(Array.isArray(previousVal)) previousVal = previousVal[0];
-
-        if(deep(currentVal, previousVal)) {
-          mutatedModels.push(key);
-        }
-
-        nextKey();
-      }, next);
+      new updateInstance(context, dirtyProperties, mutatedModels, next);
     },
-
-    // Update The Current Record
-    updateRecord: ['compareModelValues', function(next) {
-
-      // Shallow clone proto.toObject() to remove all the functions
-      var data = _.clone(proto.toObject());
-
-      new updateInstance(context, data, mutatedModels, function(err, data) {
-        next(err, data);
-      });
-    }],
-
 
     // Build a set of associations to add and remove.
     // These are populated from using model[associationKey].add() and
     // model[associationKey].remove().
-    buildAssociationOperations: ['compareModelValues', function(next) {
+    buildAssociationOperations: function(next) {
 
       // Build a dictionary to hold operations based on association key
       var operations = {
@@ -104,7 +81,7 @@ module.exports = function(context, proto, cb) {
       });
 
       return next(null, operations);
-    }],
+    },
 
     // Create new associations for each association key
     addAssociations: ['buildAssociationOperations', 'updateRecord', function(next, results) {
@@ -138,7 +115,6 @@ module.exports = function(context, proto, cb) {
         next(null, failedTransactions);
       });
     }]
-
   },
 
   function(err, results) {
@@ -170,19 +146,26 @@ module.exports = function(context, proto, cb) {
     // Rebuild proper criteria object from the original query
     var PK = context.primaryKey;
 
-    if(!results.updateRecord.length) {
-      if (!Array.isArray(results.updateRecord)) {
-        return cb (null, results.updateRecord);
-      }
-
+    if (typeof results.updateRecord !== 'undefined' && !results.updateRecord.length) {
       var error = new Error('Error updating a record.');
       if(deferred) {
         deferred.reject(error);
       }
+
       return cb(error);
     }
 
-    var obj = results.updateRecord[0].toObject();
+    if (dirtyProperties) {
+      proto.clean();
+    }
+
+    if (typeof results.updateRecord === 'undefined') {
+      results.updateRecord = proto;
+    } else {
+      results.updateRecord = results.updateRecord[0];
+    }
+
+    var obj = results.updateRecord.toObject();
     var populations = Object.keys(proto.associations);
     var criteria = {};
     criteria[PK] = obj[PK];

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -21,8 +21,8 @@ var noop = function() {};
  * @api public
  */
 
-module.exports = function(context, proto, cb) {
-  
+module.exports = function(context, proto, cb, associationsOnly) {
+
   var deferred;
 
   if(typeof cb !== 'function') {
@@ -167,10 +167,12 @@ module.exports = function(context, proto, cb) {
       return cb(failedTransactions);
     }
 
+    results.updateRecord = Array.isArray(results.updateRecord) ? results.updateRecord[0].toObject() : results.updateRecord;
+
     // Rebuild proper criteria object from the original query
     var PK = context.primaryKey;
 
-    if(!results.updateRecord.length) {
+    if(!results.updateRecord) {
       var error = new Error('Error updating a record.');
       if(deferred) {
         deferred.reject(error);
@@ -178,7 +180,7 @@ module.exports = function(context, proto, cb) {
       return cb(error);
     }
 
-    var obj = results.updateRecord[0].toObject();
+    var obj = results.updateRecord;
     var populations = Object.keys(proto.associations);
     var criteria = {};
     criteria[PK] = obj[PK];

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -167,12 +167,14 @@ module.exports = function(context, proto, cb) {
       return cb(failedTransactions);
     }
 
-    results.updateRecord = Array.isArray(results.updateRecord) ? results.updateRecord[0].toObject() : results.updateRecord;
-
     // Rebuild proper criteria object from the original query
     var PK = context.primaryKey;
 
-    if(!results.updateRecord) {
+    if(!Array.isArray(results.updateRecord)) {
+      if (results.updateRecord) {
+        return cb (null, results.updateRecord);
+      }
+
       var error = new Error('Error updating a record.');
       if(deferred) {
         deferred.reject(error);
@@ -180,7 +182,7 @@ module.exports = function(context, proto, cb) {
       return cb(error);
     }
 
-    var obj = results.updateRecord;
+    var obj = results.updateRecord[0].toObject();
     var populations = Object.keys(proto.associations);
     var criteria = {};
     criteria[PK] = obj[PK];

--- a/lib/waterline/model/lib/internalMethods/defineAssociations.js
+++ b/lib/waterline/model/lib/internalMethods/defineAssociations.js
@@ -29,15 +29,6 @@ var Define = module.exports = function(context, proto) {
     value: {}
   });
 
-  // Build associations cache to hold original values.
-  // Used to check if values have been mutated and need to be synced when
-  // a model.save call is made.
-  Object.defineProperty(proto, 'associationsCache', {
-    enumerable: false,
-    writable: true,
-    value: {}
-  });
-
   var attributes = context._attributes || {};
   var collections = this.collectionKeys(attributes);
   var models = this.modelKeys(attributes);
@@ -128,7 +119,4 @@ Define.prototype.buildBelongsToProperty = function(model) {
 
   // Attach to a non-enumerable property
   this.proto.associations[model.key] = model.val;
-
-  // Build a cache for this model
-  this.proto.associationsCache[model.key] = {};
 };

--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -41,9 +41,17 @@ var Model = module.exports = function(attrs, options) {
   // Build association getters and setters
   this._defineAssociations();
 
+  // List of original attributes of the object, so we know what is dirty!
+  Object.defineProperty(this, '_originalValues', {
+    enumerable: false,
+    value: {}
+  });
+
   // Attach attributes to the model instance
   for(var key in attrs) {
     this[key] = attrs[key];
+    // Add a copy of the attribute to the cache.
+    this._originalValues[key] = _.cloneDeep(attrs[key]);
 
     if(this.associationsCache.hasOwnProperty(key)) {
       this.associationsCache[key] = _.cloneDeep(attrs[key]);

--- a/lib/waterline/model/lib/model.js
+++ b/lib/waterline/model/lib/model.js
@@ -41,25 +41,20 @@ var Model = module.exports = function(attrs, options) {
   // Build association getters and setters
   this._defineAssociations();
 
-  // List of original attributes of the object, so we know what is dirty!
-  Object.defineProperty(this, '_originalValues', {
-    enumerable: false,
-    value: {}
-  });
-
   // Attach attributes to the model instance
   for(var key in attrs) {
     this[key] = attrs[key];
-    // Add a copy of the attribute to the cache.
-    this._originalValues[key] = _.cloneDeep(attrs[key]);
-
-    if(this.associationsCache.hasOwnProperty(key)) {
-      this.associationsCache[key] = _.cloneDeep(attrs[key]);
-    }
   }
 
   // Normalize associations
   this._normalizeAssociations();
+
+  // List of original attributes of the object, so we know what is dirty!
+  Object.defineProperty(this, '_originalValues', {
+    enumerable: false,
+    writable: true,
+    value: self.toObject()
+  });
 
 
   /**

--- a/lib/waterline/utils/nestedOperations/create.js
+++ b/lib/waterline/utils/nestedOperations/create.js
@@ -41,7 +41,6 @@ module.exports = function(parentModel, values, associations, cb) {
     	optValues = _.isString(optValues) ? optValues.split(',') : [optValues];
     }
     optValues.forEach(function(val) {
-
       // If value is not an object, queue up an add
       if(!_.isPlainObject(val)) return parentModel[association].add(val);
 
@@ -52,9 +51,8 @@ module.exports = function(parentModel, values, associations, cb) {
       if(relatedPK.autoIncrement && related.autoPK && hasOwnProperty(val, pk)) {
         return parentModel[association].add(val[pk]);
       }
-      else {
-        parentModel[association].add(val);
-      }
+
+      parentModel[association].add(val);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "waterline-schema": "~0.1.17"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
     "codeclimate-test-reporter": "0.0.4",
     "istanbul": "~0.3.14",
     "mocha": "~2.2.5",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
     "waterline-schema": "~0.1.17"
   },
   "devDependencies": {
+    "chai": "^3.0.0",
     "codeclimate-test-reporter": "0.0.4",
-    "mocha": "~2.2.5",
     "istanbul": "~0.3.14",
-    "should": "~6.0.3",
+    "mocha": "~2.2.5",
     "sails-memory": "balderdashy/sails-memory",
+    "should": "~6.0.3",
     "waterline-adapter-tests": "balderdashy/waterline-adapter-tests"
   },
   "keywords": [

--- a/test/unit/model/association.add.hasMany.id.js
+++ b/test/unit/model/association.add.hasMany.id.js
@@ -28,7 +28,7 @@ describe('instance methods', function() {
           };
 
           obj.prototype.exec = function(cb) {
-            cb(null, [new model(container.update[0].values)]);
+            cb(null); // Just return nothing, so we can function as a mock only.
           };
 
           obj.prototype.populate = function() { return this; };
@@ -81,14 +81,14 @@ describe('instance methods', function() {
         person.bars.add(1);
         person.bars.add(2);
 
+        /**
+         * We've added two new children. This means two creates will be triggered. No updates needed.
+         */
         person.save(function(err) {
-          assert(bar.update.length === 2);
-          assert(bar.update.length === 2);
-          assert(bar.update[0].criteria.id === 1);
 
-          assert(bar.update[0].values.foo);
-          assert(bar.update[1].criteria.id === 2);
-          assert(bar.update[1].values.foo);
+          assert.equal(bar.update.length, 2, 'We did not get two updates.');
+          assert.deepEqual(bar.update[0].values, {foo: 1}, 'Update did not go as planned.');
+          assert.deepEqual(bar.update[1].values, {foo: 1}, 'Create did not go as planned.');
 
           done();
         });

--- a/test/unit/model/association.add.hasMany.object.js
+++ b/test/unit/model/association.add.hasMany.object.js
@@ -5,7 +5,6 @@ var _ = require('lodash'),
 
 describe('instance methods', function() {
   describe('hasMany association add', function() {
-
     describe('with an object', function() {
 
       /////////////////////////////////////////////////////
@@ -28,7 +27,7 @@ describe('instance methods', function() {
           };
 
           obj.prototype.exec = function(cb) {
-            cb(null, [new model(container.update[0].values)]);
+            cb(null); // Just return nothing, so we can function as a mock only.
           };
 
           obj.prototype.populate = function() { return this; };
@@ -50,8 +49,9 @@ describe('instance methods', function() {
         };
 
         // Mock Collection Create Method
-        var createFn = function(container) {
+        var createFn = function(container, d) {
           return function(values, cb) {
+
             var obj = { values: values };
             values.id = i;
             i++;
@@ -63,8 +63,6 @@ describe('instance methods', function() {
         // Add Collection Methods to all fixture collections
         fixture.update = updateFn(foo);
         fixture.findOne = findOneFn(foo);
-        fixture.waterline.collections.foo.update = updateFn(foo);
-        fixture.waterline.collections.bar.update = updateFn(bar);
         fixture.waterline.collections.bar.create = createFn(bar);
 
         model = new Model(fixture, {});
@@ -81,16 +79,14 @@ describe('instance methods', function() {
         person.bars.add({ name: 'foo' });
         person.bars.add({ name: 'bar' });
 
+        /**
+         * We've added two new children. This means two creates will be triggered. No updates needed.
+         */
         person.save(function(err) {
-          assert(bar.create.length === 2);
 
-          assert(bar.create[0].values.foo);
-          assert(bar.create[0].values.name);
-          assert(bar.create[1].values.foo);
-          assert(bar.create[1].values.name);
-
-          assert(bar.create[0].values.name === 'foo');
-          assert(bar.create[1].values.name === 'bar');
+          assert.equal(bar.create.length, 2, 'We did not get two creates');
+          assert.deepEqual(bar.create[0].values, {id : 1, foo: 1, name: 'foo'}, 'Create did not go as planned.');
+          assert.deepEqual(bar.create[1].values, {id : 2, foo: 1, name: 'bar'}, 'Create did not go as planned.');
 
           done();
         });

--- a/test/unit/model/dirty.js
+++ b/test/unit/model/dirty.js
@@ -1,0 +1,43 @@
+var assert = require('assert'),
+    belongsToFixture = require('../../support/fixtures/model/context.belongsTo.fixture'),
+    Model = require('../../../lib/waterline/model');
+
+describe('model dirty', function() {
+
+  /////////////////////////////////////////////////////
+  // TEST SETUP
+  ////////////////////////////////////////////////////
+
+  var fixture, model;
+
+  before(function() {
+    fixture = belongsToFixture();
+    model = new Model(fixture);
+  });
+
+
+  /////////////////////////////////////////////////////
+  // TEST METHODS
+  ////////////////////////////////////////////////////
+
+  it('works with basic values', function() {
+    var person = new model();
+    assert(person.dirty('foo') === false);
+    person.foo = 'lala';
+    assert(person.dirty('foo') === true);
+    person.foo = undefined;
+    assert(person.dirty('foo') === false);
+  });
+
+  it('cleans correctly', function() {
+    var person = new model();
+    person.foo = 'lala';
+    assert(person.dirty('foo') === true);
+    person.clean();
+    assert(person.dirty('foo') === false);
+    person.foo = 'asdf';
+    assert(person.dirty('foo') === true);
+    person.foo = 'lala';
+    assert(person.dirty('foo') === false);
+  });
+});

--- a/test/unit/model/dirty.js
+++ b/test/unit/model/dirty.js
@@ -1,4 +1,4 @@
-var assert            = require('chai').assert,
+var assert            = require('assert'),
     _                 = require('lodash'),
     belongsToFixture  = require('../../support/fixtures/model/context.belongsTo.fixture'),
     manyToManyFixture = require('../../support/fixtures/model/context.manyToMany.fixture'),

--- a/test/unit/model/dirty.js
+++ b/test/unit/model/dirty.js
@@ -1,43 +1,135 @@
-var assert = require('assert'),
-    belongsToFixture = require('../../support/fixtures/model/context.belongsTo.fixture'),
-    Model = require('../../../lib/waterline/model');
+var assert            = require('chai').assert,
+    _                 = require('lodash'),
+    belongsToFixture  = require('../../support/fixtures/model/context.belongsTo.fixture'),
+    manyToManyFixture = require('../../support/fixtures/model/context.manyToMany.fixture'),
+    Model             = require('../../../lib/waterline/model');
 
-describe('model dirty', function() {
-
-  /////////////////////////////////////////////////////
-  // TEST SETUP
-  ////////////////////////////////////////////////////
-
+describe('model dirty', function () {
   var fixture, model;
 
-  before(function() {
-    fixture = belongsToFixture();
+  before(function () {
+    fixture = manyToManyFixture();
     model = new Model(fixture);
   });
 
+  it('.dirty() works with basic values', function () {
+    var testModel = new model();
 
-  /////////////////////////////////////////////////////
-  // TEST METHODS
-  ////////////////////////////////////////////////////
+    assert.deepEqual(testModel.dirty('foo'), false, 'Model is dirty initially.');
+    assert.deepEqual(testModel.dirty(), false, 'Model is dirty initially.');
 
-  it('works with basic values', function() {
-    var person = new model();
-    assert(person.dirty('foo') === false);
-    person.foo = 'lala';
-    assert(person.dirty('foo') === true);
-    person.foo = undefined;
-    assert(person.dirty('foo') === false);
+    testModel.foo = 'abc';
+    testModel.bar = 'def';
+
+    assert.deepEqual(testModel.dirty('foo'), {foo: 'abc'}, 'Model isn\'t as dirty as expected.');
+    assert.deepEqual(testModel.dirty(), {foo: 'abc', bar: 'def'}, 'Model isn\'t as dirty as expected.');
+
+    testModel.foo = undefined;
+    testModel.bar = undefined;
+
+    assert.deepEqual(testModel.dirty('foo'), false, 'After cleanup, model still thinks it\'s dirty.');
+    assert.deepEqual(testModel.dirty(), false, 'After cleanup, model still thinks it\'s dirty.');
   });
 
-  it('cleans correctly', function() {
-    var person = new model();
-    person.foo = 'lala';
-    assert(person.dirty('foo') === true);
-    person.clean();
-    assert(person.dirty('foo') === false);
-    person.foo = 'asdf';
-    assert(person.dirty('foo') === true);
-    person.foo = 'lala';
-    assert(person.dirty('foo') === false);
+  it('.dirty(), on simple models, sets the PK on the results if needed', function () {
+    var testModel = new model({id: 1, name: 'My ID will be set upon change.'});
+
+    assert.equal(testModel.dirty('foo'), false, 'PK model is dirty initially.');
+
+    testModel.name = 'I will make you filthy.';
+    testModel.foo = 'abc';
+
+    assert.deepEqual(testModel.dirty('name'), {
+      name: 'I will make you filthy.',
+      id  : 1
+    }, 'Model isn\'t as dirty as expected.');
+    assert.deepEqual(testModel.dirty(), {
+      name: 'I will make you filthy.',
+      foo : 'abc',
+      id  : 1
+    }, 'Model isn\'t as dirty as expected.');
+  });
+
+  it('.dirty() works with associations', function () {
+    var testModel = new model({
+      name: 'Assoc time.',
+      bars: [
+        new model({name: 'Upon change, my PK will not be supplied.'}), // Because otherwise it'll miss the dirty method.
+      ]
+    }, {showJoins: true});
+
+    assert.deepEqual(testModel.dirty('name'), false, 'Model is dirty initially.');
+    assert.deepEqual(testModel.dirty('bars'), false, 'Model is dirty initially.');
+    assert.deepEqual(testModel.dirty(), false, 'Model is dirty initially.');
+
+    testModel.name = 'Bacon.. Hmmm';
+    testModel.bars.push(6);
+    testModel.bars[0].name = 'You changed';
+
+    assert.deepEqual(testModel.dirty(), {name: 'Bacon.. Hmmm', bars: [{name: 'You changed'}, 6]});
+    assert.deepEqual(testModel.dirty('bars'), {bars: [{name: 'You changed'}, 6]});
+    assert.deepEqual(testModel.dirty('name'), {name: 'Bacon.. Hmmm'});
+  });
+
+  it('.dirty() on association models, sets the PK on the results if needed', function () {
+    var testModel = new model({
+      id  : 1,
+      name: 'Assoc time.',
+      bars: [
+        new model({id: 1, name: 'Upon change, my PK will be supplied.'}),
+        new model({name: 'Upon change, my PK will not be supplied.'}),
+      ]
+    }, {showJoins: true});
+
+    assert.deepEqual(testModel.dirty('name'), false, 'Model is dirty initially.');
+    assert.deepEqual(testModel.dirty('bars'), false, 'Model is dirty initially.');
+    assert.deepEqual(testModel.dirty(), false, 'Model is dirty initially.');
+
+    testModel.name = 'Bacon.. Hmmm';
+    testModel.bars.push(6);
+    testModel.bars[0].name = 'You changed';
+
+    assert.deepEqual(testModel.dirty(), {id: 1, name: 'Bacon.. Hmmm', bars: [{id: 1, name: 'You changed'}, 6]});
+    assert.deepEqual(testModel.dirty('bars'), {bars: [{id: 1, name: 'You changed'}, 6], id: 1});
+    assert.deepEqual(testModel.dirty('name'), {name: 'Bacon.. Hmmm', id: 1});
+  });
+
+  it('.clean() cleans the entire model correctly', function () {
+    var testModel = new model();
+    testModel.foo = 'abc';
+    assert.deepEqual(testModel.dirty('foo'), {foo: 'abc'}, 'Model did not detect change as dirty.');
+    testModel.clean();
+    assert.equal(testModel.dirty('foo'), false, 'Model is still dirty after clean.');
+  });
+
+  it('.clean() cleans specific properties correctly', function () {
+    var testModel = new model();
+    testModel.foo = 'abc';
+    testModel.bar = 'def';
+    assert.deepEqual(testModel.dirty(), {foo: 'abc', bar: 'def'}, 'Model did not detect change as dirty.');
+    testModel.clean('foo');
+    assert.deepEqual(testModel.dirty(), {bar: 'def'}, 'Model is not as dirty as anticipated.');
+  });
+
+  it('.clean() cleans the entire association correctly', function () {
+    var testModel = new model({
+      id  : 1,
+      name: 'Assoc time.',
+      bars: [
+        new model({id: 1, name: 'Upon change, my PK will be supplied.'}),
+        new model({name: 'Upon change, my PK will not be supplied.'}),
+      ]
+    }, {showJoins: true});
+
+    testModel.bars[0].name = 'Oh no';
+
+    assert.deepEqual(testModel.dirty(), {
+      id  : 1,
+      bars: [{id: 1, name: 'Oh no'}]
+    }, 'Model did not detect change as dirty.');
+
+    testModel.clean('bars');
+
+    assert.deepEqual(testModel.dirty(), false, 'Model still has dirty properties.');
   });
 });

--- a/test/unit/query/query.update.nested.js
+++ b/test/unit/query/query.update.nested.js
@@ -73,7 +73,7 @@ describe('Collection Query', function() {
         });
       });
     });
-    
+
     describe('with nested model values (create)', function() {
       var query;
 
@@ -323,7 +323,7 @@ describe('Collection Query', function() {
         query.update({}, { id: 5, name: 'foo', nestedModels: nestedModels }, function(err, status) {
           assert(!err, err);
           assert(status[0].nestedModels.length === 0);
-          assert(updatedModels.length === 10);
+          assert(updatedModels.length === 9);
           done();
         });
       });


### PR DESCRIPTION
This PR makes it so that:

* You can view the diff on a model
* You don't get afterUpdate to trigger on create
* You don't get an update at all, on create (because there's no diff)
* .save() only updates changed fields, in stead of everything
* There's no association cache anymore
* The original values are retrievable on the model.

### Notes to self
* ~~`.compareModelValues()` in `save.js` can probably go.~~
* ~~`.findPrimaryKey()` can probably go. Context has a primaryKey property.~~
* ~~Don't forget to set status back to clean after various save operations.~~