### PR TITLE
Set createdAt and updatedAt to the same value on creation.

### DIFF
--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -193,17 +193,20 @@ function beforeCallbacks(valuesObject, cb) {
 
 function createValues(valuesObject, cb) {
   var self = this;
+  var date;
 
   // Automatically add updatedAt and createdAt (if enabled)
   if (self.autoCreatedAt) {
     if (!valuesObject.values[self.autoCreatedAt]) {
-      valuesObject.values[self.autoCreatedAt] = new Date();
+      date = date || new Date();
+      valuesObject.values[self.autoCreatedAt] = date;
     }
   }
 
   if (self.autoUpdatedAt) {
     if (!valuesObject.values[self.autoUpdatedAt]) {
-      valuesObject.values[self.autoUpdatedAt] = new Date();
+      date = date || new Date();
+      valuesObject.values[self.autoUpdatedAt] = date;
     }
   }
 


### PR DESCRIPTION
When automatic createdAt and updatedAt property setting is enabled, while the best would be to set both times to some "transaction time", if it's not available, at least on creation the dates should be always set to the same value. The way it was implemented before, the times could differ by a millisecond (or two).