### PR TITLE
Adding default encoding option at the table level

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ var User = Waterline.Collection.extend({
   // Define an adapter to use
   adapter: 'postgresql',
 
+  // Define default encoding
+  encoding: {charset: 'utf8', collation: 'utf8_general_ci'},
+
   // Define attributes for this collection
   attributes: {
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Available options are:
   - `attributes` A hash of attributes to be defined for a model
   - `autoCreatedAt` and `autoUpdatedAt` Set false to prevent creating `createdAt` and `updatedAt` properties in your model
   - `autoPK` Set false to prevent creating `id`. By default `id` will be created as index with auto increment
-  - `encoding` Set default encoding for this model. Expects an object with `charset` and/or `collation` keys.
+  - `encoding` Set default encoding for this model. Expects an object with `charset` and/or `collation` properties.
   - [lifecyle callbacks](#lifecycle-callbacks)
   - any other class method you define!
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Available options are:
   - `attributes` A hash of attributes to be defined for a model
   - `autoCreatedAt` and `autoUpdatedAt` Set false to prevent creating `createdAt` and `updatedAt` properties in your model
   - `autoPK` Set false to prevent creating `id`. By default `id` will be created as index with auto increment
+  - `encoding` Set default encoding for this model
   - [lifecyle callbacks](#lifecycle-callbacks)
   - any other class method you define!
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Available options are:
   - `attributes` A hash of attributes to be defined for a model
   - `autoCreatedAt` and `autoUpdatedAt` Set false to prevent creating `createdAt` and `updatedAt` properties in your model
   - `autoPK` Set false to prevent creating `id`. By default `id` will be created as index with auto increment
-  - `encoding` Set default encoding for this model
+  - `encoding` Set default encoding for this model. Expects an object with `charset` and/or `collation` keys.
   - [lifecyle callbacks](#lifecycle-callbacks)
   - any other class method you define!
 

--- a/lib/waterline/collection/index.js
+++ b/lib/waterline/collection/index.js
@@ -37,6 +37,9 @@ var Collection = module.exports = function(waterline, connections, cb) {
   // Cache reference to the parent
   this.waterline = waterline;
 
+  // Set encoding for this collection
+  this.encoding = this.encoding || {};
+
   // Default Attributes
   this.attributes = this.attributes || {};
 


### PR DESCRIPTION
Currently, there is no way to specify default encoding for a table, other than to execute a query in Sails bootstrap.js.

This change allows users to specify a model property whose value consists of an object with `charset` and/or `collation` properties. This property can then be used by a DB adapter.