### PR TITLE
Many-To-Many Through patch

### DIFF
--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -126,7 +126,7 @@ Waterline.prototype.initialize = function(options, cb) {
         var junctionTables = [];
 
         Object.keys(self.schema).forEach(function(table) {
-          if (!self.schema[table].junctionTable) return;
+          if (!self.schema[table].junctionTable || self.schema[table].throughTable) return;
           junctionTables.push(Waterline.Collection.extend(self.schema[table]));
         });
 
@@ -157,6 +157,9 @@ Waterline.prototype.initialize = function(options, cb) {
         var meta = collection.meta || {};
         meta.junctionTable = hasOwnProperty(collection.waterline.schema[collection.identity], 'junctionTable') ?
           collection.waterline.schema[collection.identity].junctionTable : false;
+
+        meta.throughTable = hasOwnProperty(collection.waterline.schema[collection.identity], 'throughTable') ?
+          collection.waterline.schema[collection.identity].throughTable : false;
 
         schemas[collection.identity] = collection;
         schemas[collection.identity].definition = schema;

--- a/test/unit/query/associations/manyToManyThrough.js
+++ b/test/unit/query/associations/manyToManyThrough.js
@@ -1,11 +1,14 @@
-var Waterline = require('../../../../lib/waterline'),
-    assert = require('assert'),
-    async = require('async');
+var Waterline = require('../../../../lib/waterline');
+var assert = require('assert');
+var async = require('async');
+var _ = require('lodash');
 
 describe('Collection Query', function() {
 
   describe('many to many through association', function() {
     var Drive;
+    var User;
+    var Car;
 
     before(function(done) {
 
@@ -23,7 +26,7 @@ describe('Collection Query', function() {
           cars: {
             collection: 'car',
             through: 'drive',
-            via: 'car'
+            via: 'user'
           }
         }
       });
@@ -55,7 +58,8 @@ describe('Collection Query', function() {
           },
           drivers: {
             collection: 'user',
-            via: 'cars',
+            through: 'drive',
+            via: 'car',
             dominant: true
           }
         }
@@ -72,10 +76,11 @@ describe('Collection Query', function() {
       };
 
       waterline.initialize({adapters: {adapter: require('sails-memory')}, connections: connections }, function(err, colls) {
-        if(err) done(err);
+        if (err) return done(err);
         User = colls.collections.user;
         Drive = colls.collections.drive;
         Car = colls.collections.car;
+
         async.series([
           function (callback) {
             User.create({id: 1}, callback);
@@ -86,7 +91,7 @@ describe('Collection Query', function() {
           function (callback) {
             Car.create({id: 1}, callback);
           }
-        ],function(err) {
+        ], function(err) {
           done();
         });
       });
@@ -98,9 +103,11 @@ describe('Collection Query', function() {
       .populate('car')
       .populate('user')
       .exec(function(err, drive) {
-        if(err) return done(err);
-		assert(!drive.car instanceof Array,"through table model associations return Array instead of single Objet");
-        assert(!drive.user instanceof Array,"through table model associations return Array instead of single Objet");
+        if (err) return done(err);
+
+        assert(!_.isArray(drive.car), 'through table model associations return Array instead of single Objet');
+        assert(!_.isArray(drive.user), 'through table model associations return Array instead of single Objet');
+
         done();
       });
     });

--- a/test/unit/query/associations/manyToManyThrough.js
+++ b/test/unit/query/associations/manyToManyThrough.js
@@ -1,0 +1,109 @@
+var Waterline = require('../../../../lib/waterline'),
+    assert = require('assert'),
+    async = require('async');
+
+describe('Collection Query', function() {
+
+  describe('many to many through association', function() {
+    var Drive;
+
+    before(function(done) {
+
+      var waterline = new Waterline();
+      var collections = {};
+
+      collections.user = Waterline.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          id: {
+            type: 'integer',
+            primaryKey: true
+          },
+          cars: {
+            collection: 'car',
+            through: 'drive',
+            via: 'car'
+          }
+        }
+      });
+
+      collections.drive = Waterline.Collection.extend({
+        identity: 'drive',
+        connection: 'foo',
+        attributes: {
+          id: {
+            type: 'integer',
+            primaryKey: true
+          },
+          car: {
+            model: 'car'
+          },
+          user: {
+            model: 'user'
+          }
+        }
+      });
+
+      collections.car = Waterline.Collection.extend({
+        identity: 'car',
+        connection: 'foo',
+        attributes: {
+          id: {
+            type: 'integer',
+            primaryKey: true
+          },
+          drivers: {
+            collection: 'user',
+            via: 'cars',
+            dominant: true
+          }
+        }
+      });
+
+      waterline.loadCollection(collections.user);
+      waterline.loadCollection(collections.drive);
+      waterline.loadCollection(collections.car);
+
+      var connections = {
+        'foo': {
+          adapter: 'adapter'
+        }
+      };
+
+      waterline.initialize({adapters: {adapter: require('sails-memory')}, connections: connections }, function(err, colls) {
+        if(err) done(err);
+        User = colls.collections.user;
+        Drive = colls.collections.drive;
+        Car = colls.collections.car;
+        async.series([
+          function (callback) {
+            User.create({id: 1}, callback);
+          },
+          function (callback) {
+            Drive.create({id: 1, car: 1, user: 1}, callback);
+          },
+          function (callback) {
+            Car.create({id: 1}, callback);
+          }
+        ],function(err) {
+          done();
+        });
+      });
+    });
+
+
+    it('through table model associations should return a single objet', function(done) {
+      Drive.findOne(1)
+      .populate('car')
+      .populate('user')
+      .exec(function(err, drive) {
+        if(err) return done(err);
+		assert(!drive.car instanceof Array,"through table model associations return Array instead of single Objet");
+        assert(!drive.user instanceof Array,"through table model associations return Array instead of single Objet");
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
This should resolve issue #1133 discovered by @atiertant. It uses the patched version of Waterline-Schema from https://github.com/balderdashy/waterline-schema/pull/32 to use the `throughTable` flag.

If everything looks good we will need to bump the minimum version of waterline-schema once this is merged.

This is an alternative for #1134 and includes the unit test from that PR.

**EDIT:** to be clear this isn't adding any new `through` support. Only fixing an issue with the support that already existed.