### PR TITLE
Build up an OR clause for reflexive many to many joins

### DIFF
--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -86,17 +86,17 @@ module.exports = function(criteria, cb) {
 
       function destroyJoinTableRecords(item, next) {
         var collection = self.waterline.collections[item];
-        var refKey;
+        var refKey = [];
 
         Object.keys(collection._attributes).forEach(function(key) {
           var attr = collection._attributes[key];
           if (attr.references !== self.identity) return;
-          refKey = key;
+          refKey.push(key);
         });
 
         // If no refKey return, this could leave orphaned join table values but it's better
         // than crashing.
-        if (!refKey) return next();
+        if (!refKey.length) return next();
 
         // Make sure we don't return any undefined pks
         var mappedValues = result.reduce(function(memo, vals) {
@@ -109,7 +109,22 @@ module.exports = function(criteria, cb) {
         var criteria = {};
 
         if (mappedValues.length > 0) {
-          criteria[refKey] = mappedValues;
+          // Handle reflexive associations by building up an OR clause.
+          if (refKey.length > 1) {
+            var orCriteria = [];
+            _.each(refKey, function(columnName) {
+              var where = {};
+              where[columnName] = mappedValues;
+              orCriteria.push(where);
+            });
+
+            criteria = {
+              or: orCriteria
+            };
+          } else {
+            criteria[_.first(refKey)] = mappedValues;
+          }
+
           collection.destroy(criteria).exec(next);
         } else {
           return next();


### PR DESCRIPTION
When a join table is made up of two columns both using the same model's primary key, build up an `OR` clause to check both sides of the join.