### PR TITLE
Adds afterFind callback and associated specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ var User = Waterline.Collection.extend({
    * afterCreate
    * beforeDestroy
    * afterDestroy
+   * afterFind
    */
 
   beforeCreate: function(values, cb) {
@@ -545,6 +546,10 @@ Lifecycle callbacks are functions you can define to run at certain times in a qu
   - afterValidate / *fn(valuesToUpdate, cb)*
   - beforeUpdate / *fn(valuesToUpdate, cb)*
   - afterUpdate / *fn(updatedRecord, cb)*
+
+**Callbacks run on Find & FindOne**
+
+  - afterFind / *fn(values, cb)*
 
 **Callbacks run on Destroy**
 

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -6,6 +6,7 @@ var usageError = require('../../utils/usageError');
 var utils = require('../../utils/helpers');
 var normalize = require('../../utils/normalize');
 var sorter = require('../../utils/sorter');
+var callbacks = require('../../utils/callbacksRunner');
 var Deferred = require('../deferred');
 var Joins = require('./joins');
 var Operations = require('./operations');
@@ -177,7 +178,15 @@ module.exports = {
           models.push(new self._model(model, data.options));
         });
 
-        cb(null, models[0]);
+        return after(models[0]);
+      }
+
+      // Run After Find Callbacks
+      function after(model) {
+        callbacks.afterFind(self, model, function(err) {
+          if (err) return cb(err);
+          cb(null, model);
+        });
       }
     });
   },
@@ -388,8 +397,16 @@ module.exports = {
           models.push(new self._model(model, data.options));
         });
 
+        async.each(models, after, function(err) {
+          cb(err, models);
+        })
+      }
 
-        cb(null, models);
+      function after(model, callback) {
+        callbacks.afterFind(self, model, function(err) {
+          if (err) return callback(err);
+          callback(null, model);
+        });
       }
 
     });

--- a/lib/waterline/utils/callbacks.js
+++ b/lib/waterline/utils/callbacks.js
@@ -10,5 +10,6 @@ module.exports = [
   'beforeCreate',
   'afterCreate',
   'beforeDestroy',
-  'afterDestroy'
+  'afterDestroy',
+  'afterFind'
 ];

--- a/lib/waterline/utils/callbacksRunner.js
+++ b/lib/waterline/utils/callbacksRunner.js
@@ -138,3 +138,21 @@ runner.afterDestroy = function(context, values, cb) {
 
   async.eachSeries(context._callbacks.afterDestroy, fn, cb);
 };
+
+/**
+ * Run After Find Callbacks
+ *
+ * @param {Object} context
+ * @param {Object} values
+ * @param {Function} cb
+ * @api public
+ */
+
+runner.afterFind = function(context, values, cb) {
+
+  var fn = function(item, next) {
+    item.call(context, values, next);
+  };
+
+  async.eachSeries(context._callbacks.afterFind, fn, cb);
+};

--- a/test/unit/callbacks/afterFind.find.js
+++ b/test/unit/callbacks/afterFind.find.js
@@ -1,0 +1,114 @@
+var Waterline = require('../../../lib/waterline'),
+    assert = require('assert');
+
+describe('.afterFind()', function() {
+
+  describe('basic function', function() {
+    var person;
+
+    before(function(done) {
+      var waterline = new Waterline();
+      var Model = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          name: 'string',
+        },
+        afterFind: function(values, cb) {
+          values.name = values.name + ' found';
+          cb();
+        }
+      });
+
+      waterline.loadCollection(Model);
+
+      // Fixture Adapter Def
+      var adapterDef = { find: function(con, col, values, cb) { return cb(null, [values]); }};
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        person = colls.collections.user;
+        done();
+      });
+    });
+
+    /**
+     * Find
+     */
+
+    describe('.find()', function() {
+
+      it('should run afterFind and mutate values', function(done) {
+        person.find({}, function(err, users) {
+          assert(!err);
+          assert(users[0].name === 'undefined found');
+          done();
+        });
+      });
+    });
+  });
+
+  /**
+   * Test Callbacks can be defined as arrays and run in order.
+   */
+
+  describe('array of functions', function() {
+    var person;
+
+    before(function(done) {
+      var waterline = new Waterline();
+      var Model = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          name: 'string'
+        },
+
+        afterFind: [
+          // Function 1
+          function(values, cb) {
+            values.name = values.name + ' fn1';
+            cb();
+          },
+
+          // Function 2
+          function(values, cb) {
+            values.name = values.name + ' fn2';
+            cb();
+          }
+        ]
+      });
+
+      waterline.loadCollection(Model);
+
+      // Fixture Adapter Def
+      var adapterDef = { find: function(con, col, values, cb) { return cb(null, [values]); }};
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        person = colls.collections.user;
+        done();
+      });
+    });
+
+    it('should run the functions in order', function(done) {
+      person.find({}, function(err, users) {
+        assert(!err);
+        assert(users[0].name === 'undefined fn1 fn2');
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/callbacks/afterFind.findOne.js
+++ b/test/unit/callbacks/afterFind.findOne.js
@@ -1,0 +1,115 @@
+var Waterline = require('../../../lib/waterline'),
+    assert = require('assert');
+
+describe('.afterFind()', function() {
+
+  describe('basic function', function() {
+    var person;
+
+    before(function(done) {
+      var waterline = new Waterline();
+      var Model = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          name: 'string',
+        },
+
+        afterFind: function(values, cb) {
+          values.name = values.name + ' found';
+          cb();
+        }
+      });
+
+      waterline.loadCollection(Model);
+
+      // Fixture Adapter Def
+      var adapterDef = { find: function(con, col, criteria, cb) { return cb(null, [criteria]); }};
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        person = colls.collections.user;
+        done();
+      });
+    });
+
+    /**
+     * FindOne
+     */
+
+    describe('.findOne()', function() {
+
+      it('should run afterFind and mutate values', function(done) {
+        person.findOne(1, function(err, user) {
+          assert(!err);
+          assert(user.name === 'undefined found');
+          done();
+        });
+      });
+    });
+  });
+
+  /**
+   * Test Callbacks can be defined as arrays and run in order.
+   */
+
+  describe('array of functions', function() {
+    var person;
+
+    before(function(done) {
+      var waterline = new Waterline();
+      var Model = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          name: 'string'
+        },
+
+        afterFind: [
+          // Function 1
+          function(values, cb) {
+            values.name = values.name + ' fn1';
+            cb();
+          },
+
+          // Function 2
+          function(values, cb) {
+            values.name = values.name + ' fn2';
+            cb();
+          }
+        ]
+      });
+
+      waterline.loadCollection(Model);
+
+      // Fixture Adapter Def
+      var adapterDef = { find: function(con, col, values, cb) { return cb(null, [values]); }};
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        person = colls.collections.user;
+        done();
+      });
+    });
+
+    it('should run the functions in order', function(done) {
+      person.findOne(1, function(err, user) {
+        assert(!err);
+        assert(user.name === 'undefined fn1 fn2');
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/callbacks/afterFind.findOrCreate.js
+++ b/test/unit/callbacks/afterFind.findOrCreate.js
@@ -1,0 +1,235 @@
+var Waterline = require('../../../lib/waterline'),
+    assert = require('assert');
+
+describe('.afterFind()', function() {
+
+  describe('basic function', function() {
+
+    /**
+     * findOrCreate
+     */
+
+    describe('.findOrCreate()', function() {
+
+      describe('without a record', function() {
+        var person;
+
+        before(function(done) {
+          var waterline = new Waterline();
+          var Model = Waterline.Collection.extend({
+            identity: 'user',
+            connection: 'foo',
+            attributes: {
+              name: 'string'
+            },
+
+            afterFind: function(values, cb) {
+              values.name = values.name + ' updated';
+              cb();
+            }
+          });
+
+          waterline.loadCollection(Model);
+
+          // Fixture Adapter Def
+          var adapterDef = {
+            find: function(con, col, criteria, cb) { return cb(null, null); },
+            create: function(con, col, values, cb) { return cb(null, values); }
+          };
+
+          var connections = {
+            'foo': {
+              adapter: 'foobar'
+            }
+          };
+
+          waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+            if(err) done(err);
+            person = colls.collections.user;
+            done();
+          });
+        });
+
+        it('should not run afterFind on create', function(done) {
+          person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
+            assert(!err);
+            assert(user.name === 'test');
+            done();
+          });
+        });
+      });
+
+      describe('with a record', function() {
+        var person;
+
+        before(function(done) {
+          var waterline = new Waterline();
+          var Model = Waterline.Collection.extend({
+            identity: 'user',
+            connection: 'foo',
+            attributes: {
+              name: 'string'
+            },
+
+            afterFind: function(values, cb) {
+              values.name = values.name + ' updated';
+              cb();
+            }
+          });
+
+          waterline.loadCollection(Model);
+
+          // Fixture Adapter Def
+          var adapterDef = {
+            find: function(con, col, criteria, cb) { return cb(null, [criteria.where]); },
+            create: function(con, col, values, cb) { return cb(null, values); }
+          };
+
+          var connections = {
+            'foo': {
+              adapter: 'foobar'
+            }
+          };
+
+          waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+            if(err) done(err);
+            person = colls.collections.user;
+            done();
+          });
+        });
+
+        it('should run afterFind and mutate values on find', function(done) {
+          person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
+            assert(!err);
+            assert(user.name === 'test updated');
+            done();
+          });
+        });
+      });
+    });
+  });
+
+
+  /**
+   * Test Callbacks can be defined as arrays and run in order.
+   */
+
+  describe('array of functions', function() {
+
+    describe('without a record', function() {
+      var person;
+
+      before(function(done) {
+
+        var waterline = new Waterline();
+        var Model = Waterline.Collection.extend({
+          identity: 'user',
+          connection: 'foo',
+          attributes: {
+            name: 'string'
+          },
+
+          afterFind: [
+            // Function 1
+            function(values, cb) {
+              values.name = values.name + ' fn1';
+              cb();
+            },
+
+            // Function 2
+            function(values, cb) {
+              values.name = values.name + ' fn2';
+              cb();
+            }
+          ]
+        });
+
+        waterline.loadCollection(Model);
+
+        // Fixture Adapter Def
+        var adapterDef = {
+          find: function(con, col, criteria, cb) { return cb(null, null); },
+          create: function(con, col, values, cb) { return cb(null, values); }
+        };
+
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+          if(err) done(err);
+          person = colls.collections.user;
+          done();
+        });
+      });
+
+      it('should not run the functions on create', function(done) {
+        person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
+          assert(!err);
+          assert(user.name === 'test');
+          done();
+        });
+      });
+    });
+
+    describe('with a record', function() {
+      var person;
+
+      before(function(done) {
+
+        var waterline = new Waterline();
+        var Model = Waterline.Collection.extend({
+          identity: 'user',
+          connection: 'foo',
+          attributes: {
+            name: 'string'
+          },
+
+          afterFind: [
+            // Function 1
+            function(values, cb) {
+              values.name = values.name + ' fn1';
+              cb();
+            },
+
+            // Function 2
+            function(values, cb) {
+              values.name = values.name + ' fn2';
+              cb();
+            }
+          ]
+        });
+
+        waterline.loadCollection(Model);
+
+        // Fixture Adapter Def
+        var adapterDef = {
+          find: function(con, col, criteria, cb) { return cb(null, [criteria.where]); },
+          create: function(con, col, values, cb) { return cb(null, values); }
+        };
+
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+          if(err) done(err);
+          person = colls.collections.user;
+          done();
+        });
+      });
+
+      it('should now run any of the functions on find', function(done) {
+        person.findOrCreate({ name: 'test' }, { name: 'test' }, function(err, user) {
+          assert(!err);
+          assert(user.name === 'test fn1 fn2');
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
References issue #923

Adds afterFind callback to the `find`, `findOne`, `findOrCreate`, and `findOrCreateEach` methods, and callback runner.

Allows users to modify each record that has been found.

Includes specs for running the `afterFind` callback after `find`, `findOne`, and `findOrCreate`
