### PR TITLE
Run afterValidate with Model instance as `this`

### DIFF
--- a/lib/waterline/query/validate.js
+++ b/lib/waterline/query/validate.js
@@ -63,7 +63,7 @@ module.exports = {
       // Run After Validate Lifecycle Callbacks
       function(cb) {
         var runner = function(item, callback) {
-          item(values, function(err) {
+          item.call(self, values, function(err) {
             if (err) return callback(err);
             callback();
           });


### PR DESCRIPTION
Align context of `afterValidate` with those of `beforeValidate` and make `this` point to model instead of a global scope.

This is much beneficial since allows to implement common logic in single place (e.g. config/models.js in Sails).

Also it's just weird that `beforeValidate` and `afterValidate` which mirror each other are run in different contexts.