### PR TITLE
Fix M-T-M Not Being Mapped

### DIFF
--- a/lib/waterline/model/lib/associationMethods/add.js
+++ b/lib/waterline/model/lib/associationMethods/add.js
@@ -290,11 +290,12 @@ Add.prototype.createManyToMany = function(collection, attribute, pk, key, cb) {
 
   // Grab the associated collection's primaryKey
   var collectionAttributes = this.collection.waterline.schema[attribute.collection.toLowerCase()];
-  var associationKey = collectionAttributes.attributes[attribute.on].via;
+  var associationKeyAttr = collectionAttributes.attributes[attribute.on] || collectionAttributes.attributes[attribute.via];
+  var associationKey = associationKeyAttr.via;
 
   // If this is a throughTable, look into the meta data cache for what key to use
   if (collectionAttributes.throughTable) {
-    var cacheKey = collectionAttributes.throughTable[attribute.on + '.' + key];
+    var cacheKey = collectionAttributes.throughTable[attribute.on + '.' + key] || collectionAttributes.throughTable[attribute.via + '.' + key];
     if (!cacheKey) {
       return cb(new Error('Unable to find the proper cache key in the through table definition'));
     }

--- a/lib/waterline/model/lib/associationMethods/remove.js
+++ b/lib/waterline/model/lib/associationMethods/remove.js
@@ -228,11 +228,12 @@ Remove.prototype.removeManyToMany = function(collection, attribute, pk, key, cb)
 
   // Grab the associated collection's primaryKey
   var collectionAttributes = this.collection.waterline.schema[attribute.collection.toLowerCase()];
-  var associationKey = collectionAttributes.attributes[attribute.on].via;
+  var associationKeyAttr = collectionAttributes.attributes[attribute.on] || collectionAttributes.attributes[attribute.via];
+  var associationKey = associationKeyAttr.via;
 
   // If this is a throughTable, look into the meta data cache for what key to use
   if (collectionAttributes.throughTable) {
-    var cacheKey = collectionAttributes.throughTable[attribute.on + '.' + key];
+    var cacheKey = collectionAttributes.throughTable[attribute.on + '.' + key] || collectionAttributes.throughTable[attribute.via + '.' + key];
     if (!cacheKey) {
       return cb(new Error('Unable to find the proper cache key in the through table definition'));
     }


### PR DESCRIPTION
When a custom column name is used in a many-to-many through the joins for the create weren't being mapped correctly.

See this [Stackoverflow Issue](http://stackoverflow.com/questions/37774857/sailsjs-through-association-how-to-create-association) for more details.