### PR TITLE
Return empty/zero from IN w/empty array

### DIFF
--- a/lib/waterline/query/dql/count.js
+++ b/lib/waterline/query/dql/count.js
@@ -39,6 +39,12 @@ module.exports = function(criteria, options, cb) {
   // Normalize criteria and fold in options
   criteria = normalize.criteria(criteria);
 
+  // If there was something defined in the criteria that would return no results, don't even
+  // run the query and just return 0
+  if(criteria === false) {
+      return cb(null, 0);
+  }
+
   if(_.isObject(options) && _.isObject(criteria)) {
     criteria = _.extend({}, criteria, options);
   }

--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -36,6 +36,12 @@ module.exports = function(criteria, cb) {
   // Normalize criteria
   criteria = normalize.criteria(criteria);
 
+  // If there was something defined in the criteria that would return no results, don't even
+  // run the query and just return an empty result set.
+  if(criteria === false) {
+      return cb(null, []);
+  }
+
   // Return Deferred or pass to adapter
   if(typeof cb !== 'function') {
     return new Deferred(this, this.destroy, criteria);

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -36,6 +36,12 @@ module.exports = function(criteria, values, cb) {
     return new Deferred(this, this.update, criteria, values);
   }
 
+  // If there was something defined in the criteria that would return no results, don't even
+  // run the query and just return an empty result set.
+  if(criteria === false) {
+      return cb(null, []);
+  }
+
   // Ensure proper function signature
   var usage = utils.capitalize(this.identity) + '.update(criteria, values, callback)';
   if(!values) return usageError('No updated values specified!', usage, cb);
@@ -138,7 +144,7 @@ function createBelongsTo(valuesObject, cb) {
       var pk = val[model.primaryKey];
 
       valuesObject.values[item] = pk;
-      
+
       // now we have pk value attached, remove it from models
       _.remove(valuesObject.associations.models, function(_item) { return _item == item; });
       next();

--- a/test/unit/query/query.destroy.js
+++ b/test/unit/query/query.destroy.js
@@ -56,6 +56,14 @@ describe('Collection Query', function() {
           done();
         });
       });
+
+      it('should not delete an empty IN array', function(done) {
+        query.destroy({id: []}, function(err, deleted) {
+          assert(!err);
+          assert(deleted.length === 0);
+          done();
+        });
+      });
     });
 
     describe('with custom columnName set', function() {


### PR DESCRIPTION
Calling Collection.destroy({id: []}) destroys *all* documents. [Functionality exists in normalize that returns false if there's an empty array](https://github.com/balderdashy/waterline/blob/317cdf0173990face8afe67b336bc6e6d0fe5630/lib/waterline/utils/normalize.js#L191), but false is OR'd with {}, [resulting in a {} being passed to the sails-mongo adapter](https://github.com/balderdashy/sails-mongo/blob/master/lib/adapter.js#L367), which deletes everything.

This PR just applies [what is already implemented for find()](https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/finders/basic.js#L222).

We found this out the hard way. :(