### PR TITLE
[patch] Streamline validations

### DIFF
--- a/accessible/allowed-validations.js
+++ b/accessible/allowed-validations.js
@@ -1,0 +1,1 @@
+module.exports = require('anchor/accessible/rules');

--- a/lib/waterline/utils/system/validation-builder.js
+++ b/lib/waterline/utils/system/validation-builder.js
@@ -16,49 +16,22 @@
 
 var _ = require('@sailshq/lodash');
 var anchor = require('anchor');
-var RESERVED_PROPERTY_NAMES = require('./reserved-property-names');
-var RESERVED_VALIDATION_NAMES = require('./reserved-validation-names');
+var RESERVED_VALIDATION_NAMES = require('../../../../accessible/allowed-validations');
 
 module.exports = function ValidationBuilder(attributes) {
-  // Hold the validations used for each attribute
-  var validations = {};
 
 
   //  ╔╦╗╔═╗╔═╗  ┌─┐┬ ┬┌┬┐  ┬  ┬┌─┐┬  ┬┌┬┐┌─┐┌┬┐┬┌─┐┌┐┌┌─┐
   //  ║║║╠═╣╠═╝  │ ││ │ │   └┐┌┘├─┤│  │ ││├─┤ │ ││ ││││└─┐
   //  ╩ ╩╩ ╩╩    └─┘└─┘ ┴    └┘ ┴ ┴┴─┘┴─┴┘┴ ┴ ┴ ┴└─┘┘└┘└─┘
-  _.each(attributes, function(attribute, attributeName) {
+  var validations = _.reduce(attributes, function(memo, attribute, attributeName) {
+
     // Build a validation list for the attribute
-    validations[attributeName] = {};
+    memo[attributeName] = attribute.validations || {};
 
-    // Process each property in the attribute and look for any validation
-    // properties.
-    _.each(attribute, function(property, propertyName) {
-      // Ignore NULL values
-      if (_.isNull(property)) {
-        return;
-      }
+    return memo;
 
-      // If the property is reserved, don't do anything with it
-      if (_.indexOf(RESERVED_PROPERTY_NAMES, propertyName) > -1) {
-        return;
-      }
-
-      // If the property is an `enum` alias it to the anchor IN validation
-      if (propertyName.toLowerCase() === 'enum') {
-        validations[attributeName].in = property;
-        return;
-      }
-
-      // Otherwise validate that the property name is a valid anchor validation.
-      if (_.indexOf(RESERVED_VALIDATION_NAMES, propertyName) < 0) {
-        return;
-      }
-
-      // Set the validation
-      validations[attributeName][propertyName] = property;
-    });
-  });
+  }, {});
 
 
   //  ╔╗ ╦ ╦╦╦  ╔╦╗  ┬  ┬┌─┐┬  ┬┌┬┐┌─┐┌┬┐┬┌─┐┌┐┌  ┌─┐┌┐┌
@@ -117,13 +90,6 @@ module.exports = function ValidationBuilder(attributes) {
       // If value is not required and empty then don't try and validate it
       if (!curValidation.required) {
         if (_.isNull(value) || value === '') {
-          return;
-        }
-      }
-
-      // If Boolean and required manually check
-      if (curValidation.required && curValidation.type === 'boolean' && (!_.isUndefined(value)  && !_.isNull(value))) {
-        if (value.toString() === 'true' || value.toString() === 'false') {
           return;
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",
-    "anchor": "~0.11.2",
+    "anchor": "^1.0.0",
     "async": "2.0.1",
     "bluebird": "3.2.1",
     "flaverr": "^1.0.0",


### PR DESCRIPTION
`sails-hook-rom` will now handle moving top-level properties like `isEmail` into a `validations` property on an attribute, so Waterline now just has to read that property instead of doing all the merging/checking itself.  Also, `required` isn't handled by anchor anymore so the code related to that has been removed.  And Waterline can just defer to anchor to complain about unknown validation rules.