### PR TITLE
fix for #1326

### DIFF
--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -44,6 +44,10 @@ module.exports = {
     if (options && options[pk]) {
 
       var coercePK;
+      if(!context.attributes[pk]) {
+        return pk;
+      }
+      
       if (context.attributes[pk].type == 'integer') {
         coercePK = function(pk) {return +pk;};
       } else if (context.attributes[pk].type == 'string') {


### PR DESCRIPTION
Allows `id` to work in queries when in schemaless mode.