### PR TITLE
Test node v4 and v5, support only tested node versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
-  - "0.12"
   - "0.10"
-  - "iojs"
+  - "0.12"
+  - "4"
+  - "5"
 after_script:
   - npm run coverage && cat ./coverage/lcov.info | ./node_modules/.bin/codeclimate
 addons:
   code_climate:
     repo_token: 351483555263cf9bcd2416c58b0e0ae6ca1b32438aa51bbab2c833560fb67cc0
+sudo: false

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "nibble": "eslint-nibble lib"
   },
   "engines": {
-    "node": "*"
+    "node": ">=0.10.0 <=5.x.x"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Possibly have a breaking change here.  Testing iojs has been removed, testing v4 and v5 has been added.  Added the specific tested engines into package.json to specify what waterline can actually claim to support.  Bottom line is good news: waterline passes all the tests on node v4 and node v5.  Also got the tests running on Travis's container infrastructure, which generates faster builds.  Closes #1203.