### PR TITLE
[proposal] Allow Date type in autoCreatedAt/autoUpdatedAt with the 'ref' type

### DIFF
--- a/lib/waterline/utils/query/forge-stage-two-query.js
+++ b/lib/waterline/utils/query/forge-stage-two-query.js
@@ -1288,11 +1288,14 @@ module.exports = function forgeStageTwoQuery(query, orm) {
 
       // -• IWMIH, this is an attribute that has `autoUpdatedAt: true`,
       // and no value was explicitly provided for it.
-      assert(attrDef.type === 'number' || attrDef.type === 'string', 'If an attribute has `autoUpdatedAt: true`, then it should always have either `type: \'string\'` or `type: \'number\'`.  But the definition for attribute (`'+attrName+'`) has somehow gotten into this state!  This should be impossible, but it has both `autoUpdatedAt: true` AND `type: \''+attrDef.type+'\'`');
+      assert(attrDef.type === 'number' || attrDef.type === 'string' || attrDef.type === 'ref', 'If an attribute has `autoUpdatedAt: true`, then it should always have either `type: \'string\'`, `type: \'number\'` or `type: \'ref\'`.  But the definition for attribute (`'+attrName+'`) has somehow gotten into this state!  This should be impossible, but it has both `autoUpdatedAt: true` AND `type: \''+attrDef.type+'\'`');
 
       // Set the value equal to the current timestamp, using the appropriate format.
       if (attrDef.type === 'string') {
         query.valuesToSet[attrName] = (new Date(theMomentBeforeFS2Q)).toJSON();
+      }
+      else if (attrDef.type === 'ref') {
+        query.valuesToSet[attrName] = new Date(theMomentBeforeFS2Q);
       }
       else {
         query.valuesToSet[attrName] = theMomentBeforeFS2Q;

--- a/lib/waterline/utils/query/private/normalize-new-record.js
+++ b/lib/waterline/utils/query/private/normalize-new-record.js
@@ -371,11 +371,14 @@ module.exports = function normalizeNewRecord(newRecord, modelIdentity, orm, curr
     // > the exact same timestamp (in a `.createEach()` scenario, for example)
     else if (attrDef.autoCreatedAt || attrDef.autoUpdatedAt) {
 
-      assert(attrDef.type === 'number' || attrDef.type === 'string', 'If an attribute has `autoCreatedAt: true` or `autoUpdatedAt: true`, then it should always have either `type: \'string\'` or `type: \'number\'`.  But the definition for attribute (`'+attrName+'`) has somehow gotten into an impossible state: It has `autoCreatedAt: '+attrDef.autoCreatedAt+'`, `autoUpdatedAt: '+attrDef.autoUpdatedAt+'`, and `type: \''+attrDef.type+'\'`');
+      assert(attrDef.type === 'number' || attrDef.type === 'string' || attrDef.type === 'ref', 'If an attribute has `autoCreatedAt: true` or `autoUpdatedAt: true`, then it should always have either `type: \'string\'`, `type: \'number\'` or `type: \'ref\'`.  But the definition for attribute (`'+attrName+'`) has somehow gotten into an impossible state: It has `autoCreatedAt: '+attrDef.autoCreatedAt+'`, `autoUpdatedAt: '+attrDef.autoUpdatedAt+'`, and `type: \''+attrDef.type+'\'`');
 
       // Set the value equal to the current timestamp, using the appropriate format.
       if (attrDef.type === 'string') {
         newRecord[attrName] = (new Date(currentTimestamp)).toJSON();
+      }
+      else if (attrDef.type === 'ref') {
+        newRecord[attrName] = new Date(currentTimestamp);
       }
       else {
         newRecord[attrName] = currentTimestamp;

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -358,7 +358,7 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
             record[attrName] !== '' &&
             record[attrName] !== 0 &&
             (
-              _.isString(record[attrName]) || _.isNumber(record[attrName])
+              _.isString(record[attrName]) || _.isNumber(record[attrName]) || _.isDate(record[attrName])
             )
           );
 


### PR DESCRIPTION
Until the Sails1 version, the mongo adapter stored the createdAt/updatedAt values as Date types. So to keep everything working we need to allow the same Date type in the v1 of Sails.

With this PR using the 'ref' type will allow auto generate dates with the Date type:

```javascript
  attributes: {
    createdAt: { type: 'ref', autoCreatedAt: true },
    updatedAt: { type: 'ref', autoUpdatedAt: true },
    id: { type: 'string', columnName: '_id' }
  }
```
This PR goes with another PR in waterline-schema: https://github.com/balderdashy/waterline-schema/pull/90

Plus, we need to document this behavior that all the previous sails-mongo users will need (if they don't use the migrate: 'alter' option). 