### PR TITLE
Use mongodb $lookup for populate on 1:1 assosiated models

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,7 @@ Feature                                          | Proposal                     
  :---------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------
  Pass criteria into lifecycle hooks              | [#1122](https://github.com/balderdashy/waterline/pull/1122)                           | Pass the queries criteria into lifecycle hooks.
  Deep populate                                   | [#1052](https://github.com/balderdashy/waterline/pull/1052)                           | Recursively populate child associations.
+ Use **$lookup** for relations in mongo          | [#375](https://github.com/balderdashy/sails-mongo/issues/375)                         | Add relation through new mongo left outer join substitution.
 
 
 


### PR DESCRIPTION
Mongo db **[$lookup (aggregation)](https://docs.mongodb.org/manual/reference/operator/aggregation/lookup/)** Performs a left outer join to an unsharded collection in the same database to filter in documents from the “joined” collection for processing.

IMPORTANT NOTE: this feature is only supported in Mongodb v => **3.2**, and only for not sharded collections, so whenever we will implement this we must give developers ability to turn this feature off for Mongodb < 3.2 or when they are goin to use [sharding](https://docs.mongodb.org/manual/sharding/).

IMPORTANT NOTE 2: Mongodb team recommends (embedded document)[https://docs.mongodb.org/manual/tutorial/model-embedded-one-to-one-relationships-between-documents/] approach over $lookup (aggregation) for implementing one to one relation.

### Explanation and benefits:

In **sails-mongo**, when we have **[One to One](https://github.com/balderdashy/waterline-docs/blob/master/models/associations/one-to-one.md)** association in **waterline** and we are going to read data from both main and related collection (using populate) I suppose we are doing two separate requests to database: first for main collection and then for associated collection, after it we do merge all the results on server. It loads server and adds traffic overhead (since we do 2 query and the second one for related collection I imagine is like `{foreignKeyName: {$in: [a big array of keys]}}`.

To avoid this traffic overhead and expensive array merge on server, we could write one-to-one association population as aggregation request with **$lookup**.

NOTE: actually **One to Many** and **Many to Many** associations can also be done with aggregation + two $lookup approach, but we should heed a warning on some mongodb [aggregation restrictions](https://docs.mongodb.org/manual/core/aggregation-pipeline-limits/).

### Usage example:

For user-pet:

```
// A user may only have a single pet
var User = Waterline.Collection.extend({

  identity: 'user',
  connection: 'local-postgresql',

  attributes: {
    firstName: 'string',
    lastName: 'string',

    // Add a reference to Pet
    pet: {
      model: 'pet'
    }
  }
});

var Pet = Waterline.Collection.extend({

  identity: 'pet',
  connection: 'local-postgresql',

  attributes: {
    breed: 'string',
    type: 'string',
    name: 'string',

    // Add a reference to User
    user: {
      model: 'user'
    }
  }
});
```

Say we have created a bunch of users and pets, and now are looking for all **husky** dogt's owners.

The request is the same:

```
Pet.find({breed: 'husky'})
.populate('user')
.exec(function(err, pets) {

});
```

The aggregation that makes it is going to be like:

```
pet_collection.aggregate([{$match: {breed: 'husky'}}, {$lookup: {from: 'user', localField: 'user_id', foreignField: '_id', as: 'user' }}])
```

And the result is exactely the same as it should be:

```
[{
 id: 1,
 breed: 'husky',
 type: 'dog',
 name: 'fido',
 user: {
 id: 123,
 firstName: 'Foo',
 lastName: 'Bar',
 pet: 1
 }
}...];
```

### Conclusion

**$lookup** aggregation produces the same result as plain association does, and saves server resources.