### PR TITLE
Added support for nested invalid attributes

### DIFF
--- a/lib/waterline/error/WLValidationError.js
+++ b/lib/waterline/error/WLValidationError.js
@@ -49,29 +49,12 @@ function WLValidationError(properties) {
   this.model = properties.model;
 
   // Ensure messages exist for each invalidAttribute
-  this.invalidAttributes = _.mapValues(this.invalidAttributes, function(rules, attrName) {
-    return _.map(rules, function(rule) {
-      if (!rule.message) {
-        rule.message = util.format('A record with that `%s` already exists (`%s`).', attrName, rule.value);
-      }
-      return rule;
-    });
-  });
+  this.invalidAttributes = normalizeInvalidAttributes(this.invalidAttributes);
 
-  // Customize the `details`
-  this.details = util.format('Invalid attributes sent to %s:\n', this.model) +
-  _.reduce(this.messages, function(memo, messages, attrName) {
-    memo += ' • ' + attrName + '\n';
-    memo += _.reduce(messages, function(memo, message) {
-      memo += '   • ' + message + '\n';
-      return memo;
-    }, '');
-    return memo;
-  }, '');
+  this.details = formatErrorDetails(this.invalidAttributes);
 
 }
 util.inherits(WLValidationError, WLError);
-
 
 /**
  * `rules`
@@ -144,16 +127,74 @@ WLValidationError.prototype.__defineGetter__('ValidationError', function() {
  * @type {[type]}
  */
 WLValidationError.prototype.toJSON =
-WLValidationError.prototype.toPOJO =
-function() {
-  return {
-    error: this.code,
-    status: this.status,
-    summary: this.reason,
-    model: this.model,
-    invalidAttributes: this.invalidAttributes
-  };
-};
+  WLValidationError.prototype.toPOJO =
+    function() {
+      return {
+        error: this.code,
+        status: this.status,
+        summary: this.reason,
+        model: this.model,
+        invalidAttributes: this.invalidAttributes
+      };
+    };
 
+/* Helpers */
+
+/**
+ * * @return {object}
+ */
+function normalizeInvalidAttributes(invalidAttributes){
+  return _.mapValues(invalidAttributes, function(rules, attrName) {
+    if(_.isArray(rules)){
+      return _.map(rules, function(rule) {
+        if (!rule.message) {
+          rule.message = util.format('A record with that `%s` already exists (`%s`).', attrName, rule.value);
+        }
+        return rule;
+      });
+    } else if(_.isObject(rules)){
+      // Here rules is a nested object that probably carries an array or another object,
+      // e.g  invalidAttributes = {location: {country: [{rule: 'string', message: '`undefined` should be a....']} }
+      // So when the iterations goes to the country attrName, it checks the rules and finds out its an object, so
+      // we must call this recursively to get one level deeper and keep going until we hit an array and then format it
+      return normalizeInvalidAttributes(rules)
+    }
+  });
+}
+
+/**
+ * @return {string} Formatted string with errors details (indented)
+ */
+function formatErrorDetails(invalidAttributes, indent){
+  indent = indent || '';
+  return _.reduce(invalidAttributes, function(accumulator, rules, attrName) {
+    // If the rules variable actually is an array of rules
+    // eg:  [{ rule: 'string',  message: '...'}, { rule: 'int',  message: '...'}]
+    if(_.isArray(rules)){
+      // Here we add the attribute name as an list-item-element, e.g:
+      // • type
+      accumulator += indent + ' • ' + attrName + ':\n';
+      // Here a create sub-list-item for each rule, e.g:
+      //   • "in" validation rule failed for input: null
+      //   • "required" validation rule failed for input: null
+      //   • "notEmpty" validation rule failed for input: null
+      accumulator += _.reduce(rules, function(accumulator, rule) {
+        accumulator += indent + '   • ' + rule.message + '\n';
+        return accumulator;
+      }, '');
+    } else if(_.isObject(rules)){
+      // In case rules is actually an object with subobjects or rules, we
+      // assume that the current attrName is the parent of a nested validation
+      // rules, e.g invalidAttributes = {location: {country: [{rule: 'string', message: '...']}},
+      // Following the above example, the line will turn out like this:
+      // • location
+      // And then we increase the indentation, so that all data that is nested, appears like so.
+      accumulator += indent + ' • ' + attrName + ':\n';
+      indent += '  ';
+      accumulator += formatErrorDetails(rules, indent)
+    }
+    return accumulator;
+  }, '')
+}
 
 module.exports = WLValidationError;


### PR DESCRIPTION
If you want to manually build an error based on `WLValidationError` that holds nested errors, because validation failed on nested data (association, nested documents, etc), there is no way to pass that data as invalidAttributes and get the expected result. There might not be support yet for deep validations but this opens the door for it. It's just a couple of simple helpers that iterate recursively if needed to properly normalize and format the errors.

So that this invalid attributes:

```js
{ location:
      { country:
         [ { rule: 'string',
             message: '`undefined` should be a string (instead of "null", which is a object)' },
           { rule: 'required',
             message: '"required" validation rule failed for input: null' },
           { rule: 'notEmpty',
             message: '"notEmpty" validation rule failed for input: null' } ],
        city:
         [ { rule: 'string',
             message: '`undefined` should be a string (instead of "null", which is a object)' },
           { rule: 'in',
             message: '"in" validation rule failed for input: null' },
           { rule: 'required',
             message: '"required" validation rule failed for input: null' },
           { rule: 'notEmpty',
             message: '"notEmpty" validation rule failed for input: null' } ],
        }
```
Can keep that format (otherwise it gets modified) and we can get a nice error too, like this
```
Error (E_VALIDATION)  ... some error details here
• location:
      • country:
        • `undefined` should be a string (instead of "null", which is a object)
        • "required" validation rule failed for input: null
        • "notEmpty" validation rule failed for input: null
      • city:
        • `undefined` should be a string (instead of "null", which is a object)
        • "in" validation rule failed for input: null
        • "required" validation rule failed for input: null
        • "notEmpty" validation rule failed for input: null
```

If the use case is not clear, or something needs to be improved or modified let me know.

pst: Not sure if there are tests for this, i didn't check since i'm doing this for the project i'm currently working on, so if there are some tests that needs to be modified somehow, let me know that too.