### PR TITLE
Meta attribute property

### DIFF
--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -84,7 +84,7 @@ Waterline.prototype.initialize = function(options, cb) {
   // Allow collections to be passed in to the initialize method
   if (options.collections) {
     for (var collection in options.collections) {
-      this.loadCollection(_.cloneDeep(options.collections[collection]));
+      this.loadCollection(options.collections[collection]);
     }
 
     // Remove collections from the options after they have been loaded

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -160,6 +160,7 @@ Waterline.prototype.initialize = function(options, cb) {
 
         schemas[collection.identity] = collection;
         schemas[collection.identity].definition = schema;
+        schemas[collection.identity].attributes = collection._attributes;
         schemas[collection.identity].meta = meta;
       });
 
@@ -191,7 +192,7 @@ Waterline.prototype.initialize = function(options, cb) {
             identity = self.collections[coll].__proto__.tableName;
           }
 
-          usedSchemas[identity] = results.buildCollectionSchemas[coll];
+          usedSchemas[identity] = _.pick(results.buildCollectionSchemas[coll], ['definition', 'attributes', 'meta']);
         });
 
         // Call the registerConnection method

--- a/lib/waterline/core/index.js
+++ b/lib/waterline/core/index.js
@@ -25,7 +25,7 @@ var Core = module.exports = function(options) {
 
   // Set Defaults
   this.adapter = this.adapter || {};
-  this._attributes = _.clone(this.attributes);
+  this._attributes = this.attributes;
   this.connections = this.connections || {};
 
   this.defaults = _.merge(COLLECTION_DEFAULTS, this.defaults);

--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -56,9 +56,31 @@ Validator.prototype.initialize = function(attrs, types, defaults) {
 
   defaults = defaults || {};
 
-  this.reservedProperties = ['defaultsTo', 'primaryKey', 'autoIncrement', 'unique', 'index', 'collection', 'dominant', 'through',
-          'columnName', 'foreignKey', 'references', 'on', 'groupKey', 'model', 'via', 'size',
-          'example', 'validationMessage', 'validations', 'populateSettings', 'onKey', 'protected'];
+  // These properties are reserved and may not be used as validations
+  this.reservedProperties = [
+    'defaultsTo',
+    'primaryKey',
+    'autoIncrement',
+    'unique',
+    'index',
+    'collection',
+    'dominant',
+    'through',
+    'columnName',
+    'foreignKey',
+    'references',
+    'on',
+    'groupKey',
+    'model',
+    'via',
+    'size',
+    'example',
+    'validationMessage',
+    'validations',
+    'populateSettings',
+    'onKey',
+    'protected'
+  ];
 
 
   if (defaults.ignoreProperties && Array.isArray(defaults.ignoreProperties)) {

--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -79,7 +79,8 @@ Validator.prototype.initialize = function(attrs, types, defaults) {
     'validations',
     'populateSettings',
     'onKey',
-    'protected'
+    'protected',
+    'meta'
   ];
 
 

--- a/test/unit/core/core.validations.js
+++ b/test/unit/core/core.validations.js
@@ -20,7 +20,10 @@ describe('Core Validator', function() {
           last_name: {
             type: 'string',
             required: true,
-            defaultsTo: 'Smith'
+            defaultsTo: 'Smith',
+            meta: {
+              foo: 'bar'
+            }
           }
         }
       });
@@ -57,6 +60,10 @@ describe('Core Validator', function() {
 
     it('should ignore schema properties', function() {
       assert(!person._validator.validations.last_name.defaultsTo);
+    });
+
+    it('should ignore the meta key', function() {
+      assert(!person._validator.validations.last_name.meta);
     });
 
   });


### PR DESCRIPTION
Part of the confusion and discussion about migrations has been that the attributes define properties in the physical storage layer. It's not ideal to continue adding adapter specific features to attribute definitions. This adds a reserved property to attribute definitions labeled `meta` that allows anything to be passed down to the adapter's `registerConnection` method.

The goal being that any adapter specific details can be defined and passed through. At the same time it cleans up the arguments being passed to `registerConnection` so that instead of trying to make sense of all the internal Waterline details you simple get a dictionary with the keys being the collection identity and each collection containing the following data:

* `definition` - the normalized table definition that was already being used by adapters. This stays the same.
* `attributes` - user defined attributes, including the `meta` field mentioned above.
* `meta` - a pre-existing object that defined extra generated metadata about a collection, such as the fact that it is a junctionTable.

I would still like to move all migrations out of Waterline in future releases but this will continue to be part of the spec.

```javascript
attributes: {
    email: {
      type: 'string',
      email: true,
      meta: {
        foo: 'bar',
        bar: function(hello) {
          return hello;
        }
      }
    }
  }
```