### PR TITLE
fix cannot read property 'replace' of undefined

### DIFF
--- a/lib/waterline/error/WLError.js
+++ b/lib/waterline/error/WLError.js
@@ -26,7 +26,7 @@ function WLError(properties) {
   }
 
   // Doctor up a modified version of the stack trace called `rawStack`:
-  this.rawStack = (this._e.stack.replace(/^Error(\r|\n)*(\r|\n)*/, ''));
+  this.rawStack = (this._e && this._e.stask && this._e.stack.replace(/^Error(\r|\n)*(\r|\n)*/, '') || '');
 
   // Customize `details`:
   // Try to dress up the wrapped "original" error as much as possible.


### PR DESCRIPTION
In some cases Error doesn’t have stack property ( I've faced with it in case Cassandra DB is offline and we've caught timeout exception  )