### PR TITLE
[patch] Fix issue where attribute is required and is a model attribute

### DIFF
--- a/lib/waterline/utils/query/private/normalize-new-record.js
+++ b/lib/waterline/utils/query/private/normalize-new-record.js
@@ -325,7 +325,7 @@ module.exports = function normalizeNewRecord(newRecord, modelIdentity, orm, curr
             return rttc.getNounPhrase(attrDef.type);
           }//-•
           var otherModelIdentity = attrDef.model ? attrDef.model : attrDef.collection;
-          var OtherModel = getModel(attrDef.collection, orm);
+          var OtherModel = getModel(otherModelIdentity, orm);
           var otherModelPkType = getAttribute(OtherModel.primaryKey, otherModelIdentity, orm).type;
           return rttc.getNounPhrase(otherModelPkType)+' (the '+OtherModel.primaryKey+' of a '+otherModelIdentity+')';
         })()+', '+


### PR DESCRIPTION
Fix issue where attribute is required and is a model attribute. It was throwing an error about `Error: Consistency violation: `modelIdentity` must be a non-empty string.  Instead got: undefined` because collection was not existing, as it is a required model attribute.