### PR TITLE
[Patch] Transformer fix

### DIFF
--- a/lib/waterline/adapter/sync/strategies/alter.js
+++ b/lib/waterline/adapter/sync/strategies/alter.js
@@ -201,7 +201,7 @@ module.exports = function(cb) {
             //
             // ((((TODO: actually be careful about said things))))
             //
-            self.createEach(backupData, function(err) {
+            self.query.createEach(backupData, function(err) {
               if (err) return uhoh(err, backupData, cb);
 
               // Done.

--- a/lib/waterline/adapter/sync/strategies/alter.js
+++ b/lib/waterline/adapter/sync/strategies/alter.js
@@ -98,7 +98,7 @@ module.exports = function(cb) {
       queryCriteria = {};
     }
 
-    self.find(queryCriteria, function(err, existingData) {
+    self.query.find(queryCriteria, function(err, existingData) {
 
       if (err) {
         //

--- a/lib/waterline/core/transformations.js
+++ b/lib/waterline/core/transformations.js
@@ -126,6 +126,19 @@ Transformation.prototype.serialize = function(attributes, behavior) {
         return recursiveParse(obj[property]);
       }
 
+      // If the property === SELECT check for any transformation keys
+      if (property === 'select' && _.isArray(obj[property])) {
+        var arr = _.clone(obj[property]);
+        _.each(arr, function(prop) {
+          if(_.has(self._transformations, prop)) {
+            var idx = _.indexOf(obj[property], prop);
+            if(idx > -1) {
+              obj[property][idx] = self._transformations[prop];
+            }
+          }
+        });
+      }
+
       // Check if property is a transformation key
       if (hasOwnProperty(self._transformations, property)) {
 

--- a/test/unit/adapter/strategy.alter.schema.js
+++ b/test/unit/adapter/strategy.alter.schema.js
@@ -82,7 +82,7 @@ describe('Alter Mode Recovery with an enforced schema', function () {
       schema: true,
       attributes: {
         name: 'string',
-        age: 'number',
+        age: 'integer',
         id: 'integer'
       }
     };

--- a/test/unit/adapter/strategy.alter.schemaless.js
+++ b/test/unit/adapter/strategy.alter.schemaless.js
@@ -81,7 +81,7 @@ describe('Alter Mode Recovery with schemaless data', function () {
       schema: false,
       attributes: {
         name: 'string',
-        age: 'number',
+        age: 'integer',
         id: 'integer'
       }
     };

--- a/test/unit/core/core.transformations/transformations.serialize.js
+++ b/test/unit/core/core.transformations/transformations.serialize.js
@@ -32,6 +32,20 @@ describe('Core Transformations', function() {
         assert(values.where.user.login);
         assert(values.where.user.login === 'foo');
       });
+
+      it('should work on SELECT queries', function() {
+        var values = transformer.serialize(
+          {
+            where: {
+              username: 'foo'
+            },
+            select: ['username']
+          }
+        );
+
+        assert(values.where.login);
+        assert.equal(values.select.indexOf('login'),  0);
+      });
     });
 
     describe('with associations', function() {


### PR DESCRIPTION
This fixes an issue with column names on auto migrations.

Before the methods were using the adapter methods so that the new stuff for projections wouldn't work because the `select` calls wouldn't get normalized to use the column names.

This runs the queries through the normal collection methods.