### PR TITLE
Adds support for arrays on populate, like populate(['drivers','tickets'])

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -84,7 +84,7 @@ Deferred.prototype.populateAll = function(criteria) {
  *
  * Used for populating associations.
  *
- * @param {String} key, the key to populate
+ * @param {String|Array} key, the key to populate or array of string keys
  * @return this
  * @chainable
  */
@@ -97,7 +97,15 @@ Deferred.prototype.populate = function(keyName, criteria) {
   var attr;
   var join;
 
-
+  // Adds support for arrays into keyName so that a list of
+  // populates can be passed
+  if (_.isArray(keyName)) {
+    keyName.forEach(function(populate) {
+      self.populate(populate, criteria);
+    });
+    return this;
+  }
+  
   // Normalize sub-criteria
   try {
     criteria = normalize.criteria(criteria);

--- a/test/unit/query/associations/populateArray.js
+++ b/test/unit/query/associations/populateArray.js
@@ -1,0 +1,102 @@
+var Waterline = require('../../../../lib/waterline'),
+    assert = require('assert');
+
+describe('Collection Query', function() {
+  describe('specific populated associations', function() {
+    var User;
+    var Car;
+    var Ticket;
+
+    before(function(done) {
+
+      var waterline = new Waterline();
+      var collections = {};
+
+      collections.user = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          car: {
+            model: 'car'
+          },
+          name: {
+            columnName: 'my_name',
+            type: 'string'
+          }
+        }
+      });
+
+      collections.ticket = Waterline.Collection.extend({
+        identity: 'ticket',
+        connection: 'foo',
+        attributes: {
+          reason: {
+            columnName: 'reason',
+            type: 'string'
+          },
+          car: {
+            model: 'car'
+          }
+        }
+      });
+
+      collections.car = Waterline.Collection.extend({
+        identity: 'car',
+        connection: 'foo',
+        attributes: {
+          driver: {
+            model: 'user',
+            columnName: 'foobar'
+          },
+          tickets: {
+              collection: 'ticket',
+              via: 'car'
+          }
+        }
+      });
+
+      waterline.loadCollection(collections.user);
+      waterline.loadCollection(collections.car);
+      waterline.loadCollection(collections.ticket);
+
+      // Fixture Adapter Def
+      var adapterDef = {
+        identity: 'foo',
+        find: function(con, col, criteria, cb) {
+          if(col === 'user') return cb(null, [{ id: 1, car: 1, name: 'John Doe' }]);
+          if(col === 'car') return cb(null, [{ id: 1, foobar: 1, tickets: [1, 2]}]);
+          if(col === 'ticket') return cb(null, [{ id: 1, reason: 'red light', car:1}, { id: 2, reason: 'Parking in a disabled space', car: 1 }]);
+          return cb();
+        }
+      };
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        User = colls.collections.user;
+        Car = colls.collections.car;
+        Ticket = colls.collections.ticket;
+        done();
+      });
+    });
+
+
+    it('should populate all related collections', function(done) {
+      Car.find().populate(['driver','tickets']).exec(function(err, car) {
+        if(err) return done(err);
+        assert(car[0].driver);
+        assert(car[0].driver.name);
+        assert(car[0].tickets);
+        assert(car[0].tickets[0].car);
+        assert(car[0].tickets[1].car);
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
Its the usecase in between using populate as it is right now and populateAll. In this case, you can set in a single populate call all the collections and modules that need to be populated.