### PR TITLE
[patch] Add fix to deal with buffers correctly in association cloning

### DIFF
--- a/lib/waterline/model/lib/defaultMethods/toObject.js
+++ b/lib/waterline/model/lib/defaultMethods/toObject.js
@@ -88,7 +88,11 @@ toObject.prototype.addAssociations = function() {
         if (record === null) return;
         var item = Object.create(record.__proto__);
         Object.keys(record).forEach(function(key) {
-          item[key] = _.cloneDeep(record[key]);
+          item[key] = _.cloneDeep(record[key], function dealWithBuffers(val) {
+            if (val instanceof Buffer) {
+              return val.slice();
+            }
+          });
         });
         records.push(item);
       });


### PR DESCRIPTION
When populating, buffers are not cloned correctly with the default lodash cloneDeep function.
