### PR TITLE
fix PostgreSQL adapter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You may also supply an array of adapters and Waterline will map out the methods 
 
 #### Community Adapters
 
-  - [PostgreSQL](https://github.com/particlebanana/sails-postgresql) - *0.9+ compatible*
+  - [PostgreSQL](https://github.com/balderdashy/sails-postgresql) - *0.9+ compatible*
   - [MySQL](https://github.com/balderdashy/sails-mysql) - *0.9+ compatible*
   - [MongoDB](https://github.com/balderdashy/sails-mongo) - *0.9+ compatible*
   - [Memory](https://github.com/balderdashy/sails-memory) - *0.9+ compatible*


### PR DESCRIPTION
I believe balderdashy/sails-postgresql is the current version of the adapter, not particlebanana/sails-postgresql. Sorry for any misunderstanding!