### PR TITLE
[fixes #1429] One to many associations were being removed without checking that the actual related object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .dist
 coverage/
 npm-debug.log
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,23 @@
 ROOT=$(shell pwd)
+NPMVERSION=$(shell npm --version | cut -f1 -d.)
 
 test: test-unit test-integration
 
 test-unit:
 	@echo "\nRunning unit tests..."
-	@NODE_ENV=test mocha test/integration test/structure test/support test/unit --recursive
+	@NODE_ENV=test node_modules/.bin/mocha test/integration test/structure test/support test/unit --recursive
 
+ifeq "$(NPMVERSION)" "2"
 test-integration:
 	@echo "\nRunning integration tests..."
 	rm -rf node_modules/waterline-adapter-tests/node_modules/waterline;
 	ln -s "$(ROOT)" node_modules/waterline-adapter-tests/node_modules/waterline;
 	@NODE_ENV=test node test/adapter/runner.js
+else
+test-integration:
+	@echo "\nRunning integration tests..."
+	@NODE_ENV=test node test/adapter/runner.js
+endif
 
 coverage:
 	@echo "\n\nRunning coverage report..."

--- a/lib/waterline/model/lib/associationMethods/remove.js
+++ b/lib/waterline/model/lib/associationMethods/remove.js
@@ -43,7 +43,7 @@ var Remove = module.exports = function(collection, proto, records, cb) {
   //
   // In the future when transactions are available this will all be done on a single
   // connection and can be re-written.
-  this.removeCollectionAssociations(records, cb);
+  this.removeCollectionAssociations(records, proto, cb);
 };
 
 /**
@@ -78,11 +78,11 @@ Remove.prototype.findPrimaryKey = function(attributes, values) {
  * @api private
  */
 
-Remove.prototype.removeCollectionAssociations = function(records, cb) {
+Remove.prototype.removeCollectionAssociations = function(records, proto, cb) {
   var self = this;
 
   async.eachSeries(_.keys(records), function(associationKey, next) {
-    self.removeAssociations(associationKey, records[associationKey], next);
+    self.removeAssociations(associationKey, records[associationKey], proto, next);
   },
 
   function(err) {
@@ -103,7 +103,7 @@ Remove.prototype.removeCollectionAssociations = function(records, cb) {
  * @api private
  */
 
-Remove.prototype.removeAssociations = function(key, records, cb) {
+Remove.prototype.removeAssociations = function(key, records, proto, cb) {
   var self = this;
 
   // Grab the collection the attribute references
@@ -115,7 +115,7 @@ Remove.prototype.removeAssociations = function(key, records, cb) {
 
   // Limit Removes to 10 at a time to prevent the connection pool from being exhausted
   async.eachLimit(records, 10, function(associationId, next) {
-    self.removeRecord(associatedCollection, schema, associationId, key, next);
+    self.removeRecord(associatedCollection, schema, associationId, key, proto, next);
   }, cb);
 
 };
@@ -130,7 +130,7 @@ Remove.prototype.removeAssociations = function(key, records, cb) {
  * @api private
  */
 
-Remove.prototype.removeRecord = function(collection, attribute, associationId, key, cb) {
+Remove.prototype.removeRecord = function(collection, attribute, associationId, key, proto, cb) {
   var self = this;
 
   // Validate `values` is a correct primary key format
@@ -172,6 +172,7 @@ Remove.prototype.removeRecord = function(collection, attribute, associationId, k
   var _values = {};
 
   criteria[associationKey] = associationId;
+  criteria[attribute.on] = proto.id;
   _values[attribute.on] = null;
 
   collection.update(criteria, _values, function(err) {

--- a/test/integration/model/association.remove.hasMany.js
+++ b/test/integration/model/association.remove.hasMany.js
@@ -41,15 +41,18 @@ describe('Model', function() {
         waterline.loadCollection(Preference);
 
         var _values = [
-          { id: 1, preference: [{ foo: 'bar' }, { foo: 'foobar' }] },
-          { id: 2, preference: [{ foo: 'a' }, { foo: 'b' }] },
+          { id: 1, preference: [{ id: 10, foo: 'bar' }, { id: 20, foo: 'foobar' }] },
+          { id: 2, preference: [{ id: 30, foo: 'a' }, { id: 40, foo: 'b' }] },
         ];
 
         var adapterDef = {
           find: function(con, col, criteria, cb) { return cb(null, _values); },
           update: function(con, col, criteria, values, cb) {
             if(col === 'preference') {
-              prefValues.push({ id: criteria.where.id, values: values });
+              prefValues.push({
+                id: criteria.where.id,
+                assoc: criteria.where.user,
+                values: values });
             }
 
             return cb(null, values);
@@ -80,16 +83,18 @@ describe('Model', function() {
 
           var person = models[0];
 
-          person.preferences.remove(1);
-          person.preferences.remove(2);
+          person.preferences.remove(10);
+          person.preferences.remove(20);
 
           person.save(function(err) {
             if(err) return done(err);
 
             assert(prefValues.length === 2);
-            assert(prefValues[0].id === 1);
+            assert(prefValues[0].id === 10);
+            assert(prefValues[0].assoc === 1);
             assert(prefValues[0].values.user === null);
-            assert(prefValues[1].id === 2);
+            assert(prefValues[1].id === 20);
+            assert(prefValues[1].assoc === 1);
             assert(prefValues[1].values.user === null);
 
             done();


### PR DESCRIPTION
One to many associations were being removed without checking that the actual related object is the same as the one the user is trying to remove.
The fix adds a condition to the update, so that it makes sure that the value matches.