### PR TITLE
Pass valuesObject.criteria to beforeCallbacks

### DIFF
--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -167,12 +167,12 @@ function beforeCallbacks(valuesObject, cb) {
 
     // Run Validation with Validation LifeCycle Callbacks
     function(cb) {
-      callbacks.validate(self, valuesObject.values, true, cb, valuesObject.criteria);
+      callbacks.validate(self, valuesObject.values, valuesObject.criteria, true, cb);
     },
 
     // Before Update Lifecycle Callback
     function(cb) {
-      callbacks.beforeUpdate(self, valuesObject.values, cb, valuesObject.criteria);
+      callbacks.beforeUpdate(self, valuesObject.values, valuesObject.criteria, cb);
     }
 
   ], cb);

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -53,7 +53,7 @@ module.exports = function(criteria, values, cb) {
   createBelongsTo.call(this, valuesObject, function(err) {
     if (err) return cb(err);
 
-    beforeCallbacks.call(self, valuesObject.values, function(err) {
+    beforeCallbacks.call(self, valuesObject, function(err) {
       if (err) return cb(err);
       updateRecords.call(self, valuesObject, cb);
     });
@@ -156,23 +156,23 @@ function createBelongsTo(valuesObject, cb) {
 /**
  * Run Before* Lifecycle Callbacks
  *
- * @param {Object} values
+ * @param {Object} valuesObject
  * @param {Function} cb
  */
 
-function beforeCallbacks(values, cb) {
+function beforeCallbacks(valuesObject, cb) {
   var self = this;
 
   async.series([
 
     // Run Validation with Validation LifeCycle Callbacks
     function(cb) {
-      callbacks.validate(self, values, true, cb);
+      callbacks.validate(self, valuesObject.values, true, cb, valuesObject.criteria);
     },
 
     // Before Update Lifecycle Callback
     function(cb) {
-      callbacks.beforeUpdate(self, values, cb);
+      callbacks.beforeUpdate(self, valuesObject.values, cb, valuesObject.criteria);
     }
 
   ], cb);

--- a/lib/waterline/query/validate.js
+++ b/lib/waterline/query/validate.js
@@ -11,13 +11,28 @@ var async = require('async');
 
 module.exports = {
 
-  validate: function(values, presentOnly, cb) {
+  // validate(values, [criteria], [presentOnly], cb)
+  validate: function(values, criteria, presentOnly, cb) {
     var self = this;
 
-    // Handle optional second arg
-    if (typeof presentOnly === 'function') {
-      cb = presentOnly;
+    if (arguments.length === 2) {
+      // validate(values, cb)
+      values = arguments[0];
+      criteria = {};
       presentOnly = false;
+      cb = arguments[1];
+    } else if (arguments.length === 3 && typeof arguments[1] === 'boolean') {
+      // validate(values, presentOnly, cb)
+      values = arguments[0];
+      criteria = {};
+      presentOnly = arguments[1];
+      cb = arguments[2];
+    } else if (arguments.length === 3 && typeof arguments[1] === 'object') {
+      // validate(values, criteria, cb)
+      values = arguments[0];
+      criteria = arguments[1];
+      presentOnly = false;
+      cb = arguments[2];
     }
 
     async.series([
@@ -25,7 +40,7 @@ module.exports = {
       // Run Before Validate Lifecycle Callbacks
       function(cb) {
         var runner = function(item, callback) {
-          item.call(self, values, function(err) {
+          item.call(self, values, criteria, function(err) {
             if (err) return callback(err);
             callback();
           });

--- a/lib/waterline/utils/callbacksRunner.js
+++ b/lib/waterline/utils/callbacksRunner.js
@@ -16,13 +16,14 @@ var runner = module.exports = {};
  *
  * @param {Object} context
  * @param {Object} values
+ * @param {Object} criteria
  * @param {Boolean} presentOnly
  * @param {Function} cb
  * @api public
  */
 
-runner.validate = function(context, values, presentOnly, cb) {
-  context.validate(values, presentOnly, cb);
+runner.validate = function(context, values, criteria, presentOnly, cb) {
+  context.validate(values, criteria, presentOnly, cb);
 };
 
 
@@ -31,14 +32,15 @@ runner.validate = function(context, values, presentOnly, cb) {
  *
  * @param {Object} context
  * @param {Object} values
+ * @param {Object} criteria
  * @param {Function} cb
  * @api public
  */
 
-runner.beforeCreate = function(context, values, cb) {
+runner.beforeCreate = function(context, values, criteria, cb) {
 
   var fn = function(item, next) {
-    item.call(context, values, next);
+    item.call(context, values, criteria, next);
   };
 
   async.eachSeries(context._callbacks.beforeCreate, fn, cb);


### PR DESCRIPTION
Pass criteria to the beforeUpdate callbacks. Passes criteria as the last argument, which does not follow the Node.js convention of putting the callback last, but it would be a non-breaking change to existing implementations that expect arguments as they were.

Serves as a solution to issue #1004.