### PR TITLE
Fix aggregate options ignored in where

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -338,17 +338,19 @@ Deferred.prototype.where = function(criteria) {
     this._criteria = false;
   }
 
-  if (!criteria || !criteria.where) return this;
+  if (!criteria /*|| !criteria.where*/) return this;
 
   if (!this._criteria) this._criteria = {};
-  var where = this._criteria.where || {};
+  // var where = this._criteria.where || {};
 
-  // Merge with existing WHERE clause
-  Object.keys(criteria.where).forEach(function(key) {
-    where[key] = criteria.where[key];
-  });
+  // // Merge with existing WHERE clause
+  // Object.keys(criteria.where).forEach(function(key) {
+  //   where[key] = criteria.where[key];
+  // });
 
-  this._criteria.where = where;
+  // this._criteria.where = where;
+
+  _.extend(this._criteria, criteria);
 
   return this;
 };


### PR DESCRIPTION
If aggregate options are passed to where, they are saved to the criteria
object from normalize.criteria(criteria) however only criteria.where is
saved to _criteria.where, options saved to criteria object is ignored.