### PR TITLE
Projections

### DIFF
--- a/lib/waterline/adapter/sync/strategies/alter.js
+++ b/lib/waterline/adapter/sync/strategies/alter.js
@@ -40,7 +40,7 @@ module.exports = function(cb) {
     var collectionName = _.find(self.query.waterline.schema, {tableName: self.collection}).identity;
 
     // Create a mapping of column names -> attribute names
-    var columnNamesMap = _.reduce(self.query.waterline.schema[collectionName].attributes, function(memo, val, key) {
+    var columnNamesMap = _.reduce(self.query.waterline.schema[collectionName].definition, function(memo, val, key) {
       // If the attribute has a custom column name, use it as the key for the mapping
       if (val.columnName) {
         memo[val.columnName] = key;

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -189,9 +189,17 @@ Deferred.prototype.populate = function(keyName, criteria) {
       select.push(val.columnName);
     });
 
-    // Ensure the PK and FK on the parent are always selected - otherwise things
+    // Ensure the PK and FK on the child are always selected - otherwise things
     // like the integrator won't work correctly
     if(join.collection) {
+      var childPk;
+      _.each(this._context.waterline.schema[attr.references].attributes, function(val, key) {
+        if(_.has(val, 'primaryKey') && val.primaryKey) {
+          childPk = val.columnName || key;
+        }
+      });
+
+      select.push(childPk);
       select.push(attr.on);
     }
 
@@ -221,7 +229,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
         if(_.has(val, 'collection')) {
           return;
         }
-        
+
         // Check if the user has defined a custom select and if so normalize it
         if(customSelect && !_.includes(criteria.select, key)) {
           return;

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -191,15 +191,17 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
     // Ensure the PK and FK on the child are always selected - otherwise things
     // like the integrator won't work correctly
-    if(join.collection) {
-      var childPk;
-      _.each(this._context.waterline.schema[attr.references].attributes, function(val, key) {
-        if(_.has(val, 'primaryKey') && val.primaryKey) {
-          childPk = val.columnName || key;
-        }
-      });
+    var childPk;
+    _.each(this._context.waterline.schema[attr.references].attributes, function(val, key) {
+      if(_.has(val, 'primaryKey') && val.primaryKey) {
+        childPk = val.columnName || key;
+      }
+    });
 
-      select.push(childPk);
+    select.push(childPk);
+
+    // Add the foreign key for collections
+    if(join.collection) {
       select.push(attr.on);
     }
 

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -511,9 +511,8 @@ Deferred.prototype.set = function(values) {
  */
 
 Deferred.prototype.exec = function(cb) {
-
   if (!cb) {
-    console.log(new Error('Error: No Callback supplied, you must define a callback.').message);
+    console.log('Error: No Callback supplied, you must define a callback.');
     return;
   }
 

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -247,7 +247,6 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
       // Ensure the PK and FK are always selected - otherwise things like the
       // integrator won't work correctly
-      var childPk;
       _.each(this._context.waterline.schema[reference.references].attributes, function(val, key) {
         if(_.has(val, 'primaryKey') && val.primaryKey) {
           childPk = val.columnName || key;
@@ -261,7 +260,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
         parentKey: reference.columnName,
         child: reference.references,
         childKey: reference.on,
-        select: selects,
+        select: _.uniq(selects),
         alias: keyName,
         junctionTable: true,
         removeParentKey: !!parentKey.model,
@@ -275,8 +274,10 @@ Deferred.prototype.populate = function(keyName, criteria) {
     // Append the criteria to the correct join if available
     if (criteria && joins.length > 1) {
       joins[1].criteria = criteria;
+      joins[1].criteria.select = join.select;
     } else if (criteria) {
       joins[0].criteria = criteria;
+      joins[0].criteria.select = join.select;
     }
 
     // Set the criteria joins

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -189,10 +189,11 @@ Deferred.prototype.populate = function(keyName, criteria) {
       select.push(val.columnName);
     });
 
-    // Ensure the PK and FK are always selected - otherwise things like the
-    // integrator won't work correctly
-    select.push(pk);
-    select.push(attr.on);
+    // Ensure the PK and FK on the parent are always selected - otherwise things
+    // like the integrator won't work correctly
+    if(join.collection) {
+      select.push(attr.on);
+    }
 
     join.select = select;
 

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -171,6 +171,11 @@ Deferred.prototype.populate = function(keyName, criteria) {
     var select = [];
     var customSelect = criteria.select && _.isArray(criteria.select);
     _.each(this._context.waterline.schema[attr.references].attributes, function(val, key) {
+      // Ignore virtual attributes
+      if(_.has(val, 'collection')) {
+        return;
+      }
+
       // Check if the user has defined a custom select and if so normalize it
       if(customSelect && !_.includes(criteria.select, key)) {
         return;
@@ -211,6 +216,11 @@ Deferred.prototype.populate = function(keyName, criteria) {
     if (reference && hasOwnProperty(attr, 'on')) {
       var selects = [];
       _.each(this._context.waterline.schema[reference.references].attributes, function(val, key) {
+        // Ignore virtual attributes
+        if(_.has(val, 'collection')) {
+          return;
+        }
+        
         // Check if the user has defined a custom select and if so normalize it
         if(customSelect && !_.includes(criteria.select, key)) {
           return;

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -149,32 +149,6 @@ Deferred.prototype.populate = function(keyName, criteria) {
       );
     }
 
-    //////////////////////////////////////////////////////////////////////
-    // (there has been significant progress made towards both of these ///
-    // goals-- contact @mikermcneil if you want to help) /////////////////
-    //////////////////////////////////////////////////////////////////////
-    // TODO:
-    // Create synonym for `.populate()` syntax using criteria object
-    // syntax.  i.e. instead of using `joins` key in criteria object
-    // at the app level.
-    //////////////////////////////////////////////////////////////////////
-    // TODO:
-    // Support Mongoose-style `foo.bar.baz` syntax for nested `populate`s.
-    // (or something comparable.)
-    // One solution would be:
-    // .populate({
-    //   friends: {
-    //     where: { name: 'mike' },
-    //     populate: {
-    //       dentist: {
-    //         where: { name: 'rob' }
-    //       }
-    //     }
-    //   }
-    // }, optionalCriteria )
-    ////////////////////////////////////////////////////////////////////
-
-
     // Grab the key being populated to check if it is a has many to belongs to
     // If it's a belongs_to the adapter needs to know that it should replace the foreign key
     // with the associated value.

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -295,7 +295,7 @@ Deferred.prototype.select = function(attributes) {
   }
 
   var select = this._criteria.select || [];
-  select = _.concat(select, attributes);
+  select = select.concat(attributes);
   this._criteria.select = _.uniq(select);
 
   return this;

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -284,7 +284,10 @@ Deferred.prototype.select = function(attributes) {
     attributes = [attributes];
   }
 
-  this._criteria.select = attributes;
+  var select = this._criteria.select || [];
+  select = _.concat(select, attributes);
+  this._criteria.select = _.uniq(select);
+
   return this;
 };
 

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -271,6 +271,22 @@ Deferred.prototype.populate = function(keyName, criteria) {
 };
 
 /**
+ * Add projections to the parent
+ *
+ * @param {Array} attributes to select
+ * @return this
+ */
+
+Deferred.prototype.select = function(attributes) {
+  if(!_.isArray(attributes)) {
+    attributes = [attributes];
+  }
+
+  this._criteria.select = attributes;
+  return this;
+};
+
+/**
  * Add a Where clause to the criteria object
  *
  * @param {Object} criteria to append

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -105,7 +105,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
     });
     return this;
   }
-  
+
   // Normalize sub-criteria
   try {
     criteria = normalize.criteria(criteria);
@@ -187,7 +187,6 @@ Deferred.prototype.populate = function(keyName, criteria) {
       parentKey: attr.columnName || pk,
       child: attr.references,
       childKey: attr.on,
-      select: Object.keys(this._context.waterline.schema[attr.references].attributes),
       alias: keyName,
       removeParentKey: !!parentKey.model,
       model: !!hasOwnProperty(parentKey, 'model'),
@@ -196,15 +195,25 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
     // Build select object to use in the integrator
     var select = [];
-    Object.keys(this._context.waterline.schema[attr.references].attributes).forEach(function(key) {
-      var obj = self._context.waterline.schema[attr.references].attributes[key];
-      if (!hasOwnProperty(obj, 'columnName')) {
+    var customSelect = criteria.select && _.isArray(criteria.select);
+    _.each(this._context.waterline.schema[attr.references].attributes, function(val, key) {
+      // Check if the user has defined a custom select and if so normalize it
+      if(customSelect && !_.includes(criteria.select, key)) {
+        return;
+      }
+
+      if (!_.has(val, 'columnName')) {
         select.push(key);
         return;
       }
 
-      select.push(obj.columnName);
+      select.push(val.columnName);
     });
+
+    // Ensure the PK and FK are always selected - otherwise things like the
+    // integrator won't work correctly
+    select.push(pk);
+    select.push(attr.on);
 
     join.select = select;
 
@@ -226,12 +235,31 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
     // If a junction table is used add an additional join to get the data
     if (reference && hasOwnProperty(attr, 'on')) {
-      // Build out the second join object that will link a junction table with the
-      // values being populated
-      var selects = _.map(_.keys(this._context.waterline.schema[reference.references].attributes), function(attr) {
-        var expandedAttr = self._context.waterline.schema[reference.references].attributes[attr];
-        return expandedAttr.columnName || attr;
+      var selects = [];
+      _.each(this._context.waterline.schema[reference.references].attributes, function(val, key) {
+        // Check if the user has defined a custom select and if so normalize it
+        if(customSelect && !_.includes(criteria.select, key)) {
+          return;
+        }
+
+        if (!_.has(val, 'columnName')) {
+          selects.push(key);
+          return;
+        }
+
+        selects.push(val.columnName);
       });
+
+      // Ensure the PK and FK are always selected - otherwise things like the
+      // integrator won't work correctly
+      var childPk;
+      _.each(this._context.waterline.schema[reference.references].attributes, function(val, key) {
+        if(_.has(val, 'primaryKey') && val.primaryKey) {
+          childPk = val.columnName || key;
+        }
+      });
+
+      selects.push(childPk);
 
       join = {
         parent: attr.references,

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -53,6 +53,17 @@ module.exports = {
     // Transform Search Criteria
     criteria = self._transformer.serialize(criteria);
 
+    // If a projection is being used, ensure that the Primary Key is included
+    if(criteria.select) {
+      _.each(this._schema.schema, function(val, key) {
+        if (_.has(val, 'primaryKey') && val.primaryKey) {
+          criteria.select.push(key);
+        }
+      });
+
+      criteria.select = _.uniq(criteria.select);
+    }
+
     // serialize populated object
     if (criteria.joins) {
       criteria.joins.forEach(function(join) {
@@ -240,6 +251,17 @@ module.exports = {
       criteria = _.extend({}, criteria, options);
     }
 
+    // If a projection is being used, ensure that the Primary Key is included
+    if(criteria.select) {
+      _.each(this._schema.schema, function(val, key) {
+        if (_.has(val, 'primaryKey') && val.primaryKey) {
+          criteria.select.push(key);
+        }
+      });
+
+      criteria.select = _.uniq(criteria.select);
+    }
+
     // Transform Search Criteria
     if (!self._transformer) {
       throw new Error('Waterline can not access transformer-- maybe the context of the method is being overridden?');
@@ -320,7 +342,6 @@ module.exports = {
         results = waterlineCriteria('parent', { parent: results }, _criteria).results;
 
         // Serialize values coming from an in-memory join before modelizing
-        var _results = [];
         results.forEach(function(res) {
 
           // Go Ahead and perform any sorts on the associated data

--- a/lib/waterline/query/finders/operations.js
+++ b/lib/waterline/query/finders/operations.js
@@ -119,8 +119,6 @@ Operations.prototype._seedCache = function _seedCache() {
  */
 
 Operations.prototype._buildOperations = function _buildOperations() {
-
-  var self = this;
   var operations = [];
 
   // Check if joins were used, if not only a single operation is needed on a single connection
@@ -216,7 +214,7 @@ Operations.prototype._stageOperations = function _stageOperations(connections) {
       // Look into the previous operations and see if this is a child of any of them
       var child = false;
       localOpts.forEach(function(localOpt) {
-        if (localOpt.join.child != join.parent) return;
+        if (localOpt.join.child !== join.parent) return;
         localOpt.child = operation;
         child = true;
       });
@@ -281,7 +279,6 @@ Operations.prototype._createParentOperation = function _createParentOperation(co
   // Remove the joins from the criteria object, this will be an in-memory join
   var tmpCriteria = _.cloneDeep(this.criteria);
   delete tmpCriteria.joins;
-
   connectionName = this.context.adapterDictionary[this.parent];
 
   // If findOne was used, use the same connection `find` is on.
@@ -505,13 +502,11 @@ Operations.prototype._buildChildOpts = function _buildChildOpts(parentResults, c
             obj[pk] = _.clone(userCriteria.where);
             userCriteria.where = obj;
           }
-
-          userCriteria = userCriteria.where;
         }
       }
 
 
-      criteria = _.merge(userCriteria, criteria);
+      criteria = _.merge(userCriteria, { where: criteria });
     }
 
     // Normalize criteria
@@ -670,16 +665,17 @@ Operations.prototype._runChildOperations = function _runChildOperations(intermed
     if (hasOwnProperty(userCriteria, 'where')) {
       if (userCriteria.where === undefined) {
         delete userCriteria.where;
-      } else {
-        userCriteria = userCriteria.where;
       }
     }
 
     delete userCriteria.sort;
-    criteria = _.extend(criteria, userCriteria);
+    delete userCriteria.skip;
+    delete userCriteria.limit;
+
+    criteria = _.merge({}, userCriteria, { where: criteria });
   }
 
-  criteria = normalize.criteria({ where: criteria });
+  criteria = normalize.criteria(criteria);
 
   // Empty the cache for the join table so we can only add values used
   var cacheCopy = _.cloneDeep(self.cache[opt.join.parent]);

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -5,7 +5,7 @@ var switchback = require('switchback');
 var errorify = require('../error');
 var WLUsageError = require('../error/WLUsageError');
 
-var normalize = module.exports = {
+module.exports = {
 
   // Expand Primary Key criteria into objects
   expandPK: function(context, options) {
@@ -178,8 +178,22 @@ var normalize = module.exports = {
       delete criteria.where.max;
     }
 
-    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'select')) {
-      criteria.select = _.clone(criteria.where.select);
+    if (hop(criteria, 'where') && criteria.where !== null && hop(criteria.where, 'select') || hop(criteria, 'select')) {
+
+      if(criteria.where.select) {
+        criteria.select = _.clone(criteria.where.select);
+      }
+      
+      // If the select contains a '*' then remove the whole projection, a '*'
+      // will always return all records.
+      if(!_.isArray(criteria.select)) {
+        criteria.select = [criteria.select];
+      }
+
+      if(_.includes(criteria.select, '*')) {
+        delete criteria.select;
+      }
+
       delete criteria.where.select;
     }
 

--- a/test/unit/adapter/strategy.alter.schema.js
+++ b/test/unit/adapter/strategy.alter.schema.js
@@ -47,7 +47,7 @@ describe('Alter Mode Recovery with an enforced schema', function () {
           results = _.find(persistentData, options.where);
         }
         // Psuedo support for select (needed to act like a real adapter)
-        if(options.select) {
+        if(options.select && _.isArray(options.select) && options.select.length) {
 
           // Force ID in query
           options.select.push('id');
@@ -60,7 +60,8 @@ describe('Alter Mode Recovery with an enforced schema', function () {
         cb(null, results);
       },
       create: function (connectionName, collectionName, data, cb, connection) {
-        persistentData.push(data);
+        var schemaData = _.pick(data, ['id', 'name', 'age']);
+        persistentData.push(schemaData);
         cb(null, data);
       },
       drop: function (connectionName, collectionName, relations, cb, connection) {
@@ -125,4 +126,3 @@ describe('Alter Mode Recovery with an enforced schema', function () {
   });
 
 });
-


### PR DESCRIPTION
### DO NOT MERGE

This PR represents the initial work for projections on both the parent and child criteria. It finally brings official support for `select` and adds a `.select()` method to the deferred object. It also adds support for using `select` inside of criteria in a `populate`. 

One thing to note is that any primary keys and foreign keys used in a join will always be selected. This is unavoidable due to the way we currently build up join queries and combine results in cross-adapter populates.

The first thing that needs to happen is tests in [Waterline Adapter Tests](https://github.com/balderdashy/waterline-adapter-tests) to ensure things won't break across the officially supported adapters. There is a corresponding PR in [Waterline Sequel](https://github.com/balderdashy/waterline-sequel/pull/80) that needs to be brought in for the SQL adapters and I'm sure there will be some slight tweaks that need to happen in the Mongo adapter.

**Example Use:**

```javascript
// Deferred Object Style
User.find()
.select(['name', 'age'])
.where({
  age: {
    '>': 21
  }
})
.exec(function(err, users) {});
```

```javascript
// Populate projections
User.find()
.select(['name', 'age'])
.populate('pets', { select: ['breed', 'name'] })
.exec(function(err, users) {});
```

```javascript
// Callback style
User.find({ select: ['name', 'age'] }, function(err, users) {});
```