### PR TITLE
Refactor normalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.swo
 .dist
 coverage/
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.swp
 *.swo
 .dist
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-integration:
 coverage:
 	@echo "\n\nRunning coverage report..."
 	rm -rf coverage
-	./node_modules/istanbul/lib/cli.js cover --report none --dir coverage/core ./node_modules/.bin/_mocha \
+	@NODE_ENV=test ./node_modules/istanbul/lib/cli.js cover --report none --dir coverage/core ./node_modules/.bin/_mocha \
 		test/integration test/structure test/support test/unit -- --recursive
 	./node_modules/istanbul/lib/cli.js cover --report none --dir coverage/adapter test/adapter/runner.js
 	./node_modules/istanbul/lib/cli.js report

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test-unit:
 test-integration:
 	@echo "\nRunning integration tests..."
 	rm -rf node_modules/waterline-adapter-tests/node_modules/waterline;
-	ln -s $(ROOT) node_modules/waterline-adapter-tests/node_modules/waterline;
+	ln -s "$(ROOT)" node_modules/waterline-adapter-tests/node_modules/waterline;
 	@NODE_ENV=test node test/adapter/runner.js
 
 coverage:

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -187,8 +187,8 @@ Waterline.prototype.initialize = function(options, cb) {
         // Grab the schemas used on this connection
         connection._collections.forEach(function(coll) {
           var identity = coll;
-          if (hasOwnProperty(self.collections[coll].__proto__, 'tableName')) {
-            identity = self.collections[coll].__proto__.tableName;
+          if (hasOwnProperty(Object.getPrototypeOf(self.collections[coll]), 'tableName')) {
+            identity = Object.getPrototypeOf(self.collections[coll]).tableName;
           }
 
           usedSchemas[identity] = results.buildCollectionSchemas[coll];
@@ -238,8 +238,6 @@ Waterline.prototype.teardown = function teardown(cb) {
  */
 
 Waterline.prototype.bootstrap = function bootstrap(cb) {
-  var self = this;
-
   //
   // TODO:
   // Come back to this -- see https://github.com/balderdashy/waterline/issues/259

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -4,13 +4,7 @@ var hop = util.object.hasOwnProperty;
 var switchback = require('switchback');
 var errorify = require('../error');
 var WLUsageError = require('../error/WLUsageError');
-if (process.env.NODE_ENV === "test" ) {
-  module.exports.NotExposed = {
-    StandardizedForm:  StandardizeForm,
-    ProcessWhereClauseAttributes:  ProcessWhereClauseAttributes,
-    ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters
-  };
-}
+
 module.exports = {
 
   // Expand Primary Key criteria into objects
@@ -375,15 +369,14 @@ function ProcessWhereClauseAttributes(criteria) {
   // this also used to validate the limit and skip properties, as well as parse them
   // to ints. Here we blindly move those values and leave it to the validate method
   // to parse those values rather than here.
-
   var propertiesToCheck = [
     'limit', 'skip', 'sort', 'sum', 'average', 'groupBy', 'min',
     'min', 'max', 'select'
   ];
   _.forEach(propertiesToCheck, function(prop) {
     if (hasA(prop)) {
-      criteria.prop = _.clone(criteria.where.prop);
-      delete criteria.where.prop;
+      criteria[prop] = _.clone(criteria.where[prop]);
+      delete criteria.where[prop];
     }
   });
 
@@ -391,48 +384,6 @@ function ProcessWhereClauseAttributes(criteria) {
   //   criteria.limit = parseInt(_.clone(criteria.where.limit), 10);
   //   if (criteria.limit < 0) criteria.limit = 0;
   //   delete criteria.where.limit;
-  // }
-
-  // if (hasA('skip')) {
-  //   criteria.skip = parseInt(_.clone(criteria.where.skip), 10);
-  //   if (criteria.skip < 0) criteria.skip = 0;
-  //   delete criteria.where.skip;
-  // }
-
-  // if (hasA('sort')) {
-  //   criteria.sort = _.clone(criteria.where.sort);
-  //   delete criteria.where.sort;
-  // }
-
-  // // Pull out aggregation keys from where key
-  // if (hasA('sum')) {
-  //   criteria.sum = _.clone(criteria.where.sum);
-  //   delete criteria.where.sum;
-  // }
-
-  // if (hasA('average')) {
-  //   criteria.average = _.clone(criteria.where.average);
-  //   delete criteria.where.average;
-  // }
-
-  // if (hasA('groupBy')) {
-  //   criteria.groupBy = _.clone(criteria.where.groupBy);
-  //   delete criteria.where.groupBy;
-  // }
-
-  // if (hasA('min')) {
-  //   criteria.min = _.clone(criteria.where.min);
-  //   delete criteria.where.min;
-  // }
-
-  // if (hasA('max')) {
-  //   criteria.max = _.clone(criteria.where.max);
-  //   delete criteria.where.max;
-  // }
-
-  // if (hasA('select')) {
-  //   criteria.select = _.clone(criteria.where.select);
-  //   delete criteria.where.select;
   // }
 }
 
@@ -462,4 +413,12 @@ function ValidateLimitAndSkipParameters(criteria) {
 
 function applyInOriginalCtx(fn, args) {
   return (_.partial.apply(null, [fn].concat(Array.prototype.slice.call(args))))();
+}
+
+if (process.env.NODE_ENV === "test" ){
+  module.exports.NotExposed = {
+    StandardizedForm:  StandardizeForm,
+    ProcessWhereClauseAttributes:  ProcessWhereClauseAttributes,
+    ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters
+  };
 }

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -136,48 +136,10 @@ module.exports = {
       });
     }
 
-    // Normalize sort criteria
-    if (hop(criteria, 'sort') && criteria.sort !== null) {
-
-      // Split string into attr and sortDirection parts (default to 'asc')
-      if (_.isString(criteria.sort)) {
-        var parts = criteria.sort.split(' ');
-
-        // Set default sort to asc
-        parts[1] = parts[1] ? parts[1].toLowerCase() : 'asc';
-
-        // Expand criteria.sort into object
-        criteria.sort = {};
-        criteria.sort[parts[0]] = parts[1];
-      }
-
-      // normalize ASC/DESC notation
-      Object.keys(criteria.sort).forEach(function(attr) {
-
-        if (_.isString(criteria.sort[attr])) {
-          criteria.sort[attr] = criteria.sort[attr].toLowerCase();
-
-          // Throw error on invalid sort order
-          if (criteria.sort[attr] !== 'asc' && criteria.sort[attr] !== 'desc') {
-            throw new WLUsageError('Invalid sort criteria :: ' + criteria.sort);
-          }
-        }
-
-        if (criteria.sort[attr] === 'asc') criteria.sort[attr] = 1;
-        if (criteria.sort[attr] === 'desc') criteria.sort[attr] = -1;
-      });
-
-      // normalize binary sorting criteria
-      Object.keys(criteria.sort).forEach(function(attr) {
-        if (criteria.sort[attr] === 0) criteria.sort[attr] = -1;
-      });
-
-      // Verify that user either specified a proper object
-      // or provided explicit comparator function
-      if (!_.isObject(criteria.sort) && !_.isFunction(criteria.sort)) {
-        throw new WLUsageError('Invalid sort criteria for ' + attrName + ' :: ' + direction);
-      }
-    }
+    // Normalize sort criteria {sort: "column"}, {sort: "column asc"},
+    // {sort: {column: 'asc'}} all map to {sort: {column: 1}} on the
+    // top level of the criteria object
+    NormalizeSortOptions(criteria);
 
     return criteria;
   },
@@ -400,6 +362,53 @@ function ValidateLimitAndSkipParameters(criteria) {
     if (criteria.skip < 0) criteria.skip = 0;
   }
 }
+
+function NormalizeSortOptions(criteria) {
+  if (hop(criteria, 'sort') && criteria.sort !== null) {
+
+      // Split string into attr and sortDirection parts (default to 'asc')
+      if (_.isString(criteria.sort)) {
+        var parts = criteria.sort.split(' ');
+        var columnName = parts[0];
+        var sortDirection = parts[1];
+
+        // Set default sort to asc
+        sortDirection = sortDirection ? sortDirection.toLowerCase() : 'asc';
+
+        // Expand criteria.sort into object
+        criteria.sort = {};
+        criteria.sort[columnName] = sortDirection;
+      }
+
+      // normalize ASC/DESC notation
+      Object.keys(criteria.sort).forEach(function(attr) {
+
+        if (_.isString(criteria.sort[attr])) {
+          criteria.sort[attr] = criteria.sort[attr].toLowerCase();
+
+          // Throw error on invalid sort order
+          if (criteria.sort[attr] !== 'asc' && criteria.sort[attr] !== 'desc') {
+            throw new WLUsageError('Invalid sort criteria :: ' + criteria.sort);
+          }
+        }
+
+        if (criteria.sort[attr] === 'asc') criteria.sort[attr] = 1;
+        if (criteria.sort[attr] === 'desc') criteria.sort[attr] = -1;
+      });
+
+      // normalize binary sorting criteria
+      Object.keys(criteria.sort).forEach(function(attr) {
+        if (criteria.sort[attr] === 0) criteria.sort[attr] = -1;
+      });
+
+      // Verify that user either specified a proper object
+      // or provided explicit comparator function
+      if (!_.isObject(criteria.sort) && !_.isFunction(criteria.sort)) {
+        throw new WLUsageError('Invalid sort criteria for ' + attrName + ' :: ' + direction);
+      }
+    }
+}
+
 /**
  * Like _.partial, but accepts an array of arguments instead of
  * comma-seperated args (if _.partial is `call`, this is `apply`.)
@@ -421,6 +430,7 @@ if (process.env.NODE_ENV === 'test') {
   module.exports.NotExposed = {
     StandardizedForm: StandardizeForm,
     ProcessWhereClauseAttributes: ProcessWhereClauseAttributes,
-    ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters
+    ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters,
+    NormalizeSortOptions: NormalizeSortOptions
   };
 }

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -96,10 +96,6 @@ module.exports = {
     // Move Limit, Skip, sort outside the where criteria
     ProcessWhereClauseAttributes(criteria);
 
-    // If WHERE is {}, always change it back to null
-    if (criteria.where && _.keys(criteria.where).length === 0) {
-      criteria.where = null;
-    }
 
     // limit and skip clauses could exist chained and now we validate they don't
     // call to skip -3 or skip -4 results. Check these arguments are above 0
@@ -379,6 +375,12 @@ function ProcessWhereClauseAttributes(criteria) {
       delete criteria.where[prop];
     }
   });
+
+
+  // If WHERE is {}, always change it back to null
+  if (criteria.where && _.keys(criteria.where).length === 0) {
+    criteria.where = null;
+  }
 
   // if (hasA('limit')) {
   //   criteria.limit = parseInt(_.clone(criteria.where.limit), 10);

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -363,50 +363,61 @@ function ValidateLimitAndSkipParameters(criteria) {
   }
 }
 
+// Sort criteria can come in as strings or objects: {sort: "column"}
+// {sort: "column direction"} or {sort: {column: "direction"}}.  These
+// must be transformed into {sort: {column: 1}} for ascending or -1
+// for descending It also allows for {sort: {column: 1}}, and note
+// this needs no transformation, or {sort: {column: 0}} which must be
+// transformed into {sort: {column: -1}}
 function NormalizeSortOptions(criteria) {
-  if (hop(criteria, 'sort') && criteria.sort !== null) {
+  // if no sort clause, let's bail
+  if (!(hop(criteria, 'sort') && criteria.sort !== null) ) return;
 
-      // Split string into attr and sortDirection parts (default to 'asc')
-      if (_.isString(criteria.sort)) {
-        var parts = criteria.sort.split(' ');
-        var columnName = parts[0];
-        var sortDirection = parts[1];
+  // transform string versions into objects
+  // Split string into attr and sortDirection parts (default to 'asc')
+  if (_.isString(criteria.sort)) {
+    var parts = criteria.sort.split(' ');
+    var columnName = parts[0];
+    var sortDirection = parts[1];
 
-        // Set default sort to asc
-        sortDirection = sortDirection ? sortDirection.toLowerCase() : 'asc';
+    // Set default sort to asc if no second word
+    sortDirection = sortDirection ? sortDirection.toLowerCase() : 'asc';
 
-        // Expand criteria.sort into object
-        criteria.sort = {};
-        criteria.sort[columnName] = sortDirection;
-      }
+    // Expand criteria.sort into object
+    criteria.sort = {};
+    criteria.sort[columnName] = sortDirection;
+  }
 
-      // normalize ASC/DESC notation
-      Object.keys(criteria.sort).forEach(function(attr) {
+  // normalize ASC/DESC notation
+  Object.keys(criteria.sort).forEach(function(attr) {
 
-        if (_.isString(criteria.sort[attr])) {
-          criteria.sort[attr] = criteria.sort[attr].toLowerCase();
+    if (_.isString(criteria.sort[attr])) {
+      criteria.sort[attr] = criteria.sort[attr].toLowerCase();
 
-          // Throw error on invalid sort order
-          if (criteria.sort[attr] !== 'asc' && criteria.sort[attr] !== 'desc') {
-            throw new WLUsageError('Invalid sort criteria :: ' + criteria.sort);
-          }
-        }
-
-        if (criteria.sort[attr] === 'asc') criteria.sort[attr] = 1;
-        if (criteria.sort[attr] === 'desc') criteria.sort[attr] = -1;
-      });
-
-      // normalize binary sorting criteria
-      Object.keys(criteria.sort).forEach(function(attr) {
-        if (criteria.sort[attr] === 0) criteria.sort[attr] = -1;
-      });
-
-      // Verify that user either specified a proper object
-      // or provided explicit comparator function
-      if (!_.isObject(criteria.sort) && !_.isFunction(criteria.sort)) {
-        throw new WLUsageError('Invalid sort criteria for ' + attrName + ' :: ' + direction);
+      // Throw error on invalid sort order
+      if (criteria.sort[attr] !== 'asc' && criteria.sort[attr] !== 'desc') {
+        throw new WLUsageError('Invalid sort criteria :: ' + criteria.sort);
       }
     }
+
+    if (criteria.sort[attr] === 'asc') criteria.sort[attr] = 1;
+    if (criteria.sort[attr] === 'desc') criteria.sort[attr] = -1;
+  });
+
+  // normalize binary sorting criteria. This handles the cases
+  // {sort: {column: 0}}
+  Object.keys(criteria.sort).forEach(function(attr) {
+    if (criteria.sort[attr] === 0) criteria.sort[attr] = -1;
+  });
+
+  // Verify that user either specified a proper object or provided
+  // explicit comparator function. If its not a function and not a
+  // comparison function, i'm not sure how to provide information
+  // about what it is.
+  if (!_.isPlainObject(criteria.sort) && !_.isFunction(criteria.sort)) {
+    var representation = criteria.sort.toString();
+    throw new WLUsageError('Invalid sort criteria for ' + representation);
+  }
 }
 
 /**

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -90,16 +90,16 @@ module.exports = {
 
     // standardize form a little bit. If a primitive, turn into {id: primitive}
     // add where clause if not found, delete extraneous keys if no real structure to object
-    criteria = StandardizeForm(criteria);
+    criteria = standardizeForm(criteria);
 
 
     // Move Limit, Skip, sort outside the where criteria
-    ProcessWhereClauseAttributes(criteria);
+    criteria = processWhereClauseAttributes(criteria);
 
 
     // limit and skip clauses could exist chained and now we validate they don't
     // call to skip -3 or skip -4 results. Check these arguments are above 0
-    ValidateLimitAndSkipParameters(criteria);
+    criteria = validateLimitAndSkipParameters(criteria);
 
     // If an IN was specified in the top level query and is an empty array, we can return an
     // empty object without running the query because nothing will match anyway. Let's return
@@ -139,7 +139,7 @@ module.exports = {
     // Normalize sort criteria {sort: "column"}, {sort: "column asc"},
     // {sort: {column: 'asc'}} all map to {sort: {column: 1}} on the
     // top level of the criteria object
-    NormalizeSortOptions(criteria);
+    criteria = normalizeSortOptions(criteria);
 
     return criteria;
   },
@@ -262,7 +262,7 @@ function isNumbery(value) {
   return Math.pow(+value, 2) > 0;
 }
 
-function StandardizeForm(criteria) {
+function standardizeForm(criteria) {
   // Empty undefined values from criteria object
   _.each(criteria, function(val, key) {
     if (_.isUndefined(val)) criteria[key] = null;
@@ -311,11 +311,11 @@ function StandardizeForm(criteria) {
 // Eg: {where: {id: 4, skip: 5}} ==>
 //            {where: {id: 4}, skip: 5}
 // We are normalizing the form
-function ProcessWhereClauseAttributes(criteria) {
+function processWhereClauseAttributes(criteria) {
 
   // if no where clause, there is no processing to do
   var whereExists = hop(criteria, 'where') && criteria.where !== null;
-  if (!whereExists) return;
+  if (!whereExists) return criteria;
 
   var hasA = function(prop) {
     return hop(criteria.where, prop);
@@ -342,9 +342,11 @@ function ProcessWhereClauseAttributes(criteria) {
   if (criteria.where && _.keys(criteria.where).length === 0) {
     criteria.where = null;
   }
+
+  return criteria;
 }
 
-function ValidateLimitAndSkipParameters(criteria) {
+function validateLimitAndSkipParameters(criteria) {
   if (hop(criteria, 'limit')) {
     criteria.limit = parseInt(criteria.limit, 10);
     if (criteria.limit < 0) criteria.limit = 0;
@@ -354,6 +356,8 @@ function ValidateLimitAndSkipParameters(criteria) {
     criteria.skip = parseInt(criteria.skip, 10);
     if (criteria.skip < 0) criteria.skip = 0;
   }
+
+  return criteria;
 }
 
 // Sort criteria can come in as strings or objects: {sort: "column"}
@@ -362,9 +366,9 @@ function ValidateLimitAndSkipParameters(criteria) {
 // for descending It also allows for {sort: {column: 1}}, and note
 // this needs no transformation, or {sort: {column: 0}} which must be
 // transformed into {sort: {column: -1}}
-function NormalizeSortOptions(criteria) {
+function normalizeSortOptions(criteria) {
   // if no sort clause, let's bail
-  if (!(hop(criteria, 'sort') && criteria.sort !== null)) return;
+  if (!(hop(criteria, 'sort') && criteria.sort !== null)) return criteria;
 
   // transform string versions into objects
   // Split string into attr and sortDirection parts (default to 'asc')
@@ -411,6 +415,8 @@ function NormalizeSortOptions(criteria) {
     var representation = criteria.sort.toString();
     throw new WLUsageError('Invalid sort criteria for ' + representation);
   }
+
+  return criteria;
 }
 
 /**
@@ -428,13 +434,4 @@ function NormalizeSortOptions(criteria) {
 
 function applyInOriginalCtx(fn, args) {
   return (_.partial.apply(null, [fn].concat(Array.prototype.slice.call(args))))();
-}
-
-if (process.env.NODE_ENV === 'test') {
-  module.exports.NotExposed = {
-    StandardizedForm: StandardizeForm,
-    ProcessWhereClauseAttributes: ProcessWhereClauseAttributes,
-    ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters,
-    NormalizeSortOptions: NormalizeSortOptions
-  };
 }

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -151,9 +151,7 @@ module.exports = {
   likeCriteria: function(criteria, attributes, enhancer) {
 
     // Only accept criteria as an object
-    if (criteria !== Object(criteria)) return false;
-
-    criteria = _.clone(criteria);
+    if (!_.isObject(criteria)) return false;
 
     if (!criteria.where) criteria = { where: criteria };
 

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -12,12 +12,11 @@ module.exports = {
 
     // Default to id as primary key
     var pk = 'id';
-
     // If autoPK is not used, attempt to find a primary key
     if (!context.autoPK) {
       // Check which attribute is used as primary key
       for (var key in context.attributes) {
-        if (!util.object.hasOwnProperty(context.attributes[key], 'primaryKey')) continue;
+        if (!hop(context.attributes[key], 'primaryKey')) continue;
 
         // Check if custom primaryKey value is falsy
         if (!context.attributes[key].primaryKey) continue;
@@ -42,7 +41,6 @@ module.exports = {
     // If we're querying by primary key, create a coercion function for it
     // depending on the data type of the key
     if (options && options[pk]) {
-
       var coercePK;
       if (context.attributes[pk].type === 'integer') {
         coercePK = function(pk) {return +pk;};
@@ -55,6 +53,8 @@ module.exports = {
       }
 
       // If the criteria is an array of PKs, coerce them all
+      // given options [1, 2, 3], it looks up the type and then
+      // converts each of the members of the array to that type
       if (Array.isArray(options[pk])) {
         options[pk] = options[pk].map(coercePK);
 
@@ -323,10 +323,11 @@ function ProcessWhereClauseAttributes(criteria) {
     return hop(criteria.where, prop);
   };
 
-  // there were multiple identical checks for properties. One thing to note:
-  // this also used to validate the limit and skip properties, as well as parse them
-  // to ints. Here we blindly move those values and leave it to the validate method
-  // to parse those values rather than here.
+  // there were multiple identical checks for properties. One thing to
+  // note: this also used to validate the limit and skip properties,
+  // as well as parse them to ints. Here we blindly move those values
+  // and leave it to the validate method to parse those values rather
+  // than here.
   var propertiesToCheck = [
     'limit', 'skip', 'sort', 'sum', 'average', 'groupBy', 'min',
     'min', 'max', 'select'
@@ -343,12 +344,6 @@ function ProcessWhereClauseAttributes(criteria) {
   if (criteria.where && _.keys(criteria.where).length === 0) {
     criteria.where = null;
   }
-
-  // if (hasA('limit')) {
-  //   criteria.limit = parseInt(_.clone(criteria.where.limit), 10);
-  //   if (criteria.limit < 0) criteria.limit = 0;
-  //   delete criteria.where.limit;
-  // }
 }
 
 function ValidateLimitAndSkipParameters(criteria) {

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -371,7 +371,7 @@ function ValidateLimitAndSkipParameters(criteria) {
 // transformed into {sort: {column: -1}}
 function NormalizeSortOptions(criteria) {
   // if no sort clause, let's bail
-  if (!(hop(criteria, 'sort') && criteria.sort !== null) ) return;
+  if (!(hop(criteria, 'sort') && criteria.sort !== null)) return;
 
   // transform string versions into objects
   // Split string into attr and sortDirection parts (default to 'asc')

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -124,16 +124,16 @@ module.exports = {
         throw new WLUsageError('An `or` clause in a query should be specified as an array of subcriteria');
       }
 
-      var _clone = _.cloneDeep(criteria.where.or);
-      criteria.where.or.forEach(function(clause, i) {
-        Object.keys(clause).forEach(function(key) {
-          if (Array.isArray(clause[key]) && clause[key].length === 0) {
-            _clone.splice(i, 1);
+      _.reduce(criteria.where.or, function(orClauses, clause, i) {
+        // if clause contains an empty array, then delete it
+        _.each(clause, function(value) {
+          if (Array.isArray(value)) {
+            // is is the clause index. If we found an empty array,
+            // delete the whole clause
+            orClauses.splice(i, 1);
           }
         });
       });
-
-      criteria.where.or = _clone;
     }
 
     // Normalize sort criteria

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -4,8 +4,14 @@ var hop = util.object.hasOwnProperty;
 var switchback = require('switchback');
 var errorify = require('../error');
 var WLUsageError = require('../error/WLUsageError');
-
-var normalize = module.exports = {
+if (process.env.NODE_ENV === "test" ) {
+  module.exports.NotExposed = {
+    StandardizedForm:  StandardizeForm,
+    ProcessWhereClauseAttributes:  ProcessWhereClauseAttributes,
+    ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters
+  };
+}
+module.exports = {
 
   // Expand Primary Key criteria into objects
   expandPK: function(context, options) {
@@ -44,12 +50,12 @@ var normalize = module.exports = {
     if (options && options[pk]) {
 
       var coercePK;
-      if (context.attributes[pk].type == 'integer') {
+      if (context.attributes[pk].type === 'integer') {
         coercePK = function(pk) {return +pk;};
-      } else if (context.attributes[pk].type == 'string') {
+      } else if (context.attributes[pk].type === 'STRING') {
         coercePK = function(pk) {return String(pk).toString();};
 
-      // If the data type is unspecified, return the key as-is
+        // If the data type is unspecified, return the key as-is
       } else {
         coercePK = function(pk) {return pk;};
       }
@@ -58,7 +64,7 @@ var normalize = module.exports = {
       if (Array.isArray(options[pk])) {
         options[pk] = options[pk].map(coercePK);
 
-      // Otherwise just coerce the one
+        // Otherwise just coerce the one
       } else {
         if (!_.isObject(options[pk])) {
           options[pk] = coercePK(options[pk]);
@@ -88,105 +94,22 @@ var normalize = module.exports = {
     // where we need the PK of the collection or a .findOrCreateEach
     if (Array.isArray(criteria)) return criteria;
 
-    // Empty undefined values from criteria object
-    _.each(criteria, function(val, key) {
-      if (_.isUndefined(val)) criteria[key] = null;
-    });
-
-    // Convert non-objects (ids) into a criteria
-    // TODO: use customizable primary key attribute
-    if (!_.isObject(criteria)) {
-      criteria = {
-        id: +criteria || criteria
-      };
-    }
-
-    if (_.isObject(criteria) && !criteria.where && criteria.where !== null) {
-      criteria = { where: criteria };
-    }
-
-    // Return string to indicate an error
-    if (!_.isObject(criteria)) throw new WLUsageError('Invalid options/criteria :: ' + criteria);
-
-    // If criteria doesn't seem to contain operational keys, assume all the keys are criteria
-    if (!criteria.where && !criteria.joins && !criteria.join && !criteria.limit && !criteria.skip &&
-      !criteria.sort && !criteria.sum && !criteria.average &&
-      !criteria.groupBy && !criteria.min && !criteria.max && !criteria.select) {
-
-      // Delete any residuals and then use the remaining keys as attributes in a criteria query
-      delete criteria.where;
-      delete criteria.joins;
-      delete criteria.join;
-      delete criteria.limit;
-      delete criteria.skip;
-      delete criteria.sort;
-      criteria = {
-        where: criteria
-      };
-
-    // If where is null, turn it into an object
-    } else if (_.isNull(criteria.where)) criteria.where = {};
+    // standardize form a little bit. If a primitive, turn into {id: primitive}
+    // add where clause if not found, delete extraneous keys if no real structure to object
+    criteria = StandardizeForm(criteria);
 
 
     // Move Limit, Skip, sort outside the where criteria
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'limit')) {
-      criteria.limit = parseInt(_.clone(criteria.where.limit), 10);
-      if (criteria.limit < 0) criteria.limit = 0;
-      delete criteria.where.limit;
-    } else if (hop(criteria, 'limit')) {
-      criteria.limit = parseInt(criteria.limit, 10);
-      if (criteria.limit < 0) criteria.limit = 0;
-    }
-
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'skip')) {
-      criteria.skip = parseInt(_.clone(criteria.where.skip), 10);
-      if (criteria.skip < 0) criteria.skip = 0;
-      delete criteria.where.skip;
-    } else if (hop(criteria, 'skip')) {
-      criteria.skip = parseInt(criteria.skip, 10);
-      if (criteria.skip < 0) criteria.skip = 0;
-    }
-
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'sort')) {
-      criteria.sort = _.clone(criteria.where.sort);
-      delete criteria.where.sort;
-    }
-
-    // Pull out aggregation keys from where key
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'sum')) {
-      criteria.sum = _.clone(criteria.where.sum);
-      delete criteria.where.sum;
-    }
-
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'average')) {
-      criteria.average = _.clone(criteria.where.average);
-      delete criteria.where.average;
-    }
-
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'groupBy')) {
-      criteria.groupBy = _.clone(criteria.where.groupBy);
-      delete criteria.where.groupBy;
-    }
-
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'min')) {
-      criteria.min = _.clone(criteria.where.min);
-      delete criteria.where.min;
-    }
-
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'max')) {
-      criteria.max = _.clone(criteria.where.max);
-      delete criteria.where.max;
-    }
-
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'select')) {
-      criteria.select = _.clone(criteria.where.select);
-      delete criteria.where.select;
-    }
+    ProcessWhereClauseAttributes(criteria);
 
     // If WHERE is {}, always change it back to null
     if (criteria.where && _.keys(criteria.where).length === 0) {
       criteria.where = null;
     }
+
+    // limit and skip clauses could exist chained and now we validate they don't
+    // call to skip -3 or skip -4 results. Check these arguments are above 0
+    ValidateLimitAndSkipParameters(criteria);
 
     // If an IN was specified in the top level query and is an empty array, we can return an
     // empty object without running the query because nothing will match anyway. Let's return
@@ -389,17 +312,141 @@ function isNumbery(value) {
   return Math.pow(+value, 2) > 0;
 }
 
-// Replace % with %%%
-function escapeLikeQuery(likeCriterion) {
-  return likeCriterion.replace(/[^%]%[^%]/g, '%%%');
+function StandardizeForm(criteria) {
+  // Empty undefined values from criteria object
+  _.each(criteria, function(val, key) {
+    if (_.isUndefined(val)) criteria[key] = null;
+  });
+
+  // Convert non-objects (ids) into a criteria
+  // TODO: use customizable primary key attribute
+  if (!_.isObject(criteria)) {
+    criteria = {
+      id: +criteria || criteria
+    };
+  }
+
+  if (_.isObject(criteria) && !criteria.where && criteria.where !== null) {
+    criteria = { where: criteria };
+  }
+
+  // Return string to indicate an error
+  if (!_.isObject(criteria)) throw new WLUsageError('Invalid options/criteria :: ' + criteria);
+
+  // If criteria doesn't seem to contain operational keys, assume all the keys are criteria
+  if (!criteria.where && !criteria.joins && !criteria.join && !criteria.limit && !criteria.skip &&
+      !criteria.sort && !criteria.sum && !criteria.average &&
+      !criteria.groupBy && !criteria.min && !criteria.max && !criteria.select) {
+
+    // Delete any residuals and then use the remaining keys as attributes in a criteria query
+    delete criteria.where;
+    delete criteria.joins;
+    delete criteria.join;
+    delete criteria.limit;
+    delete criteria.skip;
+    delete criteria.sort;
+    criteria = {
+      where: criteria
+    };
+
+    // If where is null, turn it into an object
+  } else if (_.isNull(criteria.where)) criteria.where = {};
+
+  return criteria;
 }
 
-// Replace %%% with %
-function unescapeLikeQuery(likeCriterion) {
-  return likeCriterion.replace(/%%%/g, '%');
+// we move limit, skip, sort, sum, etc. clauses from nested within the
+// where clause to their own properties at the top level of the
+// criteria object.
+// Eg: {where: {id: 4, skip: 5}} ==>
+//            {where: {id: 4}, skip: 5}
+// We are normalizing the form
+function ProcessWhereClauseAttributes(criteria) {
+
+  // if no where clause, there is no processing to do
+  var whereExists = hop(criteria, 'where') && criteria.where !== null;
+  if (!whereExists) return;
+
+  var hasA = function(prop) {
+    return hop(criteria.where, prop);
+  };
+
+  // there were multiple identical checks for properties. One thing to note:
+  // this also used to validate the limit and skip properties, as well as parse them
+  // to ints. Here we blindly move those values and leave it to the validate method
+  // to parse those values rather than here.
+
+  var propertiesToCheck = [
+    'limit', 'skip', 'sort', 'sum', 'average', 'groupBy', 'min',
+    'min', 'max', 'select'
+  ];
+  _.forEach(propertiesToCheck, function(prop) {
+    if (hasA(prop)) {
+      criteria.prop = _.clone(criteria.where.prop);
+      delete criteria.where.prop;
+    }
+  });
+
+  // if (hasA('limit')) {
+  //   criteria.limit = parseInt(_.clone(criteria.where.limit), 10);
+  //   if (criteria.limit < 0) criteria.limit = 0;
+  //   delete criteria.where.limit;
+  // }
+
+  // if (hasA('skip')) {
+  //   criteria.skip = parseInt(_.clone(criteria.where.skip), 10);
+  //   if (criteria.skip < 0) criteria.skip = 0;
+  //   delete criteria.where.skip;
+  // }
+
+  // if (hasA('sort')) {
+  //   criteria.sort = _.clone(criteria.where.sort);
+  //   delete criteria.where.sort;
+  // }
+
+  // // Pull out aggregation keys from where key
+  // if (hasA('sum')) {
+  //   criteria.sum = _.clone(criteria.where.sum);
+  //   delete criteria.where.sum;
+  // }
+
+  // if (hasA('average')) {
+  //   criteria.average = _.clone(criteria.where.average);
+  //   delete criteria.where.average;
+  // }
+
+  // if (hasA('groupBy')) {
+  //   criteria.groupBy = _.clone(criteria.where.groupBy);
+  //   delete criteria.where.groupBy;
+  // }
+
+  // if (hasA('min')) {
+  //   criteria.min = _.clone(criteria.where.min);
+  //   delete criteria.where.min;
+  // }
+
+  // if (hasA('max')) {
+  //   criteria.max = _.clone(criteria.where.max);
+  //   delete criteria.where.max;
+  // }
+
+  // if (hasA('select')) {
+  //   criteria.select = _.clone(criteria.where.select);
+  //   delete criteria.where.select;
+  // }
 }
 
+function ValidateLimitAndSkipParameters(criteria) {
+  if (hop(criteria, 'limit')) {
+    criteria.limit = parseInt(criteria.limit, 10);
+    if (criteria.limit < 0) criteria.limit = 0;
+  }
 
+  if (hop(criteria, 'skip')) {
+    criteria.skip = parseInt(criteria.skip, 10);
+    if (criteria.skip < 0) criteria.skip = 0;
+  }
+}
 /**
  * Like _.partial, but accepts an array of arguments instead of
  * comma-seperated args (if _.partial is `call`, this is `apply`.)

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -417,10 +417,10 @@ function applyInOriginalCtx(fn, args) {
   return (_.partial.apply(null, [fn].concat(Array.prototype.slice.call(args))))();
 }
 
-if (process.env.NODE_ENV === "test" ){
+if (process.env.NODE_ENV === 'test') {
   module.exports.NotExposed = {
-    StandardizedForm:  StandardizeForm,
-    ProcessWhereClauseAttributes:  ProcessWhereClauseAttributes,
+    StandardizedForm: StandardizeForm,
+    ProcessWhereClauseAttributes: ProcessWhereClauseAttributes,
     ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters
   };
 }

--- a/lib/waterline/utils/schema.js
+++ b/lib/waterline/utils/schema.js
@@ -3,7 +3,6 @@
  */
 
 var _ = require('lodash');
-var types = require('./types');
 var callbacks = require('./callbacks');
 var hasOwnProperty = require('./helpers').object.hasOwnProperty;
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,18 @@
+{
+  "globals": {
+    "it": true,
+    "describe": true
+  },
+
+  "extends": "standard-warn",
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "eqeqeq":                       [1, "smart"],
+    "no-multiple-empty-lines":      [1, {"max": 2}],
+    "semi":                         [1, "always"],
+    "space-before-function-paren":  [1, "never"],
+    "spaced-comment":               [1, "always", {"exceptions": ["/"]}]
+  }
+}

--- a/test/unit/query/query.find.js
+++ b/test/unit/query/query.find.js
@@ -67,7 +67,6 @@ describe('Collection Query', function() {
       .limit(1)
       .skip(1)
       .sort({ name: 'desc' })
-      .sort("name desc")
       .exec(function(err, results) {
         assert(!err);
         assert(Array.isArray(results));

--- a/test/unit/query/query.find.js
+++ b/test/unit/query/query.find.js
@@ -66,7 +66,8 @@ describe('Collection Query', function() {
       .where({ id: { '>': 1 } })
       .limit(1)
       .skip(1)
-      .sort({ name: 0 })
+      .sort({ name: 'desc' })
+      .sort("name desc")
       .exec(function(err, results) {
         assert(!err);
         assert(Array.isArray(results));

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -53,9 +53,48 @@ describe("Normalize utility", function() {
       });
 
       it('should handle multiple clauses in the where clause', function() {
-        var criteria = {where: {skip: 5, sort: "ASC", limit: 7}};
-        var expected = {where: null, skip: 5, sort: "ASC", limit: 7};
+        var criteria = {where: {skip: 5, sort: "ASC", limit: 7, id:4}};
+        var expected = {where: {id: 4}, skip: 5, sort: "ASC", limit: 7};
         process(criteria);
+        assert.deepEqual(expected, criteria);
+      });
+
+      it('should make empty where clauses null', function() {
+        var criteria = {where: {skip: 5, sort: "ASC"}};
+        var expected = {where: null, skip: 5, sort: "ASC"};
+        process(criteria);
+        assert.deepEqual(expected, criteria);
+      });
+    });
+
+    describe("Skip and Limit Attribute Validator", function() {
+      var validate = units.ValidateLimitAndSkipParameters;
+
+      it("skip should turn negative numbers to zero", function() {
+        var criteria = {skip: -4};
+        var expected = {skip: 0};
+        validate(criteria);
+        assert.deepEqual(expected, criteria);
+      });
+
+      it("limit should turn negative numbers to zero", function() {
+        var criteria = {limit: -63823};
+        var expected = {limit: 0};
+        validate(criteria);
+        assert.deepEqual(expected, criteria);
+      });
+
+      it("skip should parse strings", function() {
+        var criteria = {skip: "4"};
+        var expected = {skip: 4};
+        validate(criteria);
+        assert.deepEqual(expected, criteria);
+      });
+
+      it("limit should parse strings", function() {
+        var criteria = {limit: "42"};
+        var expected = {limit: 42};
+        validate(criteria);
         assert.deepEqual(expected, criteria);
       });
     });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -155,4 +155,50 @@ describe('Normalize utility', function() {
     });
   });
 
+  describe('expandPK', function() {
+    describe('primary key finding', function() {
+      it('should default to id', function() {
+        var options = 4;
+        var result = normalize.expandPK({attributes: {id: {type: 'integer'}}}, options);
+        assert.equal(result.id, options);
+      });
+
+      it('should find the primary key', function() {
+        var options = 4;
+        var context = {attributes: {key: {type: 'integer', primaryKey: true}}};
+        var result = normalize.expandPK(context, options);
+        assert.equal(result.key, options);
+      });
+    });
+
+    describe('return primary key coercion function', function() {
+      it('should build an integer coercion function for integer type', function() {
+        var options = "4";
+        var context = {attributes: {key: {type: 'integer', primaryKey: true}}};
+        var processed = normalize.expandPK(context, options);
+        var expectedType = 'number';
+        var foundType = typeof(processed.key);
+        assert.equal(foundType, expectedType);
+      });
+
+      it('should build an string coercion function for string type', function() {
+        var options = "4";
+        var context = {attributes: {key: {type: 'STRING', primaryKey: true}}};
+        var processed = normalize.expandPK(context, options);
+        var expectedType = 'string';
+        var foundType = typeof(processed.key);
+        assert.equal(foundType, expectedType);
+      });
+
+      it('should coerce all elements of an array if given an array', function() {
+        var options = [1, 2, 3];
+        var context = {attributes: {key: {type: 'STRING', primaryKey: true}}};
+        var processed = normalize.expandPK(context, options);
+        var expectedType = 'string';
+        console.log(processed);
+        var foundType = typeof(processed.key[0]);
+        assert.equal(foundType, expectedType);
+      });
+    });
+  });
 });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -54,7 +54,7 @@ describe("Normalize utility", function() {
 
       it('should handle multiple clauses in the where clause', function() {
         var criteria = {where: {skip: 5, sort: "ASC", limit: 7}};
-        var expected = {where: {}, skip: 5, sort: "ASC", limit: 7};
+        var expected = {where: null, skip: 5, sort: "ASC", limit: 7};
         process(criteria);
         assert.deepEqual(expected, criteria);
       });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -1,13 +1,54 @@
 var assert = require('assert'),
-    normalize = require('../../../lib/waterline/utils/normalize');
+    normalize = require('../../../lib/waterline/utils/normalize'),
+    units = normalize.NotExposed;
 
 describe("Normalize utility", function() {
 
   describe(".criteria()", function() {
 
+    describe("default checks", function() {
+      it("should return false if given false", function() {
+        var criteria = normalize.criteria(false);
+        assert(criteria === false);
+      });
+
+      it("should return arrays to the calling method", function() {
+        var criteria = [1,2,3];
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(criteria, result);
+      });
+
+      it("should change undefined values to null", function() {
+        var undefinedValue;
+        var criteria = {id: undefinedValue};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual({where: {id:null}}, result);
+      });
+
+      it("should wrap primitives with an id tag", function() {
+        var primitives = [1,-17,"idtag"];
+        for (var i = 0; i < primitives.length; i++) {
+          var prop = primitives[i];
+          var result = normalize.criteria(prop);
+          assert.deepEqual({where: {id: prop}}, result);
+        }
+      });
+
+      it("should not add a where clause if already present", function() {
+        var criteria = {where: {id: 4}};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(criteria, result);
+      });
+    });
+
+    // describe("Where Clause Attribute Transformation", function() {
+
+    // })
+
     describe("sort", function() {
       it("should default to asc", function() {
         var criteria = normalize.criteria({ sort: "name" });
+        console.log(criteria);
 
         assert(criteria.sort.name === 1);
       });
@@ -26,17 +67,18 @@ describe("Normalize utility", function() {
 
       it("should properly normalize valid sort", function() {
         var criteria = normalize.criteria({ sort: "name desc" });
+        console.log(criteria);
 
         assert(criteria.sort.name === -1);
       });
-      
+
       it("should properly normalize valid sort with upper case", function() {
         var criteria = normalize.criteria({ sort: "name DESC" });
-
+        console.log(criteria);
         assert(criteria.sort.name === -1);
       });
     });
-    
+
     describe("sort object", function() {
       it("should throw error on invalid order", function() {
         var error;
@@ -49,12 +91,13 @@ describe("Normalize utility", function() {
 
         assert(typeof error !== 'undefined');
       });
-      
+
       it("should properly normalize valid sort", function() {
         var criteria = normalize.criteria({ sort: { name: "asc" } });
+        console.log(criteria);
         assert(criteria.sort.name === 1);
       });
-      
+
       it("should properly normalize valid sort with upper case", function() {
         var criteria = normalize.criteria({ sort: { name: "DESC" } });
         assert(criteria.sort.name === -1);

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -195,10 +195,43 @@ describe('Normalize utility', function() {
         var context = {attributes: {key: {type: 'STRING', primaryKey: true}}};
         var processed = normalize.expandPK(context, options);
         var expectedType = 'string';
-        console.log(processed);
         var foundType = typeof(processed.key[0]);
         assert.equal(foundType, expectedType);
       });
+    });
+  });
+
+  describe('likeCriteria', function() {
+    var like = normalize.likeCriteria;
+    it('should return false if not given an object', function() {
+      var criteria = 3;
+      var result = like(criteria);
+      var expected = false;
+      assert.equal(result, expected);
+    });
+
+    it('should add a where clause', function() {
+      var criteria = {id: 4};
+      var expected = {where: {like: {id: 4}}};
+      var result = like(criteria);
+      assert.deepEqual(result, expected);
+    });
+
+    it('should not add an extra where clause', function() {
+      var criteria = {where: {id: 4}};
+      var expected = {where: {like: {id: 4}}};
+      var result = like(criteria);
+      assert.deepEqual(result, expected);
+    });
+
+    it('should apply the enhancer funciton', function() {
+      var enhancer = function applyStartsWith(criteria) {
+        return criteria + '%';
+      };
+      var criteria = {where: {name: "Bob"}};
+      var expected = {where: {like: {name: "Bob%"}}};
+      var result = like(criteria, {}, enhancer);
+      assert.deepEqual(result, expected);
     });
   });
 });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
 var normalize = require('../../../lib/waterline/utils/normalize');
-var units = normalize.NotExposed;
 var WLUsageError = require('../../../lib/waterline/error/WLUsageError');
 
 
@@ -46,59 +45,57 @@ describe('Normalize utility', function() {
     });
 
     describe('Where Clause Attribute Transformation', function() {
-      var process = units.ProcessWhereClauseAttributes;
 
       it('should recognize a sort clause', function() {
         var criteria = {where: {id: 3, sort: 'ASC'}};
-        var expected = {where: {id: 3}, sort: 'ASC'};
-        process(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: {id: 3}, sort: {ASC: 1}};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
 
       it('should handle multiple clauses in the where clause', function() {
         var criteria = {where: {skip: 5, sort: 'ASC', limit: 7, id: 4}};
-        var expected = {where: {id: 4}, skip: 5, sort: 'ASC', limit: 7};
-        process(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: {id: 4}, skip: 5, sort: {ASC: 1}, limit: 7};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, expected);
       });
 
       it('should make empty where clauses null', function() {
         var criteria = {where: {skip: 5, sort: 'ASC'}};
-        var expected = {where: null, skip: 5, sort: 'ASC'};
-        process(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: null, skip: 5, sort: {ASC: 1}};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
     });
 
     describe('Skip and Limit Attribute Validator', function() {
-      var validate = units.ValidateLimitAndSkipParameters;
 
       it('skip should turn negative numbers to zero', function() {
         var criteria = {skip: -4};
-        var expected = {skip: 0};
-        validate(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: null, skip: 0};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
 
       it('limit should turn negative numbers to zero', function() {
         var criteria = {limit: -63823};
-        var expected = {limit: 0};
-        validate(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: null, limit: 0};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
 
       it('skip should parse strings', function() {
         var criteria = {skip: '4'};
-        var expected = {skip: 4};
-        validate(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: null, skip: 4};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
 
       it('limit should parse strings', function() {
         var criteria = {limit: '42'};
-        var expected = {limit: 42};
-        validate(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: null, limit: 42};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
     });
 
@@ -133,24 +130,24 @@ describe('Normalize utility', function() {
         assert(criteria.sort.name === -1);
       });
 
-      var sort = units.NormalizeSortOptions;
       it('should handle the binary format properly when given a 1', function() {
         var criteria = {sort: {column: 1}};
-        var expected = {sort: {column: 1}};
-        sort(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: null, sort: {column: 1}};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
 
       it('should handle the binary format properly when given a 0', function() {
         var criteria = {sort: {column: 0}};
-        var expected = {sort: {column: -1}};
-        sort(criteria);
-        assert.deepEqual(expected, criteria);
+        var expected = {where: null, sort: {column: -1}};
+        var result = normalize.criteria(criteria);
+        assert.deepEqual(expected, result);
       });
 
       it('should throw an error and description on nonrecognized input', function() {
         var criteria = {sort: [1, 2, 3]};
-        assert.throws(function() { sort(criteria); }, WLUsageError);
+        assert.throws(function() {
+          normalize.criteria(criteria); }, WLUsageError);
       });
     });
   });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -1,6 +1,7 @@
 var assert = require('assert'),
     normalize = require('../../../lib/waterline/utils/normalize'),
     units = normalize.NotExposed;
+var stform = require('../../../lib/waterline/utils/normalize').NotExposed;
 
 describe("Normalize utility", function() {
 
@@ -41,14 +42,27 @@ describe("Normalize utility", function() {
       });
     });
 
-    // describe("Where Clause Attribute Transformation", function() {
+    describe("Where Clause Attribute Transformation", function() {
+      var process = units.ProcessWhereClauseAttributes;
 
-    // })
+      it("should recognize a sort clause", function() {
+        var criteria = {where: {id: 3, sort: "ASC"}};
+        var expected = {where: {id: 3}, sort: "ASC"};
+        process(criteria);
+        assert.deepEqual(expected, criteria);
+      });
+
+      it('should handle multiple clauses in the where clause', function() {
+        var criteria = {where: {skip: 5, sort: "ASC", limit: 7}};
+        var expected = {where: {}, skip: 5, sort: "ASC", limit: 7};
+        process(criteria);
+        assert.deepEqual(expected, criteria);
+      });
+    });
 
     describe("sort", function() {
       it("should default to asc", function() {
         var criteria = normalize.criteria({ sort: "name" });
-        console.log(criteria);
 
         assert(criteria.sort.name === 1);
       });
@@ -67,14 +81,13 @@ describe("Normalize utility", function() {
 
       it("should properly normalize valid sort", function() {
         var criteria = normalize.criteria({ sort: "name desc" });
-        console.log(criteria);
 
         assert(criteria.sort.name === -1);
       });
 
       it("should properly normalize valid sort with upper case", function() {
         var criteria = normalize.criteria({ sort: "name DESC" });
-        console.log(criteria);
+
         assert(criteria.sort.name === -1);
       });
     });
@@ -94,7 +107,7 @@ describe("Normalize utility", function() {
 
       it("should properly normalize valid sort", function() {
         var criteria = normalize.criteria({ sort: { name: "asc" } });
-        console.log(criteria);
+
         assert(criteria.sort.name === 1);
       });
 

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -1,7 +1,7 @@
-var assert = require('assert'),
-    normalize = require('../../../lib/waterline/utils/normalize'),
-    units = normalize.NotExposed;
-var stform = require('../../../lib/waterline/utils/normalize').NotExposed;
+var assert = require('assert');
+var normalize = require('../../../lib/waterline/utils/normalize');
+var units = normalize.NotExposed;
+
 
 describe('Normalize utility', function() {
 
@@ -14,7 +14,7 @@ describe('Normalize utility', function() {
       });
 
       it('should return arrays to the calling method', function() {
-        var criteria = [1,2,3];
+        var criteria = [1, 2, 3];
         var result = normalize.criteria(criteria);
         assert.deepEqual(criteria, result);
       });
@@ -23,11 +23,11 @@ describe('Normalize utility', function() {
         var undefinedValue;
         var criteria = {id: undefinedValue};
         var result = normalize.criteria(criteria);
-        assert.deepEqual({where: {id:null}}, result);
+        assert.deepEqual({where: {id: null}}, result);
       });
 
       it('should wrap primitives with an id tag', function() {
-        var primitives = [1,-17,'idtag'];
+        var primitives = [1, -17, 'idtag'];
         for (var i = 0; i < primitives.length; i++) {
           var prop = primitives[i];
           var result = normalize.criteria(prop);
@@ -53,7 +53,7 @@ describe('Normalize utility', function() {
       });
 
       it('should handle multiple clauses in the where clause', function() {
-        var criteria = {where: {skip: 5, sort: 'ASC', limit: 7, id:4}};
+        var criteria = {where: {skip: 5, sort: 'ASC', limit: 7, id: 4}};
         var expected = {where: {id: 4}, skip: 5, sort: 'ASC', limit: 7};
         process(criteria);
         assert.deepEqual(expected, criteria);

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -1,6 +1,9 @@
 var assert = require('assert');
 var normalize = require('../../../lib/waterline/utils/normalize');
 var units = normalize.NotExposed;
+var WLUsageError = require('../../../lib/waterline/error/WLUsageError');
+
+
 
 
 describe('Normalize utility', function() {
@@ -129,33 +132,27 @@ describe('Normalize utility', function() {
 
         assert(criteria.sort.name === -1);
       });
-    });
 
-    describe('sort object', function() {
-      it('should throw error on invalid order', function() {
-        var error;
-
-        try {
-          normalize.criteria({ sort: { name: 'up' } });
-        } catch(e) {
-          error = e;
-        }
-
-        assert(typeof error !== 'undefined');
+      var sort = units.NormalizeSortOptions;
+      it('should handle the binary format properly when given a 1', function() {
+        var criteria = {sort: {column: 1}};
+        var expected = {sort: {column: 1}};
+        sort(criteria);
+        assert.deepEqual(expected, criteria);
       });
 
-      it('should properly normalize valid sort', function() {
-        var criteria = normalize.criteria({ sort: { name: 'asc' } });
-
-        assert(criteria.sort.name === 1);
+      it('should handle the binary format properly when given a 0', function() {
+        var criteria = {sort: {column: 0}};
+        var expected = {sort: {column: -1}};
+        sort(criteria);
+        assert.deepEqual(expected, criteria);
       });
 
-      it('should properly normalize valid sort with upper case', function() {
-        var criteria = normalize.criteria({ sort: { name: 'DESC' } });
-        assert(criteria.sort.name === -1);
+      it('should throw an error and description on nonrecognized input', function() {
+        var criteria = {sort: [1, 2, 3]};
+        assert.throws(function() { sort(criteria); }, WLUsageError);
       });
     });
-
   });
 
 });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -3,31 +3,31 @@ var assert = require('assert'),
     units = normalize.NotExposed;
 var stform = require('../../../lib/waterline/utils/normalize').NotExposed;
 
-describe("Normalize utility", function() {
+describe('Normalize utility', function() {
 
-  describe(".criteria()", function() {
+  describe('.criteria()', function() {
 
-    describe("default checks", function() {
-      it("should return false if given false", function() {
+    describe('default checks', function() {
+      it('should return false if given false', function() {
         var criteria = normalize.criteria(false);
         assert(criteria === false);
       });
 
-      it("should return arrays to the calling method", function() {
+      it('should return arrays to the calling method', function() {
         var criteria = [1,2,3];
         var result = normalize.criteria(criteria);
         assert.deepEqual(criteria, result);
       });
 
-      it("should change undefined values to null", function() {
+      it('should change undefined values to null', function() {
         var undefinedValue;
         var criteria = {id: undefinedValue};
         var result = normalize.criteria(criteria);
         assert.deepEqual({where: {id:null}}, result);
       });
 
-      it("should wrap primitives with an id tag", function() {
-        var primitives = [1,-17,"idtag"];
+      it('should wrap primitives with an id tag', function() {
+        var primitives = [1,-17,'idtag'];
         for (var i = 0; i < primitives.length; i++) {
           var prop = primitives[i];
           var result = normalize.criteria(prop);
@@ -35,82 +35,82 @@ describe("Normalize utility", function() {
         }
       });
 
-      it("should not add a where clause if already present", function() {
+      it('should not add a where clause if already present', function() {
         var criteria = {where: {id: 4}};
         var result = normalize.criteria(criteria);
         assert.deepEqual(criteria, result);
       });
     });
 
-    describe("Where Clause Attribute Transformation", function() {
+    describe('Where Clause Attribute Transformation', function() {
       var process = units.ProcessWhereClauseAttributes;
 
-      it("should recognize a sort clause", function() {
-        var criteria = {where: {id: 3, sort: "ASC"}};
-        var expected = {where: {id: 3}, sort: "ASC"};
+      it('should recognize a sort clause', function() {
+        var criteria = {where: {id: 3, sort: 'ASC'}};
+        var expected = {where: {id: 3}, sort: 'ASC'};
         process(criteria);
         assert.deepEqual(expected, criteria);
       });
 
       it('should handle multiple clauses in the where clause', function() {
-        var criteria = {where: {skip: 5, sort: "ASC", limit: 7, id:4}};
-        var expected = {where: {id: 4}, skip: 5, sort: "ASC", limit: 7};
+        var criteria = {where: {skip: 5, sort: 'ASC', limit: 7, id:4}};
+        var expected = {where: {id: 4}, skip: 5, sort: 'ASC', limit: 7};
         process(criteria);
         assert.deepEqual(expected, criteria);
       });
 
       it('should make empty where clauses null', function() {
-        var criteria = {where: {skip: 5, sort: "ASC"}};
-        var expected = {where: null, skip: 5, sort: "ASC"};
+        var criteria = {where: {skip: 5, sort: 'ASC'}};
+        var expected = {where: null, skip: 5, sort: 'ASC'};
         process(criteria);
         assert.deepEqual(expected, criteria);
       });
     });
 
-    describe("Skip and Limit Attribute Validator", function() {
+    describe('Skip and Limit Attribute Validator', function() {
       var validate = units.ValidateLimitAndSkipParameters;
 
-      it("skip should turn negative numbers to zero", function() {
+      it('skip should turn negative numbers to zero', function() {
         var criteria = {skip: -4};
         var expected = {skip: 0};
         validate(criteria);
         assert.deepEqual(expected, criteria);
       });
 
-      it("limit should turn negative numbers to zero", function() {
+      it('limit should turn negative numbers to zero', function() {
         var criteria = {limit: -63823};
         var expected = {limit: 0};
         validate(criteria);
         assert.deepEqual(expected, criteria);
       });
 
-      it("skip should parse strings", function() {
-        var criteria = {skip: "4"};
+      it('skip should parse strings', function() {
+        var criteria = {skip: '4'};
         var expected = {skip: 4};
         validate(criteria);
         assert.deepEqual(expected, criteria);
       });
 
-      it("limit should parse strings", function() {
-        var criteria = {limit: "42"};
+      it('limit should parse strings', function() {
+        var criteria = {limit: '42'};
         var expected = {limit: 42};
         validate(criteria);
         assert.deepEqual(expected, criteria);
       });
     });
 
-    describe("sort", function() {
-      it("should default to asc", function() {
-        var criteria = normalize.criteria({ sort: "name" });
+    describe('sort', function() {
+      it('should default to asc', function() {
+        var criteria = normalize.criteria({ sort: 'name' });
 
         assert(criteria.sort.name === 1);
       });
 
-      it("should throw error on invalid order", function() {
+      it('should throw error on invalid order', function() {
         var error;
 
         try {
-          normalize.criteria({ sort: "name up" });
+          normalize.criteria({ sort: 'name up' });
         } catch(e) {
           error = e;
         }
@@ -118,25 +118,25 @@ describe("Normalize utility", function() {
         assert(typeof error !== 'undefined');
       });
 
-      it("should properly normalize valid sort", function() {
-        var criteria = normalize.criteria({ sort: "name desc" });
+      it('should properly normalize valid sort', function() {
+        var criteria = normalize.criteria({ sort: 'name desc' });
 
         assert(criteria.sort.name === -1);
       });
 
-      it("should properly normalize valid sort with upper case", function() {
-        var criteria = normalize.criteria({ sort: "name DESC" });
+      it('should properly normalize valid sort with upper case', function() {
+        var criteria = normalize.criteria({ sort: 'name DESC' });
 
         assert(criteria.sort.name === -1);
       });
     });
 
-    describe("sort object", function() {
-      it("should throw error on invalid order", function() {
+    describe('sort object', function() {
+      it('should throw error on invalid order', function() {
         var error;
 
         try {
-          normalize.criteria({ sort: { name: "up" } });
+          normalize.criteria({ sort: { name: 'up' } });
         } catch(e) {
           error = e;
         }
@@ -144,14 +144,14 @@ describe("Normalize utility", function() {
         assert(typeof error !== 'undefined');
       });
 
-      it("should properly normalize valid sort", function() {
-        var criteria = normalize.criteria({ sort: { name: "asc" } });
+      it('should properly normalize valid sort', function() {
+        var criteria = normalize.criteria({ sort: { name: 'asc' } });
 
         assert(criteria.sort.name === 1);
       });
 
-      it("should properly normalize valid sort with upper case", function() {
-        var criteria = normalize.criteria({ sort: { name: "DESC" } });
+      it('should properly normalize valid sort with upper case', function() {
+        var criteria = normalize.criteria({ sort: { name: 'DESC' } });
         assert(criteria.sort.name === -1);
       });
     });


### PR DESCRIPTION
## Summary of some of changes

Hi. I started to learn your project by cleaning up some eslint errors. I started in the normalize.js file, which was the last on the output list, and have that file producing no new errors and warnings. There were some unknown variables I wanted to clean up but I didn't know what was going on. I ended up writing some tests and then refactoring and have the results below. There may be some controversial things about this branch so I wanted to list them here:
- Adds an eslintrc file to ~/test/.  This allows for the specification of global functions like "it", "describe". This would allow in the future differing standards for ~/lib/ and ~/test/. I saw in a discussion the project might want strict compliance in code, with warning compliance in ~/test/. This would allow for differing lint requirements to achieve this.
- In an effort to make smaller, more unit-y tests, I moved some functions out of the normalize::criteria() function. This makes the overall code more readable and has descriptive names. In an effort to make tests smaller and just test these particular code paths, I added the following to the normalize.js file:

``` javascript
    if (process.env.NODE_ENV === 'test') {
      module.exports.NotExposed = {
        StandardizedForm: StandardizeForm,
        ProcessWhereClauseAttributes: ProcessWhereClauseAttributes,
        ValidateLimitAndSkipParameters: ValidateLimitAndSkipParameters,
        NormalizeSortOptions: NormalizeSortOptions
      };
    }
```

This allows for testing inspection and calling of these functions, while not polluting namespace in production. In the test file, i expose them with simply, 

``` javascript
var units = normalize.NotExposed;
```

I realize this could be controversial, and it did require a change. The npm test runs with the environment already set to this. I had to add this to the `make coverage` options in the Makefile. A particular downside is that previously, you could run individual test files with `mocha test/unit/utils/utils.normalize.js` but they now require `NODE_ENV=test mocha test/unit/utils/utils.normalize.js`. It seems all other automated test scripts (test-unit, test-integration, coverage) now work.
- I have included comments in code trying to explain what objects look like. Should make code more readable and very abstract notions like "critieria" more tangible when reading code and deciphering function results.
- I have tried to use real objects in the test file. I figure a good place to learn what objects are under test is to use objects as close to real values as possible. The test code tries to follow a pattern of ingoing parameter and what to expect after. This is an example of the very tangible results of the functions, to help reasoning about function results easier. The function assert.deepEqual is liberally used so that object structure is more apparent to the code reader.

``` javascript
it('should recognize a sort clause', function() {
        var criteria = {where: {id: 3, sort: 'ASC'}};
        var expected = {where: {id: 3}, sort: 'ASC'};
        process(criteria);
        assert.deepEqual(expected, criteria);
      });
```
## Reasons to reject and possible changes to make compliant
- Obviously, the use of the node testing environmental variable could be objectionable to some. I could pull these functions out into a helper file and include it, and then move the tests to a new test file testing this helper. 
- Coding style. I have tried to follow styles to produce idiomatic javascript, but it is not my most used language. If there is anything that looks particularly strange, let me know. One possible objection is modifying objects in place and not returning a new copy of it. For instance, the following calls all modify the criteria object in place and never change the original pointer--so from my perspective, why return anything when it doesn't aid us. Note that StandardizeForm can change the value of the original pointer, ie, `criteria = {id: criteria}` and therefore must return. The others have a known object so they can just change attributes as necessary. Not sure which way the wind blows on this one.

``` javascript
// standardize form a little bit. If a primitive, turn into {id: primitive}
    // add where clause if not found, delete extraneous keys if no real structure to object
    criteria = StandardizeForm(criteria);


    // Move Limit, Skip, sort outside the where criteria
    ProcessWhereClauseAttributes(criteria);


    // limit and skip clauses could exist chained and now we validate they don't
    // call to skip -3 or skip -4 results. Check these arguments are above 0
    ValidateLimitAndSkipParameters(criteria);
```
- Commit style. At work, we trying to commit in small logical units. I'm not sure what etiquette is like on larger open projects like this. I could understand if you'd like all of these commits squashed into one or two at most so that the history isn't polluted with so many commits for just a simple refactor of a single file.
