### PR TITLE
Defaults to fix

### DIFF
--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -88,7 +88,7 @@ function processValues(values) {
 
   // Set Default Values if available
   for(var key in this.attributes) {
-    if(!hop(values, key) && hop(this.attributes[key], 'defaultsTo')) {
+    if((!hop(values, key) || values[key] === undefined) && hop(this.attributes[key], 'defaultsTo')) {
       var defaultsTo = this.attributes[key].defaultsTo;
       values[key] = typeof defaultsTo === 'function' ? defaultsTo.call(values) : _.clone(defaultsTo);
     }

--- a/test/unit/query/query.create.js
+++ b/test/unit/query/query.create.js
@@ -67,6 +67,14 @@ describe('Collection Query', function() {
         });
       });
 
+      it('should set default values when the value is undefined', function(done) {
+        query.create({ first: undefined }, function(err, status) {
+          assert(status.first = 'Foo');
+          assert(status.full === 'Foo Bar');
+          done();
+        });
+      });
+
       it('should add timestamps', function(done) {
         query.create({}, function(err, status) {
           assert(status.createdAt);


### PR DESCRIPTION
If you are using `defaultsTo` and pass in a value of `undefined` the hasOwnProperty check was failing. This fixes that and will set the value correctly.

Also will need to be hot patched on the `0.10.x` branch after merge.