### PR TITLE
Criterias with extra options can pass through.

### DIFF
--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -183,11 +183,6 @@ var normalize = module.exports = {
       delete criteria.where.select;
     }
 
-    // If WHERE is {}, always change it back to null
-    if (criteria.where && _.keys(criteria.where).length === 0) {
-      criteria.where = null;
-    }
-
     // If an IN was specified in the top level query and is an empty array, we can return an
     // empty object without running the query because nothing will match anyway. Let's return
     // false from here so the query knows to exit out.


### PR DESCRIPTION
This is a really *tiny* change and i don't think it would *disrupt* any tests etc.

Basically, our team works on custom Waterline Adapters and one of things that is required is to have changes to the Query language. Currently if we pass custom options to the criteria, it is automatically `mixin`ed into `where`.

So `model.find({opt1: {})` becomes `model.find({where: {opt1: {}})`.

If we explicitly have a `where` then this doesn't happen so
`model.find({where: {name: 'abc'}, opt1: {}})` remains unchanged.

**BUT** :exclamation: `model.find({where: {}, opt1: {}})` :arrow_right: `model.find({where: {opt1: {}}})`

The only thing this PR is doing is `model.find({where: {}, opt1: {}})` remains unchanged.
I think this is a reasonable intended behavior!