### PR TITLE
Include the api version in connection properties

### DIFF
--- a/lib/waterline/VERSION.js
+++ b/lib/waterline/VERSION.js
@@ -1,0 +1,2 @@
+// Store the API Version being used
+module.exports = 1;

--- a/lib/waterline/connections/index.js
+++ b/lib/waterline/connections/index.js
@@ -4,6 +4,7 @@
 var _ = require('lodash');
 var util = require('util');
 var hasOwnProperty = require('../utils/helpers').object.hasOwnProperty;
+var API_VERSION = require('../VERSION');
 
 /**
  * Connections are active "connections" to a specific adapter for a specific configuration.
@@ -63,7 +64,7 @@ Connections.prototype._build = function _build(adapters, options) {
 
     // Build the connection config
     connection = {
-      config: _.merge({}, adapters[config.adapter].defaults, config),
+      config: _.merge({}, adapters[config.adapter].defaults, config, { version: API_VERSION }),
       _adapter: _.cloneDeep(adapters[config.adapter]),
       _collections: []
     };


### PR DESCRIPTION
This allows adapters to behave differently depending on what version of the API is being used.