### PR TITLE
Remove second argument to .save()

### DIFF
--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -191,6 +191,16 @@ module.exports = function(context, proto, options, cb) {
       return cb(error);
     }
 
+    // Reset the model attribute values with the new values.
+    // This is needed because you could have a lifecycle callback that has
+    // changed the data since last time you accessed it.
+    // Attach attributes to the model instance
+    var newData = results.updateRecord[0];
+    _.each(newData, function(val, key) {
+      proto[key] = val;
+    });
+
+    // If a promise, resolve it
     if (deferred) {
       deferred.resolve();
     }

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -7,9 +7,6 @@ var removeAssociation = require('../associationMethods/remove');
 var hop = require('../../../utils/helpers').object.hasOwnProperty;
 var defer = require('../../../utils/defer');
 var noop = function() {};
-var optDefaults = {
-  populate: true
-};
 
 /**
  * Model.save()
@@ -39,7 +36,6 @@ module.exports = function(context, proto, options, cb) {
   }
 
   cb = cb || noop;
-  options = _.defaults(options, optDefaults) || optDefaults;
 
   /**
    * TO-DO:
@@ -57,20 +53,27 @@ module.exports = function(context, proto, options, cb) {
       var modelKeys = Object.keys(proto.associationsCache);
 
       async.each(modelKeys, function(key, nextKey) {
-
-        if (!hop(proto, key) || proto[key] === undefined) return nextKey();
+        if (!hop(proto, key) || proto[key] === undefined) {
+          return async.setImmediate(function() {
+            nextKey();
+          });
+        }
 
         var currentVal = proto[key];
         var previousVal = proto.associationsCache[key];
 
         // Normalize previousVal to an object
-        if (Array.isArray(previousVal)) previousVal = previousVal[0];
+        if (Array.isArray(previousVal)) {
+          previousVal = previousVal[0];
+        }
 
         if (deep(currentVal, previousVal)) {
           mutatedModels.push(key);
         }
 
-        nextKey();
+        return async.setImmediate(function() {
+          nextKey();
+        });
       }, next);
     },
 
@@ -113,7 +116,10 @@ module.exports = function(context, proto, options, cb) {
         }
       });
 
-      return next(null, operations);
+      return async.setImmediate(function() {
+        return next(null, operations);
+      });
+
     }],
 
     // Create new associations for each association key
@@ -177,9 +183,6 @@ module.exports = function(context, proto, options, cb) {
       return cb(failedTransactions);
     }
 
-    // Rebuild proper criteria object from the original query
-    var PK = context.primaryKey;
-
     if (!results.updateRecord.length) {
       var error = new Error('Error updating a record.');
       if (deferred) {
@@ -188,40 +191,12 @@ module.exports = function(context, proto, options, cb) {
       return cb(error);
     }
 
-    var obj = results.updateRecord[0].toObject();
-    var populations = Object.keys(proto.associations);
-    var criteria = {};
-    criteria[PK] = obj[PK];
-
-    // Build up a new query and re-populate specified associations
-    var query = context.findOne(criteria);
-
-    if (options.populate) {
-      if (options.populate.constructor === Array) {
-        options.populate.forEach(function(pop) {
-          query.populate(pop.key, pop.query);
-        });
-      } else {
-        populations.forEach(function(pop) {
-          query.populate(pop);
-        });
-      }
+    if (deferred) {
+      deferred.resolve();
     }
 
-    query.exec(function(err, data) {
-      if (err) {
-        if (deferred) {
-          deferred.reject(err);
-        }
-        return cb(err);
-      }
-
-      if (deferred) {
-        deferred.resolve(data);
-      }
-
-      cb(null, data);
-    });
+    // Return the callback
+    return cb();
   });
 
   if (deferred) {

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -6,7 +6,7 @@ var addAssociation = require('../associationMethods/add');
 var removeAssociation = require('../associationMethods/remove');
 var hop = require('../../../utils/helpers').object.hasOwnProperty;
 var defer = require('../../../utils/defer');
-var WLError = require('../../../error/WLerror');
+var WLError = require('../../../error/WLError');
 var noop = function() {};
 
 /**

--- a/lib/waterline/model/lib/defaultMethods/save.js
+++ b/lib/waterline/model/lib/defaultMethods/save.js
@@ -6,6 +6,7 @@ var addAssociation = require('../associationMethods/add');
 var removeAssociation = require('../associationMethods/remove');
 var hop = require('../../../utils/helpers').object.hasOwnProperty;
 var defer = require('../../../utils/defer');
+var WLError = require('../../../error/WLerror');
 var noop = function() {};
 
 /**
@@ -167,6 +168,7 @@ module.exports = function(context, proto, options, cb) {
 
     // Collect all failed transactions if any
     var failedTransactions = [];
+    var error;
 
     if (results.addAssociations) {
       failedTransactions = failedTransactions.concat(results.addAssociations);
@@ -177,18 +179,21 @@ module.exports = function(context, proto, options, cb) {
     }
 
     if (failedTransactions.length > 0) {
+      error = new Error('Some associations could not be added or destroyed during save().');
+      error.failedTransactions = failedTransactions;
+
       if (deferred) {
-        deferred.reject(failedTransactions);
+        deferred.reject(new WLError(error));
       }
-      return cb(failedTransactions);
+      return cb(new WLError(error));
     }
 
     if (!results.updateRecord.length) {
-      var error = new Error('Error updating a record.');
+      error = new Error('Error updating a record.');
       if (deferred) {
-        deferred.reject(error);
+        deferred.reject(new WLError(error));
       }
-      return cb(error);
+      return cb(new WLError(error));
     }
 
     // Reset the model attribute values with the new values.

--- a/test/integration/model/association.remove.hasMany.js
+++ b/test/integration/model/association.remove.hasMany.js
@@ -108,10 +108,11 @@ describe('Model', function() {
 
           person.save(function(err) {
             assert(err);
-            assert(Array.isArray(err));
-            assert(err.length === 2);
-            assert(err[0].type === 'remove');
-            assert(err[1].type === 'remove');
+            assert(err.failedTransactions);
+            assert(Array.isArray(err.failedTransactions));
+            assert(err.failedTransactions.length === 2);
+            assert(err.failedTransactions[0].type === 'remove');
+            assert(err.failedTransactions[1].type === 'remove');
 
             done();
           });

--- a/test/integration/model/association.remove.manyToMany.js
+++ b/test/integration/model/association.remove.manyToMany.js
@@ -122,10 +122,11 @@ describe('Model', function() {
 
           person.save(function(err) {
             assert(err);
-            assert(Array.isArray(err));
-            assert(err.length === 2);
-            assert(err[0].type === 'remove');
-            assert(err[1].type === 'remove');
+            assert(err.failedTransactions);
+            assert(Array.isArray(err.failedTransactions));
+            assert(err.failedTransactions.length === 2);
+            assert(err.failedTransactions[0].type === 'remove');
+            assert(err.failedTransactions[1].type === 'remove');
 
             done();
           });

--- a/test/integration/model/toObject.associations.WithForeighKeyTypeDate.js
+++ b/test/integration/model/toObject.associations.WithForeighKeyTypeDate.js
@@ -1,15 +1,10 @@
 var Waterline = require('../../../lib/waterline');
 var assert = require('assert');
-var async = require('async');
 
-describe('Collection Query', function() {
-
+describe('Model', function() {
   describe('.toObject() with associations with foreign key typed as datetime', function() {
     var waterline;
-    var Trucker;
     var Schedule;
-    var Workday;
-    var scheduleId;
 
     before(function(done) {
       waterline = new Waterline();
@@ -84,62 +79,23 @@ describe('Collection Query', function() {
 
       var connections = {
         'foo': {
-          adapter: 'adapter'
+          adapter: 'foobar'
         }
       };
 
-      waterline.initialize({ adapters: { adapter: require('sails-memory') }, connections: connections }, function(err, colls) {
+      waterline.initialize({ adapters: { foobar: {} }, connections: connections }, function(err, colls) {
         if (err) { done(err); }
-
-        Trucker = colls.collections.trucker;
-        Workday = colls.collections.workday;
         Schedule = colls.collections.schedule;
-
-        async.auto({
-
-          createTrucker: function(next) {
-            Trucker.create({ truckerName: 'trucker 1' }).exec(next);
-          },
-
-          createWorkday: function(next) {
-            Workday.create({
-              id: new Date(1970, 0, 1, 0, 0),
-              start: new Date(1970, 0, 1, 12, 0),
-              end: new Date(1970, 0, 1, 17, 0)
-            }).exec(next);
-          },
-
-          createSchedule: ['createTrucker', 'createWorkday', function(next, results) {
-            Schedule.create({
-              trucker_id: results.createTrucker.id,
-              workday_id: results.createWorkday.id,
-              miles: 10
-            }).exec(next);
-          }]
-
-        },
-
-        function(err, results) {
-          if (err) return done(err);
-          scheduleId = results.createSchedule.id;
-          done();
-        });
-      });
-    });
-
-    after('teardown waterline instance', function(done) {
-      waterline.teardown(done);
-    });
-
-    it('should return a valid object with ids for foreign key fields', function(done) {
-      Schedule.findOne({ id: scheduleId }).exec(function(err, schedule) {
-        if (err) { return done(err); }
-        var obj = schedule.toObject();
-        assert(obj.trucker === 1);
-        assert((new Date(obj.workday)).getTime() === (new Date(1970, 0, 1, 0, 0)).getTime());
-        assert(obj.miles === 10);
         done();
       });
+    });
+
+    it('should return a valid object with ids for foreign key fields', function() {
+      var schedule = new Schedule._model({ trucker: 1, workday: new Date(1970, 0, 1, 0, 0), miles: 10 });
+      var obj = schedule.toObject();
+      assert(obj.trucker === 1);
+      assert((new Date(obj.workday)).getTime() === (new Date(1970, 0, 1, 0, 0)).getTime());
+      assert(obj.miles === 10);
     });
   });
 });

--- a/test/unit/query/associations/manyToManyThrough.js
+++ b/test/unit/query/associations/manyToManyThrough.js
@@ -2,16 +2,16 @@ var Waterline = require('../../../../lib/waterline');
 var assert = require('assert');
 var async = require('async');
 
-describe('Collection Query', function () {
+describe('Collection Query', function() {
 
-  describe('many to many through association', function () {
+  describe('many to many through association', function() {
     var waterline;
     var Driver;
     var Ride;
     var Taxi;
     var Payment;
 
-    before(function (done) {
+    before(function(done) {
       var collections = {};
       waterline = new Waterline();
 
@@ -157,7 +157,7 @@ describe('Collection Query', function () {
       });
     });
 
-    after('teardown waterline instance', function (done) {
+    after(function(done) {
       waterline.teardown(done);
     });
 


### PR DESCRIPTION
> This is a breaking change and will require us to go ahead and push out a smaller version of `0.11`.

This may be controversial but I think it's the right thing to do. The current behavior of `.save()` is awful as documented in #441 #1091 #1037 #954 and probably more. Right now it populates all the attributes which can easily overflow memory. There is a flag to mitigate some of this but it shouldn't happen in the first place.

Trying to determine what to populate based on what attributes are currently set in the model sounds nasty as well. Removing this attribute makes the API cleaner and more predictable as well as a tad bit faster because it has do at minimum one less query.

I want to continue removing pieces related to model serialization in future releases as well so nested/graph operations are probably next on the chopping block.

So to summarize this changes the function signature of the callback passed to `.save()` from `.save(function(err, updatedRecord) {})` to `.save(function(err) {})`.