### PR TITLE
Added ability to transform columnName in populate() criteria

### DIFF
--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -69,6 +69,8 @@ Transformation.prototype.initialize = function(_attributes, tables) {
   _mapping(_attributes, this._transformations);
 
   for (var tableName in tables) {
+    if (!tables[tableName].attributes) return;
+
     this._allTransformations[tableName] = {};
     _mapping(tables[tableName].attributes, this._allTransformations[tableName]);
   }

--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -20,7 +20,6 @@ var Transformation = module.exports = function(attributes, tables) {
 
   // Hold an internal mapping of keys to transform
   this._transformations = {};
-  this._allTransformations = {};
 
   // Initialize
   this.initialize(attributes, tables);
@@ -35,45 +34,36 @@ var Transformation = module.exports = function(attributes, tables) {
  * @param {Object} tables
  */
 
-Transformation.prototype.initialize = function(_attributes, tables) {
+Transformation.prototype.initialize = function(attributes, tables) {
+  var self = this;
 
-  function _mapping(attributes, transformations) {
-    Object.keys(attributes).forEach(function(attr) {
+  Object.keys(attributes).forEach(function(attr) {
 
-      // Ignore Functions and Strings
-      if(['function', 'string'].indexOf(typeof attributes[attr]) > -1) return;
+    // Ignore Functions and Strings
+    if(['function', 'string'].indexOf(typeof attributes[attr]) > -1) return;
 
-      // If not an object, ignore
-      if(attributes[attr] !== Object(attributes[attr])) return;
+    // If not an object, ignore
+    if(attributes[attr] !== Object(attributes[attr])) return;
 
-      // Loop through an attribute and check for transformation keys
-      Object.keys(attributes[attr]).forEach(function(key) {
+    // Loop through an attribute and check for transformation keys
+    Object.keys(attributes[attr]).forEach(function(key) {
 
-        // Currently just works with `columnName`, `collection`, `groupKey`
-        if(key !== 'columnName') return;
+      // Currently just works with `columnName`, `collection`, `groupKey`
+      if(key !== 'columnName') return;
 
-        // Error if value is not a string
-        if(typeof attributes[attr][key] !== 'string') {
-          throw new Error('columnName transformation must be a string');
-        }
+      // Error if value is not a string
+      if(typeof attributes[attr][key] !== 'string') {
+        throw new Error('columnName transformation must be a string');
+      }
 
-        // Set transformation attr to new key
-        if(key === 'columnName') {
-          if(attr === attributes[attr][key]) return;
-          transformations[attr] = attributes[attr][key];
-        }
-      });
+      // Set transformation attr to new key
+      if(key === 'columnName') {
+        if(attr === attributes[attr][key]) return;
+        self._transformations[attr] = attributes[attr][key];
+      }
+
     });
-  }
-
-  _mapping(_attributes, this._transformations);
-
-  for (var tableName in tables) {
-    if (!tables[tableName].attributes) return;
-
-    this._allTransformations[tableName] = {};
-    _mapping(tables[tableName].attributes, this._allTransformations[tableName]);
-  }
+  });
 };
 
 /**
@@ -84,12 +74,9 @@ Transformation.prototype.initialize = function(_attributes, tables) {
  * @return {Object}
  */
 
-Transformation.prototype.serialize = function(attributes, collectionName) {
-
+Transformation.prototype.serialize = function(attributes) {
   var self = this,
-      values = _.clone(attributes),
-      transformations = collectionName ?
-        self._allTransformations[collectionName] : self._transformations;
+      values = _.clone(attributes);
 
   function recursiveParse(obj) {
 
@@ -98,8 +85,8 @@ Transformation.prototype.serialize = function(attributes, collectionName) {
 
     // Handle array of types for findOrCreateEach
     if(typeof obj === 'string') {
-      if(hasOwnProperty(transformations, obj)) {
-        values = transformations[obj];
+      if(hasOwnProperty(self._transformations, obj)) {
+        values = self._transformations[obj];
         return;
       }
 
@@ -118,20 +105,20 @@ Transformation.prototype.serialize = function(attributes, collectionName) {
       if((toString.call(obj[property]) !== '[object Date]') && (_.isPlainObject(obj[property]))) {
 
         // check if object key is in the transformations
-        if(hasOwnProperty(transformations, property)) {
-          obj[transformations[property]] = _.clone(obj[property]);
+        if(hasOwnProperty(self._transformations, property)) {
+          obj[self._transformations[property]] = _.clone(obj[property]);
           delete obj[property];
 
-          return recursiveParse(obj[transformations[property]]);
+          return recursiveParse(obj[self._transformations[property]]);
         }
 
         return recursiveParse(obj[property]);
       }
 
       // Check if property is a transformation key
-      if(hasOwnProperty(transformations, property)) {
+      if(hasOwnProperty(self._transformations, property)) {
 
-        obj[transformations[property]] = obj[property];
+        obj[self._transformations[property]] = obj[property];
         delete obj[property];
       }
     });

--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -20,6 +20,7 @@ var Transformation = module.exports = function(attributes, tables) {
 
   // Hold an internal mapping of keys to transform
   this._transformations = {};
+  this._allTransformations = {};
 
   // Initialize
   this.initialize(attributes, tables);
@@ -34,36 +35,43 @@ var Transformation = module.exports = function(attributes, tables) {
  * @param {Object} tables
  */
 
-Transformation.prototype.initialize = function(attributes, tables) {
-  var self = this;
+Transformation.prototype.initialize = function(_attributes, tables) {
 
-  Object.keys(attributes).forEach(function(attr) {
+  function _mapping(attributes, transformations) {
+    Object.keys(attributes).forEach(function(attr) {
 
-    // Ignore Functions and Strings
-    if(['function', 'string'].indexOf(typeof attributes[attr]) > -1) return;
+      // Ignore Functions and Strings
+      if(['function', 'string'].indexOf(typeof attributes[attr]) > -1) return;
 
-    // If not an object, ignore
-    if(attributes[attr] !== Object(attributes[attr])) return;
+      // If not an object, ignore
+      if(attributes[attr] !== Object(attributes[attr])) return;
 
-    // Loop through an attribute and check for transformation keys
-    Object.keys(attributes[attr]).forEach(function(key) {
+      // Loop through an attribute and check for transformation keys
+      Object.keys(attributes[attr]).forEach(function(key) {
 
-      // Currently just works with `columnName`, `collection`, `groupKey`
-      if(key !== 'columnName') return;
+        // Currently just works with `columnName`, `collection`, `groupKey`
+        if(key !== 'columnName') return;
 
-      // Error if value is not a string
-      if(typeof attributes[attr][key] !== 'string') {
-        throw new Error('columnName transformation must be a string');
-      }
+        // Error if value is not a string
+        if(typeof attributes[attr][key] !== 'string') {
+          throw new Error('columnName transformation must be a string');
+        }
 
-      // Set transformation attr to new key
-      if(key === 'columnName') {
-        if(attr === attributes[attr][key]) return;
-        self._transformations[attr] = attributes[attr][key];
-      }
-
+        // Set transformation attr to new key
+        if(key === 'columnName') {
+          if(attr === attributes[attr][key]) return;
+          transformations[attr] = attributes[attr][key];
+        }
+      });
     });
-  });
+  }
+
+  _mapping(_attributes, this._transformations);
+
+  for (var tableName in tables) {
+    this._allTransformations[tableName] = {};
+    _mapping(tables[tableName].attributes, this._allTransformations[tableName]);
+  }
 };
 
 /**
@@ -74,9 +82,12 @@ Transformation.prototype.initialize = function(attributes, tables) {
  * @return {Object}
  */
 
-Transformation.prototype.serialize = function(attributes) {
+Transformation.prototype.serialize = function(attributes, collectionName) {
+
   var self = this,
-      values = _.clone(attributes);
+      values = _.clone(attributes)
+      transformations = collectionName ?
+        self._allTransformations[collectionName] : self._transformations;
 
   function recursiveParse(obj) {
 
@@ -85,8 +96,8 @@ Transformation.prototype.serialize = function(attributes) {
 
     // Handle array of types for findOrCreateEach
     if(typeof obj === 'string') {
-      if(hasOwnProperty(self._transformations, obj)) {
-        values = self._transformations[obj];
+      if(hasOwnProperty(transformations, obj)) {
+        values = transformations[obj];
         return;
       }
 
@@ -105,20 +116,20 @@ Transformation.prototype.serialize = function(attributes) {
       if((toString.call(obj[property]) !== '[object Date]') && (_.isPlainObject(obj[property]))) {
 
         // check if object key is in the transformations
-        if(hasOwnProperty(self._transformations, property)) {
-          obj[self._transformations[property]] = _.clone(obj[property]);
+        if(hasOwnProperty(transformations, property)) {
+          obj[transformations[property]] = _.clone(obj[property]);
           delete obj[property];
 
-          return recursiveParse(obj[self._transformations[property]]);
+          return recursiveParse(obj[transformations[property]]);
         }
 
         return recursiveParse(obj[property]);
       }
 
       // Check if property is a transformation key
-      if(hasOwnProperty(self._transformations, property)) {
+      if(hasOwnProperty(transformations, property)) {
 
-        obj[self._transformations[property]] = obj[property];
+        obj[transformations[property]] = obj[property];
         delete obj[property];
       }
     });

--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -85,7 +85,7 @@ Transformation.prototype.initialize = function(_attributes, tables) {
 Transformation.prototype.serialize = function(attributes, collectionName) {
 
   var self = this,
-      values = _.clone(attributes)
+      values = _.clone(attributes),
       transformations = collectionName ?
         self._allTransformations[collectionName] : self._transformations;
 

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -53,6 +53,15 @@ module.exports = {
     // Transform Search Criteria
     criteria = self._transformer.serialize(criteria);
 
+    // serialize populated object
+    if (criteria.joins) {
+	    criteria.joins.forEach(function(join) {
+		    if (join.criteria && join.criteria.where) {
+			    join.criteria.where = self._transformer.serialize(join.criteria.where, join.child);
+		    }
+	    });
+    }
+
     // If there was something defined in the criteria that would return no results, don't even
     // run the query and just return an empty result set.
     if(criteria === false || criteria.where === null) {
@@ -237,6 +246,14 @@ module.exports = {
 
     criteria = self._transformer.serialize(criteria);
 
+    // serialize populated object
+    if (criteria.joins) {
+	    criteria.joins.forEach(function(join) {
+		    if (join.criteria && join.criteria.where) {
+			    join.criteria.where = self._transformer.serialize(join.criteria.where, join.child);
+		    }
+	    });
+    }
 
     // Build up an operations set
     var operations = new Operations(self, criteria, 'find');

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -57,7 +57,8 @@ module.exports = {
     if (criteria.joins) {
 	    criteria.joins.forEach(function(join) {
 		    if (join.criteria && join.criteria.where) {
-			    join.criteria.where = self._transformer.serialize(join.criteria.where, join.child);
+          var joinCollection = self.waterline.collections[join.child];
+			    join.criteria.where = joinCollection._transformer.serialize(join.criteria.where);
 		    }
 	    });
     }
@@ -250,7 +251,8 @@ module.exports = {
     if (criteria.joins) {
 	    criteria.joins.forEach(function(join) {
 		    if (join.criteria && join.criteria.where) {
-			    join.criteria.where = self._transformer.serialize(join.criteria.where, join.child);
+          var joinCollection = self.waterline.collections[join.child];
+			    join.criteria.where = joinCollection._transformer.serialize(join.criteria.where);
 		    }
 	    });
     }

--- a/test/unit/core/core.transformations/transformations.initialize.js
+++ b/test/unit/core/core.transformations/transformations.initialize.js
@@ -16,7 +16,7 @@ describe('Core Transformations', function() {
           }
         };
 
-        transformer = new Transformer(attributes, { models: {}, collections: {} });
+        transformer = new Transformer(attributes, {});
       });
 
       it('should set a username transformation', function() {
@@ -39,7 +39,7 @@ describe('Core Transformations', function() {
       it('should NOT set a username transformation', function() {
         var msg = (function() {
           try {
-            new Transformer(attributes, { models: {}, collections: {} });
+            new Transformer(attributes, {});
           } catch(e) {
             return e.message;
           }


### PR DESCRIPTION
Added ability to transform columnName in populate() criteria.

Before this fix, `where` statement in populate() cannot use model attribute name.

Like this case.
```
// Article.js
module.exports = {
  tableName: 'articles',

  attributes: {
    title: 'string',
    body: 'string',
    categories: {
      collection: 'category',
      through: 'articlecategory'
    },
    publicationDate : {
      columnName: 'publication_date',
      type: 'Date'
    }
  }
};

// Category.js
module.exports = {
  tableName: 'categories',

  attributes: {
    name: 'string'
    articles: {
      collection: 'article',
      through: 'articlecategory'
    }
  }
}

// ArticleCategory.js
module.exports = {
  tableName: 'articles_categories',
  tables: ['articles', 'categories'],
  junctionTable: true,

  attributes: {
    article: {
      columnName: 'article',
      type: 'integer',
      foreignKey: true,
      references: 'article',
      on: 'id',
      onKey: 'id',
      via: 'category'
    },
    category: {
      columnName: 'category',
      type: 'integer',
      foreignKey: true,
      references: 'category',
      on: 'id',
      via: 'article'
    }
  }
};
```

`where` statement in `populate()` cannot use attributeName defined at model.

```
// find category with articles
Category.find().populate('articles', where: {publication_date: {'<=': new Date()}}).then(function(categories) {
  // ...
}).catch(function(error) {});

// ERROR on `publicationDate`
Category.find().populate('articles', where: {publicationDate: {'<=': new Date()}}).then(function(categories) {
  // ...
}).catch(function(error) {});

```

After this fix, `where` statement in populate() works both `columnName` and `attributeName`.


And, I fixed test case `transformations.initialize.js`. The 2nd argument of `Transformer` expects simple object (like `{article: ..., category: ...}`).
