### PR TITLE
Prevents infinite recursion in "WLError.message" setter

### DIFF
--- a/lib/waterline/error/WLError.js
+++ b/lib/waterline/error/WLError.js
@@ -133,10 +133,10 @@ Object.defineProperties(WLError.prototype, {
   message: {
     enumerable: true,
     get: function () {
-      return this.toString();
+      return this.rawMessage || this.toString();
     },
     set: function (value) {
-      this.message = value;
+      this.rawMessage = value;
     }
   }
 });

--- a/lib/waterline/error/WLError.js
+++ b/lib/waterline/error/WLError.js
@@ -127,7 +127,7 @@ Object.defineProperties(WLError.prototype, {
       return util.format('Error (%s) :: %s\n%s', this.code, this.reason, this.rawStack);
     },
     set: function (value) {
-      this.stack = value;
+      this.rawStack = value;
     }
   },
   message: {

--- a/test/unit/error/WLError.test.js
+++ b/test/unit/error/WLError.test.js
@@ -54,6 +54,11 @@ describe('lib/error', function () {
       var err = errorify();
       assert(err.stack)
     });
+    it('should allow changing the stack property', function() {
+      var err = errorify();
+      err.stack = 'new stack';
+      assert(err.stack.indexOf('new stack') >= 0, 'err.stack was not set properly');
+    });
     it('should have a message property, like Error', function() {
       var err = errorify();
       assert(err.message)

--- a/test/unit/error/WLError.test.js
+++ b/test/unit/error/WLError.test.js
@@ -52,7 +52,7 @@ describe('lib/error', function () {
   describe('lib/error/WLError.js', function() {
     it('should have a stack property, like Error', function() {
       var err = errorify();
-      assert(err.stack)
+      assert(err.stack);
     });
     it('should allow changing the stack property', function() {
       var err = errorify();
@@ -61,8 +61,13 @@ describe('lib/error', function () {
     });
     it('should have a message property, like Error', function() {
       var err = errorify();
-      assert(err.message)
+      assert(err.message);
     })
+    it('should allow changing the message property', function() {
+      var err = errorify();
+      err.message = 'new message';
+      assert.equal(err.message, 'new message');
+    });
   })
 
 });


### PR DESCRIPTION
Depends on PR #1061, so merge it afterwards!

Related to #1001 and #920, check https://github.com/shaunc/waterline/commit/cfbd38531b09b4411d8eb9a0e2fb1fc880e7917b#commitcomment-11710757.

cc: @devinivy 