### PR TITLE
[proposal] encryption at rest

### DIFF
--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -196,6 +196,14 @@ function Waterline() {
                   });
                 }//•
 
+                if (attrDef.model || attrDef.collection) {
+                  throw flaverr({
+                    code: 'E_ATTR_NOT_COMPATIBLE_WITH_AT_REST_ENCRYPTION',
+                    attrName: attrName,
+                    whyNotCompatible: 'with associations.'
+                  });
+                }//•
+
                 if (attrDef.defaultsTo !== undefined) {
                   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                   // FUTURE: Consider adding support for this.  Will require some refactoring

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -158,10 +158,31 @@ function Waterline() {
       }
 
 
-      // Next, validate the `encrypt` attribute property, if it is in use.
+      // Next, validate ORM settings related to at-rest encryption, if it is in use.
       // =============================================================================================
+      _.each(wmds, function(wmd){
 
-      // TODO
+        var modelDef = wmd.prototype;
+
+        // Verify that `encrypt` attr prop is valid, if in use.
+        _.each(modelDef.attributes, function(attrDef, attrName){
+          if (attrDef.encrypt !== undefined) {
+            if (!_.isBoolean(attrDef.encrypt)){
+              throw new Error(
+                'Invalid usage of `encrypt` in the definition of `'+modelDef.identity+'` model\'s '+
+                '`'+attrName+'` attribute.  If set, `encrypt` must be either `true` or `false`.'
+              );
+            }//•
+            if (attrDef.encrypt === true && attrDef.type === 'ref') {
+              throw new Error(
+                'Invalid usage of `encrypt` in the definition of `'+modelDef.identity+'` model\'s '+
+                '`'+attrName+'` attribute.   At-rest encryption (`encrypt: true`) cannot be used '+
+                'with `type: \'ref\'` attributes.'
+              );
+            }//•
+          }//ﬁ
+        });//∞
+      });//∞
 
 
       // Next, set up support for the default archive, and validate related settings:

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -167,24 +167,75 @@ function Waterline() {
         var modelDef = wmd.prototype;
 
         // Verify that `encrypt` attr prop is valid, if in use.
-        _.each(modelDef.attributes, function(attrDef, attrName){
-          if (attrDef.encrypt !== undefined) {
-            if (!_.isBoolean(attrDef.encrypt)){
-              throw new Error(
-                'Invalid usage of `encrypt` in the definition of `'+modelDef.identity+'` model\'s '+
-                '`'+attrName+'` attribute.  If set, `encrypt` must be either `true` or `false`.'
-              );
-            }//•
-            if (attrDef.encrypt === true && attrDef.type === 'ref') {
-              throw new Error(
-                'Invalid usage of `encrypt` in the definition of `'+modelDef.identity+'` model\'s '+
-                '`'+attrName+'` attribute.   At-rest encryption (`encrypt: true`) cannot be used '+
-                'with `type: \'ref\'` attributes.'
-              );
-            }//•
-          }//ﬁ
-        });//∞
+        try {
+          _.each(modelDef.attributes, function(attrDef, attrName){
+            if (attrDef.encrypt !== undefined) {
+              if (!_.isBoolean(attrDef.encrypt)){
+                throw flaverr({
+                  code: 'E_INVALID_ENCRYPT',
+                  attrName: attrName,
+                  message: 'If set, `encrypt` must be either `true` or `false`.'
+                });
+              }//•
 
+              if (attrDef.encrypt === true){
+
+                if (attrDef.type === 'ref') {
+                  throw flaverr({
+                    code: 'E_ATTR_NOT_COMPATIBLE_WITH_AT_REST_ENCRYPTION',
+                    attrName: attrName,
+                    whyNotCompatible: 'with `type: \'ref\'` attributes.'
+                  });
+                }//•
+
+                if (attrDef.autoCreatedAt || attrDef.autoUpdatedAt) {
+                  throw flaverr({
+                    code: 'E_ATTR_NOT_COMPATIBLE_WITH_AT_REST_ENCRYPTION',
+                    attrName: attrName,
+                    whyNotCompatible: 'with `'+(attrDef.autoCreatedAt?'autoCreatedAt':'autoUpdatedAt')+'` attributes.'
+                  });
+                }//•
+
+                if (attrDef.defaultsTo !== undefined) {
+                  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                  // FUTURE: Consider adding support for this.  Will require some refactoring
+                  // in order to do it right (i.e. otherwise we'll just be copying and pasting
+                  // the encryption logic.)  We'll want to pull it out from normalize-value-to-set
+                  // into a new utility, then call that from the appropriate spot in
+                  // normalize-new-record in order to encrypt the initial default value.
+                  //
+                  // (See also the other note in normalize-new-record re defaultsTo + cloneDeep.)
+                  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                  throw flaverr({
+                    code: 'E_ATTR_NOT_COMPATIBLE_WITH_AT_REST_ENCRYPTION',
+                    attrName: attrName,
+                    whyNotCompatible: 'with an attribute that also specifies a `defaultsTo`.  '+
+                    'Please remove the `defaultsTo` from this attribute definition.'
+                  });
+                }//•
+
+              }//ﬁ
+
+            }//ﬁ
+          });//∞
+        } catch (err) {
+          switch (err.code) {
+            case 'E_INVALID_ENCRYPT':
+              throw flaverr({
+                message:
+                'Invalid usage of `encrypt` in the definition for `'+modelDef.identity+'` model\'s '+
+                '`'+err.attrName+'` attribute.  '+err.message
+              }, err);
+            case 'E_ATTR_NOT_COMPATIBLE_WITH_AT_REST_ENCRYPTION':
+              throw flaverr({
+                message:
+                'Invalid usage of `encrypt` in the definition for `'+modelDef.identity+'` model\'s '+
+                '`'+err.attrName+'` attribute.  At-rest encryption (`encrypt: true`) cannot be used '+
+                err.whyNotCompatible
+              }, err);
+            default: throw err;
+          }
+        }
 
 
         modelDef.dataEncryptionKeys = {
@@ -217,7 +268,7 @@ function Waterline() {
         }//ﬁ
 
 
-        // If any attrs have `encrypt: true`, verify that there is both  a valid
+        // If any attrs have `encrypt: true`, verify that there is both a valid
         // `dataEncryptionKeys` dictionary and a valid `dataEncryptionKeys.default` DEK set.
         // TODO
 

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -392,17 +392,16 @@ function Waterline() {
 
 
       // Check the internal "schema map" for any junction models that were
-      // implicitly introduced above.
-      _.each(internalSchema, function(val, table) {
-        if (!val.junctionTable) {
-          return;
-        }
-
-        // Whenever one is found, generate a custom constructor for it
-        // (based on a clone of the `BaseMetaModel` constructor), then push
-        // it on to our set of wmds.
-        wmds.push(BaseMetaModel.extend(internalSchema[table]));
-      });
+      // implicitly introduced above and handle them.
+      _.each(_.keys(internalSchema), function(table) {
+        if (internalSchema[table].junctionTable) {
+          // Whenever one is found, flag it as `_private: true` and generate
+          // a custom constructor for it (based on a clone of the `BaseMetaModel`
+          // constructor), then push it on to our set of wmds.
+          internalSchema[table]._private = true;
+          wmds.push(BaseMetaModel.extend(internalSchema[table]));
+        }//ﬁ
+      });//∞
 
 
       // Now build live models

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -266,17 +266,47 @@ function Waterline() {
           // (FUTURE: maybe extend EA to support a `validateKeys()` method instead of this--
           // or at least to have error code)
           // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-          _.each(modelDef.dataEncryptionKeys, function(dek, dekId){
-            try {
-              EA(undefined, { keys: modelDef.dataEncryptionKeys, keyId: dekId }).encryptAttribute(undefined, 'test-value-purely-for-validation');
-            } catch (err) {
-              throw flaverr({
-                message: 'In the definition for the `'+modelDef.identity+'` model, one of the data encryption keys (`dataEncryptionKeys.'+dekId+'`)  is invalid.\n'+
-                'Details:\n'+
-                '  '+err.message
-              }, _.isError(err) ? err : new Error());
+          try {
+            _.each(modelDef.dataEncryptionKeys, function(dek, dekId){
+
+              if (!dek || !_.isString(dek)) {
+                throw flaverr({
+                  code: 'E_INVALID_DATA_ENCRYPTION_KEYS',
+                  dekId: dekId,
+                  message: 'Must be a cryptographically random, 32 byte string.'
+                });
+              }//•
+
+              if (!dekId.match(/^[a-z\$]([a-z0-9])*$/i)){
+                throw flaverr({
+                  code: 'E_INVALID_DATA_ENCRYPTION_KEYS',
+                  dekId: dekId,
+                  message: 'Please make sure the ids of all of your data encryption keys begin with a letter and do not contain any special characters.'
+                });
+              }//•
+
+              try {
+                EA(undefined, { keys: modelDef.dataEncryptionKeys, keyId: dekId }).encryptAttribute(undefined, 'test-value-purely-for-validation');
+              } catch (err) {
+                throw flaverr({
+                  code: 'E_INVALID_DATA_ENCRYPTION_KEYS',
+                  dekId: dekId
+                }, err);
+              }
+
+            });//∞
+          } catch (err) {
+            switch (err.code) {
+              case 'E_INVALID_DATA_ENCRYPTION_KEYS':
+                throw flaverr({
+                  message: 'In the definition for the `'+modelDef.identity+'` model, one of the data encryption keys (`dataEncryptionKeys.'+err.dekId+'`)  is invalid.\n'+
+                  'Details:\n'+
+                  '  '+err.message
+                }, err);
+              default:
+                throw err;
             }
-          });//∞
+          }
 
         }//ﬁ
 
@@ -297,7 +327,8 @@ function Waterline() {
               'For example, one common best practice is to configure them using environment variables.\n'+
               'In a Sails app:\n'+
               '    sails_models__dataEncryptionKeys__default=vpB2EhXaTi+wYKUE0ojI5cVQX/VRGP++Fa0bBW/NFSs=\n'+
-              ' [?] If you\'re unsure, head over to https://sailsjs.com/support'
+              '\n'+
+              ' [?] If you\'re unsure or want advice, head over to https://sailsjs.com/support'
             });
           }//•
         }//ﬁ

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -167,6 +167,7 @@ function Waterline() {
         var modelDef = wmd.prototype;
 
         // Verify that `encrypt` attr prop is valid, if in use.
+        var isThisModelUsingAtRestEncryption;
         try {
           _.each(modelDef.attributes, function(attrDef, attrName){
             if (attrDef.encrypt !== undefined) {
@@ -179,6 +180,8 @@ function Waterline() {
               }//•
 
               if (attrDef.encrypt === true){
+
+                isThisModelUsingAtRestEncryption = true;
 
                 if (attrDef.type === 'ref') {
                   throw flaverr({
@@ -246,15 +249,17 @@ function Waterline() {
         }
 
 
-        modelDef.dataEncryptionKeys = {
-          default: require('crypto').randomBytes(32).toString('base64')// TODO: don't bundle this fake key
-          // default: 'blah blah'
-        };
-
         // Verify `dataEncryptionKeys`.
         // (Remember, if there is a secondary key system in use, these DEKs should have
         // already been "unwrapped" before they were passed in to Waterline as model settings.)
         if (modelDef.dataEncryptionKeys !== undefined) {
+
+          if (!_.isObject(modelDef.dataEncryptionKeys) || _.isArray(modelDef.dataEncryptionKeys) || _.isFunction(modelDef.dataEncryptionKeys)) {
+            throw flaverr({
+              message: 'In the definition for the `'+modelDef.identity+'` model, the `dataEncryptionKeys` model setting '+
+              'is invalid.  If specified, `dataEncryptionKeys` must be a dictionary (plain JavaScript object).'
+            });
+          }//•
 
           // Check all DEKs for validity.
           // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -278,7 +283,24 @@ function Waterline() {
 
         // If any attrs have `encrypt: true`, verify that there is both a valid
         // `dataEncryptionKeys` dictionary and a valid `dataEncryptionKeys.default` DEK set.
-        // TODO
+        if (isThisModelUsingAtRestEncryption) {
+
+          if (!modelDef.dataEncryptionKeys || !modelDef.dataEncryptionKeys.default) {
+            throw flaverr({
+              message:
+              'DEKs should be 32 bytes long, and cryptographically random.  A random, default DEK is included '+
+              'in new Sails apps, so one easy way to generate a new DEK is to generate a new Sails app.  '+
+              'Alternatively, you could run:\n'+
+              '    require(\'crypto\').randomBytes(32).toString(\'base64\')\n'+
+              '\n'+
+              'Remember: once in production, you should manage your DEKs like you would any other sensitive credential.  '+
+              'For example, one common best practice is to configure them using environment variables.\n'+
+              'In a Sails app:\n'+
+              '    sails_models__dataEncryptionKeys__default=vpB2EhXaTi+wYKUE0ojI5cVQX/VRGP++Fa0bBW/NFSs=\n'+
+              ' [?] If you\'re unsure, head over to https://sailsjs.com/support'
+            });
+          }//•
+        }//ﬁ
 
 
       });//∞

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -10,6 +10,8 @@ var assert = require('assert');
 var util = require('util');
 var _ = require('@sailshq/lodash');
 var async = require('async');
+var EA = require('encrypted-attr');
+var flaverr = require('flaverr');
 var Schema = require('waterline-schema');
 var buildDatastoreMap = require('./waterline/utils/system/datastore-builder');
 var buildLiveWLModel = require('./waterline/utils/system/collection-builder');
@@ -182,6 +184,44 @@ function Waterline() {
             }//•
           }//ﬁ
         });//∞
+
+
+
+        modelDef.dataEncryptionKeys = {
+          default: require('crypto').randomBytes(32).toString('base64')// TODO: don't bundle this fake key
+          // default: 'blah blah'
+        };
+
+        // Verify `dataEncryptionKeys`.
+        // (Remember, if there is a secondary key system in use, these DEKs should have
+        // already been "unwrapped" before they were passed in to Waterline as model settings.)
+        if (modelDef.dataEncryptionKeys !== undefined) {
+
+          // Check all DEKs for validity.
+          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          // (FUTURE: maybe extend EA to support a `validateKeys()` method instead of this--
+          // or at least to have error code)
+          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          _.each(modelDef.dataEncryptionKeys, function(dek, dekId){
+            try {
+              EA(undefined, { keys: modelDef.dataEncryptionKeys, keyId: dekId }).encryptAttribute(undefined, 'test-value-purely-for-validation');
+            } catch (err) {
+              throw flaverr({
+                message: 'In the definition for the `'+modelDef.identity+'` model, one of the data encryption keys (`dataEncryptionKeys.'+dekId+'`)  is invalid.\n'+
+                'Details:\n'+
+                '  '+err.message
+              }, _.isError(err) ? err : new Error());
+            }
+          });//∞
+
+        }//ﬁ
+
+
+        // If any attrs have `encrypt: true`, verify that there is both  a valid
+        // `dataEncryptionKeys` dictionary and a valid `dataEncryptionKeys.default` DEK set.
+        // TODO
+
+
       });//∞
 
 

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -158,6 +158,10 @@ function Waterline() {
       }
 
 
+      // Next, validate the `encrypt` attribute property, if it is in use.
+      // =============================================================================================
+
+      // TODO
 
 
       // Next, set up support for the default archive, and validate related settings:

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -409,11 +409,11 @@ function Waterline() {
 
       // Hydrate each model definition (in-place), and also set up a
       // reference to it in the model map.
-      _.each(wmds, function (modelDef) {
+      _.each(wmds, function (wmd) {
 
         // Set the attributes and schema values using the normalized versions from
         // Waterline-Schema where everything has already been processed.
-        var schemaVersion = internalSchema[modelDef.prototype.identity];
+        var schemaVersion = internalSchema[wmd.prototype.identity];
 
         // Set normalized values from the schema version on the model definition.
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -421,25 +421,25 @@ function Waterline() {
         // (or if we determine it significantly improves the performance of ORM initialization, then
         // let's keep it, but document that here and leave a link to the benchmark as a comment)
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        modelDef.prototype.identity = schemaVersion.identity;
-        modelDef.prototype.tableName = schemaVersion.tableName;
-        modelDef.prototype.datastore = schemaVersion.datastore;
-        modelDef.prototype.primaryKey = schemaVersion.primaryKey;
-        modelDef.prototype.meta = schemaVersion.meta;
-        modelDef.prototype.attributes = schemaVersion.attributes;
-        modelDef.prototype.schema = schemaVersion.schema;
-        modelDef.prototype.hasSchema = schemaVersion.hasSchema;
+        wmd.prototype.identity = schemaVersion.identity;
+        wmd.prototype.tableName = schemaVersion.tableName;
+        wmd.prototype.datastore = schemaVersion.datastore;
+        wmd.prototype.primaryKey = schemaVersion.primaryKey;
+        wmd.prototype.meta = schemaVersion.meta;
+        wmd.prototype.attributes = schemaVersion.attributes;
+        wmd.prototype.schema = schemaVersion.schema;
+        wmd.prototype.hasSchema = schemaVersion.hasSchema;
 
         // Mixin junctionTable or throughTable if available
         if (_.has(schemaVersion, 'junctionTable')) {
-          modelDef.prototype.junctionTable = schemaVersion.junctionTable;
+          wmd.prototype.junctionTable = schemaVersion.junctionTable;
         }
 
         if (_.has(schemaVersion, 'throughTable')) {
-          modelDef.prototype.throughTable = schemaVersion.throughTable;
+          wmd.prototype.throughTable = schemaVersion.throughTable;
         }
 
-        var WLModel = buildLiveWLModel(modelDef, datastoreMap, context);
+        var WLModel = buildLiveWLModel(wmd, datastoreMap, context);
 
         // Store the live Waterline model so it can be used
         // internally to create other records

--- a/lib/waterline/methods/add-to-collection.js
+++ b/lib/waterline/methods/add-to-collection.js
@@ -204,6 +204,8 @@ module.exports = function addToCollection(/* targetRecordIds, collectionAttrName
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The target record ids (i.e. first argument) passed to `.addToCollection()` '+
                 'should be the ID (or IDs) of target records whose collection will be modified.\n'+
@@ -216,6 +218,8 @@ module.exports = function addToCollection(/* targetRecordIds, collectionAttrName
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The collection attr name (i.e. second argument) to `.addToCollection()` should '+
                 'be the name of a collection association from this model.\n'+
@@ -228,6 +232,8 @@ module.exports = function addToCollection(/* targetRecordIds, collectionAttrName
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The associated ids (i.e. using `.members()`, or the third argument) passed to `.addToCollection()` should be '+
                 'the ID (or IDs) of associated records to add.\n'+
@@ -244,6 +250,8 @@ module.exports = function addToCollection(/* targetRecordIds, collectionAttrName
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message: e.message
               }, omen)
             );

--- a/lib/waterline/methods/archive.js
+++ b/lib/waterline/methods/archive.js
@@ -167,6 +167,8 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
             return done(
               flaverr({
                 name: 'UsageError',
+                code: err.code,
+                details: err.details,
                 message:
                 'Invalid criteria.\n'+
                 'Details:\n'+

--- a/lib/waterline/methods/avg.js
+++ b/lib/waterline/methods/avg.js
@@ -189,6 +189,8 @@ module.exports = function avg( /* numericAttrName?, criteria?, explicitCbMaybe?,
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The numeric attr name (i.e. first argument) to `.avg()` should '+
                 'be the name of an attribute in this model which is defined with `type: \'number\'`.\n'+
@@ -205,6 +207,8 @@ module.exports = function avg( /* numericAttrName?, criteria?, explicitCbMaybe?,
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Attempting to compute this average would be like dividing by zero, which is impossible.\n'+
                 'Details:\n'+
@@ -217,6 +221,8 @@ module.exports = function avg( /* numericAttrName?, criteria?, explicitCbMaybe?,
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message: e.message
               }, omen)
             );

--- a/lib/waterline/methods/count.js
+++ b/lib/waterline/methods/count.js
@@ -179,6 +179,8 @@ module.exports = function count( /* criteria?, explicitCbMaybe?, meta?, moreQuer
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message: e.message
               }, omen)
             );

--- a/lib/waterline/methods/create-each.js
+++ b/lib/waterline/methods/create-each.js
@@ -163,7 +163,9 @@ module.exports = function createEach( /* newRecords?, explicitCbMaybe?, meta? */
             return done(
               flaverr({
                 name: 'UsageError',
-                message: e.message
+                code: e.code,
+                message: e.message,
+                details: e.details,
               }, omen)
             );
             // ^ when the standard usage error message is good enough as-is, without any further customization

--- a/lib/waterline/methods/create.js
+++ b/lib/waterline/methods/create.js
@@ -155,6 +155,8 @@ module.exports = function create(newRecord, explicitCbMaybe, metaContainer) {
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid new record(s).\n'+
                 'Details:\n'+

--- a/lib/waterline/methods/destroy.js
+++ b/lib/waterline/methods/destroy.js
@@ -170,6 +170,8 @@ module.exports = function destroy(/* criteria, explicitCbMaybe, metaContainer */
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid criteria.\n'+
                 'Details:\n'+

--- a/lib/waterline/methods/find-one.js
+++ b/lib/waterline/methods/find-one.js
@@ -191,6 +191,8 @@ module.exports = function findOne( /* criteria?, populates?, explicitCbMaybe?, m
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid criteria.\n' +
                 'Details:\n' +
@@ -202,6 +204,8 @@ module.exports = function findOne( /* criteria?, populates?, explicitCbMaybe?, m
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid populate(s).\n' +
                 'Details:\n' +

--- a/lib/waterline/methods/find-or-create.js
+++ b/lib/waterline/methods/find-or-create.js
@@ -168,6 +168,8 @@ module.exports = function findOrCreate( /* criteria?, newRecord?, explicitCbMayb
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid criteria.\n' +
                 'Details:\n' +
@@ -179,6 +181,8 @@ module.exports = function findOrCreate( /* criteria?, newRecord?, explicitCbMayb
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid new record(s).\n'+
                 'Details:\n'+

--- a/lib/waterline/methods/find.js
+++ b/lib/waterline/methods/find.js
@@ -185,6 +185,8 @@ module.exports = function find( /* criteria?, populates?, explicitCbMaybe?, meta
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid criteria.\n' +
                 'Details:\n' +
@@ -196,6 +198,8 @@ module.exports = function find( /* criteria?, populates?, explicitCbMaybe?, meta
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid populate(s).\n' +
                 'Details:\n' +

--- a/lib/waterline/methods/find.js
+++ b/lib/waterline/methods/find.js
@@ -260,13 +260,11 @@ module.exports = function find( /* criteria?, populates?, explicitCbMaybe?, meta
             return done(err);
           }//-•
 
-          // Check the record to verify compliance with the adapter spec.,
-          // as well as any issues related to stale data that might not have been
-          // been migrated to keep up with the logical schema (`type`, etc. in
-          // attribute definitions).
+          // Perform post-processing on the populated (no longer "physical"!) records.
           try {
             processAllRecords(populatedRecords, query.meta, modelIdentity, orm);
-          } catch (e) { return done(e); }
+          } catch (err) { return done(err); }
+
 
           //  ┬ ┬┌─┐┌┐┌┌┬┐┬  ┌─┐  ╔═╗╔═╗╔╦╗╔═╗╦═╗  ┬  ┬┌─┐┌─┐┌─┐┬ ┬┌─┐┬  ┌─┐  ┌─┐┌─┐┬  ┬  ┌┐ ┌─┐┌─┐┬┌─
           //  ├─┤├─┤│││ │││  ├┤   ╠═╣╠╣  ║ ║╣ ╠╦╝  │  │├┤ ├┤ │  └┬┘│  │  ├┤   │  ├─┤│  │  ├┴┐├─┤│  ├┴┐

--- a/lib/waterline/methods/remove-from-collection.js
+++ b/lib/waterline/methods/remove-from-collection.js
@@ -206,6 +206,8 @@ module.exports = function removeFromCollection(/* targetRecordIds?, collectionAt
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The target record ids (i.e. first argument) passed to `.removeFromCollection()` '+
                 'should be the ID (or IDs) of target records whose collection will be modified.\n'+
@@ -218,6 +220,8 @@ module.exports = function removeFromCollection(/* targetRecordIds?, collectionAt
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The collection attr name (i.e. second argument) to `.removeFromCollection()` should '+
                 'be the name of a collection association from this model.\n'+
@@ -230,6 +234,8 @@ module.exports = function removeFromCollection(/* targetRecordIds?, collectionAt
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The associated ids (i.e. using `.members()`, or the third argument) passed to `.removeFromCollection()` should be '+
                 'the ID (or IDs) of associated records to remove.\n'+
@@ -246,6 +252,8 @@ module.exports = function removeFromCollection(/* targetRecordIds?, collectionAt
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message: e.message
               }, omen)
             );

--- a/lib/waterline/methods/replace-collection.js
+++ b/lib/waterline/methods/replace-collection.js
@@ -203,6 +203,8 @@ module.exports = function replaceCollection(/* targetRecordIds?, collectionAttrN
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The target record ids (i.e. first argument) passed to `.replaceCollection()` '+
                 'should be the ID (or IDs) of target records whose collection will be modified.\n'+
@@ -215,6 +217,8 @@ module.exports = function replaceCollection(/* targetRecordIds?, collectionAttrN
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The collection attr name (i.e. second argument) to `.replaceCollection()` should '+
                 'be the name of a collection association from this model.\n'+
@@ -227,6 +231,8 @@ module.exports = function replaceCollection(/* targetRecordIds?, collectionAttrN
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The associated ids (i.e. using `.members()`, or the third argument) passed to `.replaceCollection()` should be '+
                 'the ID (or IDs) of associated records to use.\n'+
@@ -243,6 +249,8 @@ module.exports = function replaceCollection(/* targetRecordIds?, collectionAttrN
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message: e.message
               }, omen)
             );

--- a/lib/waterline/methods/stream.js
+++ b/lib/waterline/methods/stream.js
@@ -215,7 +215,11 @@ module.exports = function stream( /* criteria?, eachRecordFn?, explicitCbMaybe?,
           case 'E_INVALID_STREAM_ITERATEE':
             return done(
               flaverr(
-                { name: 'UsageError' },
+                {
+                  name: 'UsageError',
+                  code: e.code,
+                  details: e.details,
+                },
                 new Error(
                   'Missing or invalid iteratee function for `.stream()`.\n'+
                   'Details:\n' +

--- a/lib/waterline/methods/sum.js
+++ b/lib/waterline/methods/sum.js
@@ -193,6 +193,8 @@ module.exports = function sum( /* numericAttrName?, criteria?, explicitCbMaybe?,
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'The numeric attr name (i.e. first argument) to `.sum()` should '+
                 'be the name of an attribute in this model which is defined with `type: \'number\'`.\n'+
@@ -209,6 +211,8 @@ module.exports = function sum( /* numericAttrName?, criteria?, explicitCbMaybe?,
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message: e.message
               }, omen)
             );

--- a/lib/waterline/methods/update.js
+++ b/lib/waterline/methods/update.js
@@ -163,6 +163,8 @@ module.exports = function update(criteria, valuesToSet, explicitCbMaybe, metaCon
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Invalid criteria.\n'+
                 'Details:\n'+
@@ -174,6 +176,8 @@ module.exports = function update(criteria, valuesToSet, explicitCbMaybe, metaCon
             return done(
               flaverr({
                 name: 'UsageError',
+                code: e.code,
+                details: e.details,
                 message:
                 'Cannot perform update with the provided values.\n'+
                 'Details:\n'+

--- a/lib/waterline/utils/query/forge-stage-two-query.js
+++ b/lib/waterline/utils/query/forge-stage-two-query.js
@@ -1142,7 +1142,7 @@ module.exports = function forgeStageTwoQuery(query, orm) {
 
 
     try {
-      query.newRecord = normalizeNewRecord(query.newRecord, query.using, orm, theMomentBeforeFS2Q);
+      query.newRecord = normalizeNewRecord(query.newRecord, query.using, orm, theMomentBeforeFS2Q, query.meta);
     } catch (e) {
       switch (e.code){
 
@@ -1207,7 +1207,7 @@ module.exports = function forgeStageTwoQuery(query, orm) {
     query.newRecords = _.map(query.newRecords, function (newRecord){
 
       try {
-        return normalizeNewRecord(newRecord, query.using, orm, theMomentBeforeFS2Q);
+        return normalizeNewRecord(newRecord, query.using, orm, theMomentBeforeFS2Q, query.meta);
       } catch (e) {
         switch (e.code){
 
@@ -1279,7 +1279,7 @@ module.exports = function forgeStageTwoQuery(query, orm) {
       // > for collection attributes (plural associations) -- by passing in `false`.
       // > That said, we currently still allow this.
       try {
-        query.valuesToSet[attrNameToSet] = normalizeValueToSet(query.valuesToSet[attrNameToSet], attrNameToSet, query.using, orm);
+        query.valuesToSet[attrNameToSet] = normalizeValueToSet(query.valuesToSet[attrNameToSet], attrNameToSet, query.using, orm, query.meta);
       } catch (e) {
         switch (e.code) {
 

--- a/lib/waterline/utils/query/forge-stage-two-query.js
+++ b/lib/waterline/utils/query/forge-stage-two-query.js
@@ -432,6 +432,37 @@ module.exports = function forgeStageTwoQuery(query, orm) {
     }//ﬁ
 
 
+    //  ┌┬┐┌─┐┌─┐┬─┐┬ ┬┌─┐┌┬┐
+    //   ││├┤ │  ├┬┘└┬┘├─┘ │
+    //  ─┴┘└─┘└─┘┴└─ ┴ ┴   ┴
+    if (query.meta.decrypt !== undefined) {
+
+      if (!_.isBoolean(query.meta.decrypt)) {
+        throw buildUsageError(
+          'E_INVALID_META',
+          'If provided, `decrypt` should be either `true` or `false`.',
+          query.using
+        );
+      }//•
+
+    }//ﬁ
+
+
+    //  ┌─┐┌┐┌┌─┐┬─┐┬ ┬┌─┐┌┬┐┬ ┬┬┌┬┐┬ ┬
+    //  ├┤ ││││  ├┬┘└┬┘├─┘ │ ││││ │ ├─┤
+    //  └─┘┘└┘└─┘┴└─ ┴ ┴   ┴ └┴┘┴ ┴ ┴ ┴
+    if (query.meta.encryptWith !== undefined) {
+
+      if (!_.isString(query.meta.encryptWith)) {
+        throw buildUsageError(
+          'E_INVALID_META',
+          'If provided, `encryptWith` should be a truthy string (the name of one of the configured data encryption keys).',
+          query.using
+        );
+      }//•
+
+    }//ﬁ
+
     // …
 
   }//ﬁ

--- a/lib/waterline/utils/query/private/normalize-new-record.js
+++ b/lib/waterline/utils/query/private/normalize-new-record.js
@@ -53,6 +53,10 @@ var normalizeValueToSet = require('./normalize-value-to-set');
  *        > This is passed in so that it can be exactly the same in the situation where
  *        > this utility might be running multiple times for a given query.
  *
+ * @param {Dictionary?} meta
+ *        The contents of the `meta` query key, if one was provided.
+ *        > Useful for propagating query options to low-level utilities like this one.
+ *
  * --
  *
  * @returns {Dictionary}
@@ -115,7 +119,7 @@ var normalizeValueToSet = require('./normalize-value-to-set');
  *
  * @throws {Error} If anything else unexpected occurs.
  */
-module.exports = function normalizeNewRecord(newRecord, modelIdentity, orm, currentTimestamp) {
+module.exports = function normalizeNewRecord(newRecord, modelIdentity, orm, currentTimestamp, meta) {
 
   // Tolerate this being left undefined by inferring a reasonable default.
   // Note that we can't bail early, because we need to check for more stuff
@@ -174,7 +178,7 @@ module.exports = function normalizeNewRecord(newRecord, modelIdentity, orm, curr
     // Validate & normalize this value.
     // > Note that we explicitly ALLOW values to be provided for plural associations by passing in `true`.
     try {
-      newRecord[supposedAttrName] = normalizeValueToSet(newRecord[supposedAttrName], supposedAttrName, modelIdentity, orm);
+      newRecord[supposedAttrName] = normalizeValueToSet(newRecord[supposedAttrName], supposedAttrName, modelIdentity, orm, meta);
     } catch (e) {
       switch (e.code) {
 

--- a/lib/waterline/utils/query/private/normalize-new-record.js
+++ b/lib/waterline/utils/query/private/normalize-new-record.js
@@ -362,6 +362,11 @@ module.exports = function normalizeNewRecord(newRecord, modelIdentity, orm, curr
       // > (In the mean time, this behavior should not be relied on in any new code.)
       newRecord[attrName] = _.cloneDeep(attrDef.defaultsTo);
 
+      // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      // FUTURE: maybe support encryption of the default value here.
+      // (See the related note in `waterline.js` for more information.)
+      // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
     }
     // Or use the timestamp, if this is `autoCreatedAt` or `autoUpdatedAt`
     // (the latter because we set autoUpdatedAt to the same thing as `autoCreatedAt`

--- a/lib/waterline/utils/query/private/normalize-new-record.js
+++ b/lib/waterline/utils/query/private/normalize-new-record.js
@@ -353,7 +353,7 @@ module.exports = function normalizeNewRecord(newRecord, modelIdentity, orm, curr
       newRecord[attrName] = [];
     }
     // Or apply the default if there is one.
-    else if (!_.isUndefined(attrDef.defaultsTo)) {
+    else if (attrDef.defaultsTo !== undefined) {
 
       // Deep clone the defaultsTo value.
       //

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -638,10 +638,6 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
       })
       .encryptAttribute(undefined, value);
 
-      // // TODO: do real encryption instead of this:  (and remove or expand the truthiness check, as necessary)
-      // if (value) {
-      //   value = WLModel.dataEncryptionKeys.default+' so encrypted:'+JSON.stringify(value);
-      // }
     } catch (err) {
       throw flaverr({
         message: 'Encryption failed for `'+supposedAttrName+'`\n'+

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -632,11 +632,15 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
 
     try {
       // Encrypt using the `default` key from the configured DEKs.
-      value = EA([supposedAttrName], {
-        keys: WLModel.dataEncryptionKeys,
-        keyId: 'default'
-      })
-      .encryptAttribute(undefined, value);
+      // value = EA([supposedAttrName], {
+      //   keys: WLModel.dataEncryptionKeys,
+      //   keyId: 'default'
+      // })
+      // .encryptAttribute(undefined, value);
+
+      // TODO: remove this hack
+      if (value.match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t encrypt something already encrypted!!!'); }
+      value = 'ENCRYPTED:'+value;
 
     } catch (err) {
       throw flaverr({

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -656,7 +656,10 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
         }
 
         // Encrypt using the appropriate key from the configured DEKs.
-        value = EA([], {
+
+        // console.log('•••••encrypting JSON-encoded value: `'+util.inspect(jsonEncoded, {depth:null})+'`');
+
+        value = EA([supposedAttrName], {
           keys: WLModel.dataEncryptionKeys,
           keyId: 'default'
         })
@@ -666,7 +669,6 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
         // Alternative: (hack for testing)
         // ```
         // if (value.match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t encrypt something already encrypted!!!'); }
-        // console.log('•••••encrypting JSON-encoded value: `'+util.inspect(jsonEncoded, {depth:null})+'`');
         // value = 'ENCRYPTED:'+jsonEncoded;
         // ```
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -49,6 +49,10 @@ var normalizePkValueOrValues = require('./normalize-pk-value-or-values');
  *        The Waterline ORM instance.
  *        > Useful for accessing the model definitions.
  *
+ * @param {Dictionary?} meta
+ *        The contents of the `meta` query key, if one was provided.
+ *        > Useful for propagating query options to low-level utilities like this one.
+ *
  * --
  *
  * @returns {Ref}
@@ -112,7 +116,7 @@ var normalizePkValueOrValues = require('./normalize-pk-value-or-values');
  *
  * @throws {Error} If anything else unexpected occurs.
  */
-module.exports = function normalizeValueToSet(value, supposedAttrName, modelIdentity, orm) {
+module.exports = function normalizeValueToSet(value, supposedAttrName, modelIdentity, orm, meta) {
 
   // ================================================================================================
   assert(_.isString(supposedAttrName), '`supposedAttrName` must be a string.');
@@ -621,13 +625,26 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
         'AND `encrypt: true`.'
       );
     }//•
-    if (!_.isObject(WLModel.dataEncryptionKeys) || !_.isString(WLModel.dataEncryptionKeys.default) || !WLModel.dataEncryptionKeys.default) {
+    if (!_.isObject(WLModel.dataEncryptionKeys) || !WLModel.dataEncryptionKeys.default || !_.isString(WLModel.dataEncryptionKeys.default)) {
       throw new Error(
         'Consistency violation: `'+modelIdentity+'` model has a corrupted definition.  Should not '+
         'have been allowed to declare an attribute with `encrypt: true` without also specifying '+
         'a the `dataEncryptionKeys` model setting as a valid dictionary (including a valid "default" '+
         'key).'
       );
+    }//•
+
+    // Figure out what DEK to encrypt with.
+    var idOfDekToEncryptWith;
+    if (meta && meta.encryptWith) {
+      idOfDekToEncryptWith = meta.encryptWith;
+    }
+    else {
+      idOfDekToEncryptWith = 'default';
+    }
+
+    if (!WLModel.dataEncryptionKeys[idOfDekToEncryptWith]) {
+      throw new Error('There is no known data encryption key by that name (`'+idOfDekToEncryptWith+'`).  Please make sure a valid DEK (data encryption key) is configured under `dataEncryptionKeys.'+idOfDekToEncryptWith+'`.');
     }//•
 
     try {
@@ -655,13 +672,14 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
           }, err);
         }
 
+
         // Encrypt using the appropriate key from the configured DEKs.
 
         // console.log('•••••encrypting JSON-encoded value: `'+util.inspect(jsonEncoded, {depth:null})+'`');
 
         value = EA([supposedAttrName], {
           keys: WLModel.dataEncryptionKeys,
-          keyId: 'default'
+          keyId: idOfDekToEncryptWith
         })
         .encryptAttribute(undefined, jsonEncoded);
 

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -19,7 +19,8 @@ var normalizePkValueOrValues = require('./normalize-pk-value-or-values');
  * normalizeValueToSet()
  *
  * Validate and normalize the provided `value`, hammering it destructively into a format
- * that is compatible with the specified attribute.
+ * that is compatible with the specified attribute.  (Also take care of encrypting the `value`,
+ * if configured to do so by the corresponding attribute definition.)
  *
  * This function has a return value.   But realize that this is only because the provided value
  * _might_ be a string, number, or some other primitive that is NOT passed by reference, and thus
@@ -593,7 +594,43 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
   }//</else (i.e. corresponding attr def is just a normal attr--not an association or primary key)>
 
 
-  // Return the normalized value.
+  //  ███████╗███╗   ██╗ ██████╗██████╗ ██╗   ██╗██████╗ ████████╗    ██████╗  █████╗ ████████╗ █████╗
+  //  ██╔════╝████╗  ██║██╔════╝██╔══██╗╚██╗ ██╔╝██╔══██╗╚══██╔══╝    ██╔══██╗██╔══██╗╚══██╔══╝██╔══██╗
+  //  █████╗  ██╔██╗ ██║██║     ██████╔╝ ╚████╔╝ ██████╔╝   ██║       ██║  ██║███████║   ██║   ███████║
+  //  ██╔══╝  ██║╚██╗██║██║     ██╔══██╗  ╚██╔╝  ██╔═══╝    ██║       ██║  ██║██╔══██║   ██║   ██╔══██║
+  //  ███████╗██║ ╚████║╚██████╗██║  ██║   ██║   ██║        ██║       ██████╔╝██║  ██║   ██║   ██║  ██║
+  //  ╚══════╝╚═╝  ╚═══╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   ╚═╝        ╚═╝       ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝
+  //  ╦╔═╗  ┬─┐┌─┐┬  ┌─┐┬  ┬┌─┐┌┐┌┌┬┐
+  //  ║╠╣   ├┬┘├┤ │  ├┤ └┐┌┘├─┤│││ │
+  //  ╩╚    ┴└─└─┘┴─┘└─┘ └┘ ┴ ┴┘└┘ ┴ooo
+
+  if (correspondingAttrDef && correspondingAttrDef.encrypt) {
+
+    if (correspondingAttrDef.encrypt !== true) {
+      throw new Error(
+        'Consistency violation: `'+modelIdentity+'` model\'s `'+supposedAttrName+'` attribute '+
+        'has a corrupted definition.  Should not have been allowed to set `encrypt` to anything '+
+        'other than `true` or `false`.'
+      );
+    }//•
+    if (correspondingAttrDef.type === 'ref') {
+      throw new Error(
+        'Consistency violation: `'+modelIdentity+'` model\'s `'+supposedAttrName+'` attribute '+
+        'has a corrupted definition.  Should not have been allowed to be both `type: \'ref\' '+
+        'AND `encrypt: true`.'
+      );
+    }//•
+
+    // Grab encryption key.
+    var encryptionKey = 'blah blah';// TODO
+
+    // TODO: do real encryption
+    value = encryptionKey+' so encrypted:'+JSON.stringify(value);
+
+  }//ﬁ
+
+
+  // Return the normalized (and potentially encrypted) value.
   return value;
 
 };

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -5,9 +5,10 @@
 var util = require('util');
 var assert = require('assert');
 var _ = require('@sailshq/lodash');
+var anchor = require('anchor');
 var flaverr = require('flaverr');
 var rttc = require('rttc');
-var anchor = require('anchor');
+var EA = require('encrypted-attr');
 var getModel = require('../../ontology/get-model');
 var getAttribute = require('../../ontology/get-attribute');
 var isValidAttributeName = require('./is-valid-attribute-name');
@@ -620,12 +621,35 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
         'AND `encrypt: true`.'
       );
     }//•
+    if (!_.isObject(WLModel.dataEncryptionKeys) || !_.isString(WLModel.dataEncryptionKeys.default) || !WLModel.dataEncryptionKeys.default) {
+      throw new Error(
+        'Consistency violation: `'+modelIdentity+'` model has a corrupted definition.  Should not '+
+        'have been allowed to declare an attribute with `encrypt: true` without also specifying '+
+        'a the `dataEncryptionKeys` model setting as a valid dictionary (including a valid "default" '+
+        'key).'
+      );
+    }//•
 
-    // Grab encryption key.
-    var encryptionKey = 'blah blah';// TODO
+    try {
+      // Encrypt using the `default` key from the configured DEKs.
+      value = EA([supposedAttrName], {
+        keys: WLModel.dataEncryptionKeys,
+        keyId: 'default'
+      })
+      .encryptAttribute(undefined, value);
 
-    // TODO: do real encryption
-    value = encryptionKey+' so encrypted:'+JSON.stringify(value);
+      // // TODO: do real encryption instead of this:  (and remove or expand the truthiness check, as necessary)
+      // if (value) {
+      //   value = WLModel.dataEncryptionKeys.default+' so encrypted:'+JSON.stringify(value);
+      // }
+    } catch (err) {
+      throw flaverr({
+        message: 'Encryption failed for `'+supposedAttrName+'`\n'+
+        'Details:\n'+
+        '  '+err.message
+      }, _.isError(err) ? err : new Error());
+    }
+
 
   }//ﬁ
 

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -631,20 +631,49 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
     }//•
 
     try {
-      // Encrypt using the `default` key from the configured DEKs.
-      // value = EA([supposedAttrName], {
-      //   keys: WLModel.dataEncryptionKeys,
-      //   keyId: 'default'
-      // })
-      // .encryptAttribute(undefined, value);
 
-      // TODO: remove this hack
-      if (value.match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t encrypt something already encrypted!!!'); }
-      console.log('•••••encrypting: `'+util.inspect(value, {depth:null})+'`');
-      value = 'ENCRYPTED:'+value;
+      // Never encrypt `''`(empty string), `0` (zero), `false`, or `null`, since these are possible
+      // base values.  (Note that the current code path only runs when a value is explicitly provided
+      // for the attribute-- not when it is omitted.  Thus these base values can get into the database
+      // without being encrypted _anyway_.)
+      if (value === '' || value === 0 || value === false || _.isNull(value)) {
+        // Don't encrypt.
+      }
+      else {
+        // First, JSON-encode value, to allow for differentiating between strings/numbers/booleans/null.
+        var jsonEncoded;
+        try {
+          jsonEncoded = JSON.stringify(value);
+        } catch (err) {
+          // Note: Stringification SHOULD always work, because we just checked all that out above.
+          // But just in case it doesn't, or if this code gets moved elsewhere in the future, here
+          // we include a reasonable error here as a backup.
+          throw flaverr({
+            message: 'Before encrypting, Waterline attempted to JSON-stringify this value to ensure it '+
+            'could be accurately decoded into the correct data type later (for example, `2` vs `\'2\'`).  '+
+            'But this time, JSON.stringify() failed with the following error:  '+err.message
+          }, err);
+        }
+
+        // Encrypt using the appropriate key from the configured DEKs.
+        value = EA([], {
+          keys: WLModel.dataEncryptionKeys,
+          keyId: 'default'
+        })
+        .encryptAttribute(undefined, jsonEncoded);
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        // Alternative: (hack for testing)
+        // ```
+        // if (value.match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t encrypt something already encrypted!!!'); }
+        // console.log('•••••encrypting JSON-encoded value: `'+util.inspect(jsonEncoded, {depth:null})+'`');
+        // value = 'ENCRYPTED:'+jsonEncoded;
+        // ```
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      }//ﬁ
 
     } catch (err) {
-      console.log('•••••was attempting to encrypt this value: `'+util.inspect(value, {depth:null})+'`');
+      // console.log('•••••was attempting to encrypt this value: `'+util.inspect(value, {depth:null})+'`');
       throw flaverr({
         message: 'Encryption failed for `'+supposedAttrName+'`\n'+
         'Details:\n'+

--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -640,9 +640,11 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
 
       // TODO: remove this hack
       if (value.match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t encrypt something already encrypted!!!'); }
+      console.log('•••••encrypting: `'+util.inspect(value, {depth:null})+'`');
       value = 'ENCRYPTED:'+value;
 
     } catch (err) {
+      console.log('•••••was attempting to encrypt this value: `'+util.inspect(value, {depth:null})+'`');
       throw flaverr({
         message: 'Encryption failed for `'+supposedAttrName+'`\n'+
         'Details:\n'+

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -554,6 +554,7 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
       _.each(WLModel.attributes, function (attrDef, attrName){
         try {
           if (attrDef.encrypt) {
+
             // // Decrypt using the appropriate key from the configured DEKs.
             // record[attrName] = EA([attrName], {
             //   keys: WLModel.dataEncryptionKeys
@@ -562,6 +563,7 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
 
             // TODO remove this hack
             if (!record[attrName].match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t decrypt something already decrypted!!!'); }
+            console.log('•••••decrypting: `'+util.inspect(record[attrName], {depth:null})+'`');
             record[attrName] = record[attrName].replace(/^ENCRYPTED:/, '');
 
           }//ﬁ

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -549,8 +549,8 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
     //  ╦╔═╗  ┬─┐┌─┐┬  ┌─┐┬  ┬┌─┐┌┐┌┌┬┐
     //  ║╠╣   ├┬┘├┤ │  ├┤ └┐┌┘├─┤│││ │
     //  ╩╚    ┴└─└─┘┴─┘└─┘ └┘ ┴ ┴┘└┘ ┴ooo
-    var skippingDecryption = meta && meta.skipRecordDecryption;
-    if (!skippingDecryption) {
+    var willDecrypt = meta && meta.decrypt;
+    if (willDecrypt) {
       _.each(WLModel.attributes, function (attrDef, attrName){
         try {
           if (attrDef.encrypt) {
@@ -611,6 +611,8 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
           // still log the warning, but instead of sending back the potentially-sensitive data,
           // log it as part of the warning and send back whatever the appropriate base value is
           // instead.
+          //
+          // Regardless, for now we use an actual error to be on the safe side.
           // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           throw flaverr({
             message: 'Decryption failed for `'+attrName+'` (in a `'+WLModel.identity+'` record).\n'+

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -560,10 +560,6 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
             })
             .decryptAttribute(undefined, record[attrName]);
 
-            // // TODO: do real decryption instead of this:   (and remove or expand the truthiness check, as necessary)
-            // if (record[attrName]) {
-            //   record[attrName] = JSON.parse(record[attrName].replace(new RegExp('^'+_.escapeRegExp(WLModel.dataEncryptionKeys.default)+' so encrypted:'), ''));
-            // }
           }//ﬁ
         } catch (err) {
           throw flaverr({

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -555,23 +555,69 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
         try {
           if (attrDef.encrypt) {
 
-            // // Decrypt using the appropriate key from the configured DEKs.
-            // record[attrName] = EA([attrName], {
-            //   keys: WLModel.dataEncryptionKeys
-            // })
-            // .decryptAttribute(undefined, record[attrName]);
+            // Never try to decrypt `''`(empty string), `0` (zero), `false`, or `null`, since these are
+            // possible base values, which might end up in the database.  (Note that if this is a required
+            // attribute, we could probably be more picky-- but it seems unlikely that encrypting these base
+            // values at rest will ever be a priority, since they don't contain any sensitive information.
+            // Arguably, there are edge cases where knowing _whether_ a particular field is at its base value
+            // could be deemed sensitive info, but building around that extreme edge case seems like a bad idea
+            // that probably isn't worth the extra headache and complexity in core.)
+            if (record[attrName] === '' || record[attrName] === 0 || record[attrName] === false || _.isNull(record[attrName])) {
+              // Don't try to decrypt these.
+            }
+            else {
 
-            // TODO remove this hack
-            if (!record[attrName].match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t decrypt something already decrypted!!!'); }
-            console.log('•••••decrypting: `'+util.inspect(record[attrName], {depth:null})+'`');
-            record[attrName] = record[attrName].replace(/^ENCRYPTED:/, '');
+              // Decrypt using the appropriate key from the configured DEKs.
+              var decryptedButStillJsonEncoded;
+
+              decryptedButStillJsonEncoded = EA([attrName], {
+                keys: WLModel.dataEncryptionKeys
+              })
+              .decryptAttribute(undefined, record[attrName]);
+              // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+              // Alternative: (hack for testing)
+              // ```
+              // if (!record[attrName].match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t decrypt something already decrypted!!!'); }
+              // console.log('•••••decrypting: `'+util.inspect(record[attrName], {depth:null})+'`');
+              // decryptedButStillJsonEncoded = record[attrName].replace(/^ENCRYPTED:/, '');
+              // ```
+              // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+              // Finally, JSON-decode the value, to allow for differentiating between strings/numbers/booleans/null.
+              try {
+                record[attrName] = JSON.parse(decryptedButStillJsonEncoded);
+              } catch (err) {
+                throw flaverr({
+                  message: 'After initially decrypting the raw data, Waterline attempted to JSON-parse the data '+
+                  'to ensure it was accurately decoded into the correct data type (for example, `2` vs `\'2\'`).  '+
+                  'But this time, JSON.parse() failed with the following error:  '+err.message
+                }, err);
+              }
+
+            }//ﬁ
 
           }//ﬁ
         } catch (err) {
-          console.log('•••••was attempting to decrypt this value: `'+util.inspect(record[attrName], {depth:null})+'`');
+          // console.log('•••••was attempting to decrypt this value: `'+util.inspect(record[attrName], {depth:null})+'`');
+
+          // Note: Decryption might not work, because there's no way of knowing what could have gotten into
+          // the database  (e.g. from other processes, apps, maybe not even Node.js, etc.)
+          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          // FUTURE: Instead of failing with an error, consider logging a warning and
+          // sending back the data as-is. (e.g. and attach MIGHT_BE_YOUR_FAULT suffix.)
+          // But remember: this is potentially sensitive data we're talking about, so being
+          // a little over-strict seems like the right idea.  Maybe the right answer is to
+          // still log the warning, but instead of sending back the potentially-sensitive data,
+          // log it as part of the warning and send back whatever the appropriate base value is
+          // instead.
+          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           throw flaverr({
-            message: 'Decryption failed for `'+attrName+'` (in a `'+WLModel.identity+'` record)\n'+
-            'Details:\n'+
+            message: 'Decryption failed for `'+attrName+'` (in a `'+WLModel.identity+'` record).\n'+
+            'The actual value in the record that could not be decrypted is:\n'+
+            '```\n'+
+            util.inspect(record[attrName],{depth:5})+'\n'+
+            '```\n'+
+            'Error details:\n'+
             '  '+err.message
           }, _.isError(err) ? err : new Error());
         }

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -44,20 +44,27 @@ var WARNING_SUFFIXES = {
 /**
  * processAllRecords()
  *
- * Verify the integrity of potentially-populated records coming back from the adapter, AFTER
- * they've already had their keys transformed from column names back to attribute names.  This
- * also takes care of verifying populated child records (they are only ever one-level deep).
- * Finally, note that is also takes care of attaching custom toJSON() functions, when relevant.
+ * Process potentially-populated records coming back from the adapter, AFTER they've already had
+ * their keys transformed from column names back to attribute names and had populated data reintegrated.
+ * To reiterate that: this function takes logical records, **NOT physical records**.
  *
- * > At the moment, this serves primarily as a way to check for stale, unmigrated data that
- * > might exist in the database, as well as any unexpected adapter compatibility problems.
- * > For the full specification and expected behavior, see:
- * > https://docs.google.com/spreadsheets/d/1whV739iW6O9SxRZLCIe2lpvuAUqm-ie7j7tn_Pjir3s/edit#gid=1927470769
+ * `processAllRecords()` has 3 responsibilities:
+ *
+ * (1) Verify the integrity of the provided records, and any populated child records
+ *     (Note: If present, child records only ever go 1 level deep in Waterline currently.)
+ *      > At the moment, this serves primarily as a way to check for stale, unmigrated data that
+ *      > might exist in the database, as well as any unexpected adapter compatibility problems.
+ *      > For the full specification and expected behavior, see:
+ *      > https://docs.google.com/spreadsheets/d/1whV739iW6O9SxRZLCIe2lpvuAUqm-ie7j7tn_Pjir3s/edit#gid=1927470769
+ *
+ * (2) Attach custom toJSON() functions to records, if the model says to do so.
+ *
+ * (3) Decrypt any data that was encrypted at rest.
  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  *
  * @param  {Array} records
- *         An array of records.
+ *         An array of records.  (These are logical records -- NOT physical records!!)
  *         (WARNING: This array and its deeply-nested contents might be mutated in-place!!!)
  *
  * @param {Ref?} meta

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -570,6 +570,8 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
               // Decrypt using the appropriate key from the configured DEKs.
               var decryptedButStillJsonEncoded;
 
+              // console.log('•••••decrypting: `'+util.inspect(record[attrName], {depth:null})+'`');
+
               decryptedButStillJsonEncoded = EA([attrName], {
                 keys: WLModel.dataEncryptionKeys
               })
@@ -578,7 +580,6 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
               // Alternative: (hack for testing)
               // ```
               // if (!record[attrName].match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t decrypt something already decrypted!!!'); }
-              // console.log('•••••decrypting: `'+util.inspect(record[attrName], {depth:null})+'`');
               // decryptedButStillJsonEncoded = record[attrName].replace(/^ENCRYPTED:/, '');
               // ```
               // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -5,10 +5,10 @@
 var assert = require('assert');
 var util = require('util');
 var _ = require('@sailshq/lodash');
+var EA = require('encrypted-attr');
 var flaverr = require('flaverr');
 var rttc = require('rttc');
 var eachRecordDeep = require('waterline-utils').eachRecordDeep;
-
 
 /**
  * Module constants
@@ -554,13 +554,16 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
       _.each(WLModel.attributes, function (attrDef, attrName){
         try {
           if (attrDef.encrypt) {
-            // Grab encryption key.
-            var encryptionKey = 'blah blah';// TODO
+            // Decrypt using the appropriate key from the configured DEKs.
+            record[attrName] = EA([attrName], {
+              keys: WLModel.dataEncryptionKeys
+            })
+            .decryptAttribute(undefined, record[attrName]);
 
-            // TODO: do real decryption
-            if (record[attrName]) {
-              record[attrName] = JSON.parse(record[attrName].replace(new RegExp('^'+_.escapeRegExp(encryptionKey)+' so encrypted:'), ''));
-            }
+            // // TODO: do real decryption instead of this:   (and remove or expand the truthiness check, as necessary)
+            // if (record[attrName]) {
+            //   record[attrName] = JSON.parse(record[attrName].replace(new RegExp('^'+_.escapeRegExp(WLModel.dataEncryptionKeys.default)+' so encrypted:'), ''));
+            // }
           }//ﬁ
         } catch (err) {
           throw flaverr({

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -5,6 +5,7 @@
 var assert = require('assert');
 var util = require('util');
 var _ = require('@sailshq/lodash');
+var flaverr = require('flaverr');
 var rttc = require('rttc');
 var eachRecordDeep = require('waterline-utils').eachRecordDeep;
 
@@ -106,7 +107,10 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
   // appear to be populated child records.
   eachRecordDeep(records, function _eachParentOrChildRecord(record, WLModel){
 
-    // Verify records
+    // First, check the results to verify compliance with the adapter spec.,
+    // as well as any issues related to stale data that might not have been
+    // been migrated to keep up with the logical schema (`type`, etc. in
+    // attribute definitions).
     if (!skippingRecordVerification) {
 
 
@@ -545,16 +549,28 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
     //  ╦╔═╗  ┬─┐┌─┐┬  ┌─┐┬  ┬┌─┐┌┐┌┌┬┐
     //  ║╠╣   ├┬┘├┤ │  ├┤ └┐┌┘├─┤│││ │
     //  ╩╚    ┴└─└─┘┴─┘└─┘ └┘ ┴ ┴┘└┘ ┴ooo
+    var skippingDecryption = meta && meta.skipDecryption;
+    if (!skippingDecryption) {
+      _.each(WLModel.attributes, function (attrDef, attrName){
+        try {
+          if (attrDef.encrypt) {
+            // Grab encryption key.
+            var encryptionKey = 'blah blah';// TODO
 
-    _.each(WLModel.attributes, function (attrDef, attrName){
-      if (attrDef.encrypt) {
-        // Grab encryption key.
-        var encryptionKey = 'blah blah';// TODO
-
-        // TODO: do real decryption
-        record[attrName] = JSON.parse(record[attrName].replace(new RegExp('^'+_.escapeRegExp(encryptionKey)+' so encrypted:'), ''));
-      }//ﬁ
-    });//∞
+            // TODO: do real decryption
+            if (record[attrName]) {
+              record[attrName] = JSON.parse(record[attrName].replace(new RegExp('^'+_.escapeRegExp(encryptionKey)+' so encrypted:'), ''));
+            }
+          }//ﬁ
+        } catch (err) {
+          throw flaverr({
+            message: 'Decryption failed for `'+attrName+'` (in a `'+WLModel.identity+'` record)\n'+
+            'Details:\n'+
+            '  '+err.message
+          }, _.isError(err) ? err : new Error());
+        }
+      });//∞
+    }//ﬁ
 
 
 

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -535,6 +535,29 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
       });
     }//>-
 
+
+    //  ██████╗ ███████╗ ██████╗██████╗ ██╗   ██╗██████╗ ████████╗    ██████╗  █████╗ ████████╗ █████╗
+    //  ██╔══██╗██╔════╝██╔════╝██╔══██╗╚██╗ ██╔╝██╔══██╗╚══██╔══╝    ██╔══██╗██╔══██╗╚══██╔══╝██╔══██╗
+    //  ██║  ██║█████╗  ██║     ██████╔╝ ╚████╔╝ ██████╔╝   ██║       ██║  ██║███████║   ██║   ███████║
+    //  ██║  ██║██╔══╝  ██║     ██╔══██╗  ╚██╔╝  ██╔═══╝    ██║       ██║  ██║██╔══██║   ██║   ██╔══██║
+    //  ██████╔╝███████╗╚██████╗██║  ██║   ██║   ██║        ██║       ██████╔╝██║  ██║   ██║   ██║  ██║
+    //  ╚═════╝ ╚══════╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   ╚═╝        ╚═╝       ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝
+    //  ╦╔═╗  ┬─┐┌─┐┬  ┌─┐┬  ┬┌─┐┌┐┌┌┬┐
+    //  ║╠╣   ├┬┘├┤ │  ├┤ └┐┌┘├─┤│││ │
+    //  ╩╚    ┴└─└─┘┴─┘└─┘ └┘ ┴ ┴┘└┘ ┴ooo
+
+    _.each(WLModel.attributes, function (attrDef, attrName){
+      if (attrDef.encrypt) {
+        // Grab encryption key.
+        var encryptionKey = 'blah blah';// TODO
+
+        // TODO: do real decryption
+        record[attrName] = JSON.parse(record[attrName].replace(new RegExp('^'+_.escapeRegExp(encryptionKey)+' so encrypted:'), ''));
+      }//ﬁ
+    });//∞
+
+
+
   }, false, modelIdentity, orm);//</eachRecordDeep>
 
 

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -97,416 +97,413 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
   }
 
 
-
-
-  // Check if the `skipRecordVerification` meta key is truthy.
-  if (meta && meta.skipRecordVerification) {
-
-    // If so, then just return early-- we'll skip all this stuff.
-    return;
-
-  }//-•
-
+  // Determine whether to skip record verification below.
+  // (we always do it unless the `skipRecordVerification` meta key is explicitly truthy,)
+  var skippingRecordVerification = meta && meta.skipRecordVerification;
 
 
   // Iterate over each parent record and any nested arrays/dictionaries that
   // appear to be populated child records.
   eachRecordDeep(records, function _eachParentOrChildRecord(record, WLModel){
 
+    // Verify records
+    if (!skippingRecordVerification) {
 
 
-    //  ███╗   ██╗ ██████╗ ███╗   ██╗       █████╗ ████████╗████████╗██████╗ ██╗██████╗ ██╗   ██╗████████╗███████╗
-    //  ████╗  ██║██╔═══██╗████╗  ██║      ██╔══██╗╚══██╔══╝╚══██╔══╝██╔══██╗██║██╔══██╗██║   ██║╚══██╔══╝██╔════╝
-    //  ██╔██╗ ██║██║   ██║██╔██╗ ██║█████╗███████║   ██║      ██║   ██████╔╝██║██████╔╝██║   ██║   ██║   █████╗
-    //  ██║╚██╗██║██║   ██║██║╚██╗██║╚════╝██╔══██║   ██║      ██║   ██╔══██╗██║██╔══██╗██║   ██║   ██║   ██╔══╝
-    //  ██║ ╚████║╚██████╔╝██║ ╚████║      ██║  ██║   ██║      ██║   ██║  ██║██║██████╔╝╚██████╔╝   ██║   ███████╗
-    //  ╚═╝  ╚═══╝ ╚═════╝ ╚═╝  ╚═══╝      ╚═╝  ╚═╝   ╚═╝      ╚═╝   ╚═╝  ╚═╝╚═╝╚═════╝  ╚═════╝    ╚═╝   ╚══════╝
-    //
-    //  ██╗  ██╗███████╗██╗   ██╗███████╗
-    //  ██║ ██╔╝██╔════╝╚██╗ ██╔╝██╔════╝
-    //  █████╔╝ █████╗   ╚████╔╝ ███████╗
-    //  ██╔═██╗ ██╔══╝    ╚██╔╝  ╚════██║
-    //  ██║  ██╗███████╗   ██║   ███████║
-    //  ╚═╝  ╚═╝╚══════╝   ╚═╝   ╚══════╝
-    //
-    // If this model is defined as `schema: true`, then check the returned record
-    // for any extraneous keys which do not correspond with declared attributes.
-    // If any are found, then log a warning.
-    if (WLModel.hasSchema) {
+      //  ███╗   ██╗ ██████╗ ███╗   ██╗       █████╗ ████████╗████████╗██████╗ ██╗██████╗ ██╗   ██╗████████╗███████╗
+      //  ████╗  ██║██╔═══██╗████╗  ██║      ██╔══██╗╚══██╔══╝╚══██╔══╝██╔══██╗██║██╔══██╗██║   ██║╚══██╔══╝██╔════╝
+      //  ██╔██╗ ██║██║   ██║██╔██╗ ██║█████╗███████║   ██║      ██║   ██████╔╝██║██████╔╝██║   ██║   ██║   █████╗
+      //  ██║╚██╗██║██║   ██║██║╚██╗██║╚════╝██╔══██║   ██║      ██║   ██╔══██╗██║██╔══██╗██║   ██║   ██║   ██╔══╝
+      //  ██║ ╚████║╚██████╔╝██║ ╚████║      ██║  ██║   ██║      ██║   ██║  ██║██║██████╔╝╚██████╔╝   ██║   ███████╗
+      //  ╚═╝  ╚═══╝ ╚═════╝ ╚═╝  ╚═══╝      ╚═╝  ╚═╝   ╚═╝      ╚═╝   ╚═╝  ╚═╝╚═╝╚═════╝  ╚═════╝    ╚═╝   ╚══════╝
+      //
+      //  ██╗  ██╗███████╗██╗   ██╗███████╗
+      //  ██║ ██╔╝██╔════╝╚██╗ ██╔╝██╔════╝
+      //  █████╔╝ █████╗   ╚████╔╝ ███████╗
+      //  ██╔═██╗ ██╔══╝    ╚██╔╝  ╚════██║
+      //  ██║  ██╗███████╗   ██║   ███████║
+      //  ╚═╝  ╚═╝╚══════╝   ╚═╝   ╚══════╝
+      //
+      // If this model is defined as `schema: true`, then check the returned record
+      // for any extraneous keys which do not correspond with declared attributes.
+      // If any are found, then log a warning.
+      if (WLModel.hasSchema) {
 
-      var nonAttrKeys = _.difference(_.keys(record), _.keys(WLModel.attributes));
-      if (nonAttrKeys > 0) {
+        var nonAttrKeys = _.difference(_.keys(record), _.keys(WLModel.attributes));
+        if (nonAttrKeys > 0) {
 
-        // Since this is `schema: true`, the adapter method should have
-        // received an explicit `select` clause in the S3Q `criteria`
-        // query key, and thus it should not have sent back any unrecognized
-        // attributes (or in cases where there is no `criteria` query key, e.g.
-        // a create(), the adapter should never send back extraneous properties
-        // anyways, because Waterline core should have stripped any such extra
-        // properties off on the way _in_ to the adapter).
-        //
-        // So if we made it here, we can safely assume that this is due
-        // to an issue in the _adapter_ -- not some problem with unmigrated
-        // data.
-        console.warn('\n'+
-          'Warning: A record in this result set has extraneous properties ('+nonAttrKeys+')\n'+
-          'that, after adjusting for any custom columnNames, still do not correspond\n'+
-          'any recognized attributes of this model (`'+WLModel.identity+'`).\n'+
-          'Since this model is defined as `schema: true`, this behavior is unexpected.\n'+
-          // ====================================================================================
-          // Removed this for the sake of brevity-- could bring it back if deemed helpful.
-          // ====================================================================================
-          // 'This problem could be the result of an adapter method not properly observing\n'+
-          // 'the `select` clause it receives in the incoming criteria (or otherwise sending\n'+
-          // 'extra, unexpected properties on records that were left over from old data).\n'+
-          // ====================================================================================
-          WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
-        );
+          // Since this is `schema: true`, the adapter method should have
+          // received an explicit `select` clause in the S3Q `criteria`
+          // query key, and thus it should not have sent back any unrecognized
+          // attributes (or in cases where there is no `criteria` query key, e.g.
+          // a create(), the adapter should never send back extraneous properties
+          // anyways, because Waterline core should have stripped any such extra
+          // properties off on the way _in_ to the adapter).
+          //
+          // So if we made it here, we can safely assume that this is due
+          // to an issue in the _adapter_ -- not some problem with unmigrated
+          // data.
+          console.warn('\n'+
+            'Warning: A record in this result set has extraneous properties ('+nonAttrKeys+')\n'+
+            'that, after adjusting for any custom columnNames, still do not correspond\n'+
+            'any recognized attributes of this model (`'+WLModel.identity+'`).\n'+
+            'Since this model is defined as `schema: true`, this behavior is unexpected.\n'+
+            // ====================================================================================
+            // Removed this for the sake of brevity-- could bring it back if deemed helpful.
+            // ====================================================================================
+            // 'This problem could be the result of an adapter method not properly observing\n'+
+            // 'the `select` clause it receives in the incoming criteria (or otherwise sending\n'+
+            // 'extra, unexpected properties on records that were left over from old data).\n'+
+            // ====================================================================================
+            WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+          );
+
+        }//</if>
 
       }//</if>
 
-    }//</if>
 
 
-
-    //  ██╗  ██╗███████╗██╗   ██╗███████╗    ██╗    ██╗    ██╗    ██████╗ ██╗  ██╗███████╗
-    //  ██║ ██╔╝██╔════╝╚██╗ ██╔╝██╔════╝    ██║    ██║   ██╔╝    ██╔══██╗██║  ██║██╔════╝
-    //  █████╔╝ █████╗   ╚████╔╝ ███████╗    ██║ █╗ ██║  ██╔╝     ██████╔╝███████║███████╗
-    //  ██╔═██╗ ██╔══╝    ╚██╔╝  ╚════██║    ██║███╗██║ ██╔╝      ██╔══██╗██╔══██║╚════██║
-    //  ██║  ██╗███████╗   ██║   ███████║    ╚███╔███╔╝██╔╝       ██║  ██║██║  ██║███████║
-    //  ╚═╝  ╚═╝╚══════╝   ╚═╝   ╚══════╝     ╚══╝╚══╝ ╚═╝        ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
-    //
-    //   ██████╗ ███████╗    ██╗   ██╗███╗   ██╗██████╗ ███████╗███████╗██╗███╗   ██╗███████╗██████╗
-    //  ██╔═══██╗██╔════╝    ██║   ██║████╗  ██║██╔══██╗██╔════╝██╔════╝██║████╗  ██║██╔════╝██╔══██╗
-    //  ██║   ██║█████╗      ██║   ██║██╔██╗ ██║██║  ██║█████╗  █████╗  ██║██╔██╗ ██║█████╗  ██║  ██║
-    //  ██║   ██║██╔══╝      ██║   ██║██║╚██╗██║██║  ██║██╔══╝  ██╔══╝  ██║██║╚██╗██║██╔══╝  ██║  ██║
-    //  ╚██████╔╝██║         ╚██████╔╝██║ ╚████║██████╔╝███████╗██║     ██║██║ ╚████║███████╗██████╔╝
-    //   ╚═════╝ ╚═╝          ╚═════╝ ╚═╝  ╚═══╝╚═════╝ ╚══════╝╚═╝     ╚═╝╚═╝  ╚═══╝╚══════╝╚═════╝
-    //
-    // Loop over the properties of the record.
-    _.each(_.keys(record), function (key){
-
-      // Ensure that the value was not explicitly sent back as `undefined`.
-      // (but if it was, log a warning.  Note that we don't strip it out like
-      // we would normally, because we're careful not to munge data in this utility.)
-      if(_.isUndefined(record[key])){
-        console.warn('\n'+
-          'Warning: A database adapter should never send back records that have `undefined`\n'+
-          'on the RHS of any property (e.g. `foo: undefined`).  But after transforming\n'+
-          'columnNames back to attribute names for the model `' + modelIdentity + '`, one\n'+
-          'of the records sent back from this adapter has a property (`'+key+'`) with\n'+
-          '`undefined` on the right-hand side.\n' +
-          WARNING_SUFFIXES.HARD_TO_SEE_HOW_THIS_COULD_BE_YOUR_FAULT
-        );
-      }//>-
-
-    });
-
-
-
-    // Now, loop over each attribute in the model.
-    _.each(WLModel.attributes, function (attrDef, attrName){
-
-
-      //  ██████╗ ██████╗ ██╗███╗   ███╗ █████╗ ██████╗ ██╗   ██╗    ██╗  ██╗███████╗██╗   ██╗
-      //  ██╔══██╗██╔══██╗██║████╗ ████║██╔══██╗██╔══██╗╚██╗ ██╔╝    ██║ ██╔╝██╔════╝╚██╗ ██╔╝
-      //  ██████╔╝██████╔╝██║██╔████╔██║███████║██████╔╝ ╚████╔╝     █████╔╝ █████╗   ╚████╔╝
-      //  ██╔═══╝ ██╔══██╗██║██║╚██╔╝██║██╔══██║██╔══██╗  ╚██╔╝      ██╔═██╗ ██╔══╝    ╚██╔╝
-      //  ██║     ██║  ██║██║██║ ╚═╝ ██║██║  ██║██║  ██║   ██║       ██║  ██╗███████╗   ██║
-      //  ╚═╝     ╚═╝  ╚═╝╚═╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝       ╚═╝  ╚═╝╚══════╝   ╚═╝
+      //  ██╗  ██╗███████╗██╗   ██╗███████╗    ██╗    ██╗    ██╗    ██████╗ ██╗  ██╗███████╗
+      //  ██║ ██╔╝██╔════╝╚██╗ ██╔╝██╔════╝    ██║    ██║   ██╔╝    ██╔══██╗██║  ██║██╔════╝
+      //  █████╔╝ █████╗   ╚████╔╝ ███████╗    ██║ █╗ ██║  ██╔╝     ██████╔╝███████║███████╗
+      //  ██╔═██╗ ██╔══╝    ╚██╔╝  ╚════██║    ██║███╗██║ ██╔╝      ██╔══██╗██╔══██║╚════██║
+      //  ██║  ██╗███████╗   ██║   ███████║    ╚███╔███╔╝██╔╝       ██║  ██║██║  ██║███████║
+      //  ╚═╝  ╚═╝╚══════╝   ╚═╝   ╚══════╝     ╚══╝╚══╝ ╚═╝        ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
       //
-      if (attrName === WLModel.primaryKey) {
+      //   ██████╗ ███████╗    ██╗   ██╗███╗   ██╗██████╗ ███████╗███████╗██╗███╗   ██╗███████╗██████╗
+      //  ██╔═══██╗██╔════╝    ██║   ██║████╗  ██║██╔══██╗██╔════╝██╔════╝██║████╗  ██║██╔════╝██╔══██╗
+      //  ██║   ██║█████╗      ██║   ██║██╔██╗ ██║██║  ██║█████╗  █████╗  ██║██╔██╗ ██║█████╗  ██║  ██║
+      //  ██║   ██║██╔══╝      ██║   ██║██║╚██╗██║██║  ██║██╔══╝  ██╔══╝  ██║██║╚██╗██║██╔══╝  ██║  ██║
+      //  ╚██████╔╝██║         ╚██████╔╝██║ ╚████║██████╔╝███████╗██║     ██║██║ ╚████║███████╗██████╔╝
+      //   ╚═════╝ ╚═╝          ╚═════╝ ╚═╝  ╚═══╝╚═════╝ ╚══════╝╚═╝     ╚═╝╚═╝  ╚═══╝╚══════╝╚═════╝
+      //
+      // Loop over the properties of the record.
+      _.each(_.keys(record), function (key){
 
-        assert(!attrDef.allowNull, 'The primary key attribute should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
-
-        // Do quick, incomplete verification that a valid primary key value was sent back.
-        var isProbablyValidPkValue = (
-          record[attrName] !== '' &&
-          record[attrName] !== 0 &&
-          (
-            _.isString(record[attrName]) || _.isNumber(record[attrName])
-          )
-        );
-
-        if (!isProbablyValidPkValue) {
+        // Ensure that the value was not explicitly sent back as `undefined`.
+        // (but if it was, log a warning.  Note that we don't strip it out like
+        // we would normally, because we're careful not to munge data in this utility.)
+        if(_.isUndefined(record[key])){
           console.warn('\n'+
-            'Warning: Records sent back from a database adapter should always have a valid property\n'+
-            'that corresponds with the primary key attribute (`'+WLModel.primaryKey+'`).  But in this result set,\n'+
-            'after transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
-            'there is a record with a missing or invalid `'+WLModel.primaryKey+'`.\n'+
-            'Record:\n'+
-            '```\n'+
-            util.inspect(record, {depth:5})+'\n'+
-            '```\n'+
-            WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+            'Warning: A database adapter should never send back records that have `undefined`\n'+
+            'on the RHS of any property (e.g. `foo: undefined`).  But after transforming\n'+
+            'columnNames back to attribute names for the model `' + modelIdentity + '`, one\n'+
+            'of the records sent back from this adapter has a property (`'+key+'`) with\n'+
+            '`undefined` on the right-hand side.\n' +
+            WARNING_SUFFIXES.HARD_TO_SEE_HOW_THIS_COULD_BE_YOUR_FAULT
           );
-        }
+        }//>-
 
-      }
-      //  ███████╗██╗███╗   ██╗ ██████╗ ██╗   ██╗██╗      █████╗ ██████╗
-      //  ██╔════╝██║████╗  ██║██╔════╝ ██║   ██║██║     ██╔══██╗██╔══██╗
-      //  ███████╗██║██╔██╗ ██║██║  ███╗██║   ██║██║     ███████║██████╔╝
-      //  ╚════██║██║██║╚██╗██║██║   ██║██║   ██║██║     ██╔══██║██╔══██╗
-      //  ███████║██║██║ ╚████║╚██████╔╝╚██████╔╝███████╗██║  ██║██║  ██║
-      //  ╚══════╝╚═╝╚═╝  ╚═══╝ ╚═════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝
-      //
-      else if (attrDef.model) {
+      });
 
-        assert(!attrDef.allowNull, 'Singular ("model") association attributes should never be defined with `allowNull:true` (they always allow null, by nature!).  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
 
-        // If record does not define a value for a singular association, that's ok.
-        // It may have been deliberately excluded by the `select` or `omit` clause.
-        if (_.isUndefined(record[attrName])) {
-        }
-        // If the value for this singular association came back as `null`, then that
-        // might be ok too-- it could mean that the association is empty.
-        // (Note that it might also mean that it is set, and that population was attempted,
-        // but that it failed; presumably because the associated child record no longer exists)
-        else if (_.isNull(record[attrName])) {
-        }
-        // If the value came back as something that looks vaguely like a valid primary key value,
-        // then that's probably ok--  it could mean that the association was set, but not populated.
-        else if ((_.isString(record[attrName]) || _.isNumber(record[attrName])) && record[attrName] !== '' && record[attrName] !== 0 && !_.isNaN(record[attrName])) {
-        }
-        // If the value came back as a dictionary, then that might be ok-- it could mean
-        // the association was successfully populated.
-        else if (_.isObject(record[attrName]) && !_.isArray(record[attrName]) && !_.isFunction(record[attrName])) {
-          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-          // FUTURE: we could check this more carefully in the future by providing more
-          // information to this utility-- specifically, the `populates` key from the S2Q.
-          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        }
-        // Otherwise, the value is invalid.
-        else {
-          console.warn('\n'+
-            'An association in a result record has an unexpected data type.  Since `'+attrName+'` is\n'+
-            'a singular (association), it should come back from Waterline as either:\n'+
-            '• `null` (if not populated and set to null explicitly, or populated but orphaned)\n'+
-            '• a dictionary (if successfully populated), or\n'+
-            '• a valid primary key value for the associated model (if set + not populated)\n'+
-            'But for this record, after converting column names back into attribute names, it\n'+
-            'wasn\'t any of those things.\n'+
-            'Record:\n'+
-            '```\n'+
-            util.inspect(record, {depth:5})+'\n'+
-            '```\n'+
-            WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
-          );
-        }
 
-      }
-      //  ██████╗ ██╗     ██╗   ██╗██████╗  █████╗ ██╗
-      //  ██╔══██╗██║     ██║   ██║██╔══██╗██╔══██╗██║
-      //  ██████╔╝██║     ██║   ██║██████╔╝███████║██║
-      //  ██╔═══╝ ██║     ██║   ██║██╔══██╗██╔══██║██║
-      //  ██║     ███████╗╚██████╔╝██║  ██║██║  ██║███████╗
-      //  ╚═╝     ╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
-      //
-      else if (attrDef.collection) {
-        assert(!attrDef.allowNull, 'Plural ("collection") association attributes should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
+      // Now, loop over each attribute in the model.
+      _.each(WLModel.attributes, function (attrDef, attrName){
 
-        // If record does not define a value for a plural association, that's ok.
-        // That probably just means it was not populated.
-        if (_.isUndefined(record[attrName])) {
-        }
-        // If the value for this singular association came back as an array, then
-        // that might be ok too-- it probably means that the association was populated.
-        else if (_.isArray(record[attrName])) {
-          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-          // FUTURE: we could check that it is an array of valid child records,
-          // instead of just verifying that it is an array of _some kind_.
-          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        }
-        // Otherwise, the value is invalid.
-        else {
-          console.warn('\n'+
-            'An association in a result record has an unexpected data type.  Since `'+attrName+'` is\n'+
-            'a plural (association), it should come back from Waterline as either:\n'+
-            '• `undefined` (if not populated), or\n'+
-            '• an array of child records (if populated)\n'+
-            'But for this record, it wasn\'t any of those things.\n'+
-            // Note that this could mean there was something else already there
-            // (imagine changing your model to use a plural association instead
-            // of an embedded array from a `type: 'json'` attribute)
-            'Record:\n'+
-            '```\n'+
-            util.inspect(record, {depth:5})+'\n'+
-            '```\n'+
-            WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
-          );
-        }
 
-      }
-      //  ███████╗████████╗ █████╗ ███╗   ███╗██████╗ ███████╗
-      //  ██╔════╝╚══██╔══╝██╔══██╗████╗ ████║██╔══██╗██╔════╝
-      //  ███████╗   ██║   ███████║██╔████╔██║██████╔╝███████╗
-      //  ╚════██║   ██║   ██╔══██║██║╚██╔╝██║██╔═══╝ ╚════██║
-      //  ███████║   ██║   ██║  ██║██║ ╚═╝ ██║██║     ███████║
-      //  ╚══════╝   ╚═╝   ╚═╝  ╚═╝╚═╝     ╚═╝╚═╝     ╚══════╝
-      //
-      else if (attrDef.autoCreatedAt || attrDef.autoUpdatedAt) {
+        //  ██████╗ ██████╗ ██╗███╗   ███╗ █████╗ ██████╗ ██╗   ██╗    ██╗  ██╗███████╗██╗   ██╗
+        //  ██╔══██╗██╔══██╗██║████╗ ████║██╔══██╗██╔══██╗╚██╗ ██╔╝    ██║ ██╔╝██╔════╝╚██╗ ██╔╝
+        //  ██████╔╝██████╔╝██║██╔████╔██║███████║██████╔╝ ╚████╔╝     █████╔╝ █████╗   ╚████╔╝
+        //  ██╔═══╝ ██╔══██╗██║██║╚██╔╝██║██╔══██║██╔══██╗  ╚██╔╝      ██╔═██╗ ██╔══╝    ╚██╔╝
+        //  ██║     ██║  ██║██║██║ ╚═╝ ██║██║  ██║██║  ██║   ██║       ██║  ██╗███████╗   ██║
+        //  ╚═╝     ╚═╝  ╚═╝╚═╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝       ╚═╝  ╚═╝╚══════╝   ╚═╝
+        //
+        if (attrName === WLModel.primaryKey) {
 
-        assert(!attrDef.allowNull, 'Timestamp attributes should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
+          assert(!attrDef.allowNull, 'The primary key attribute should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
 
-        // If there is no value defined on the record for this attribute...
-        if (_.isUndefined(record[attrName])) {
-
-          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-          // FUTURE: Log a warning (but note that, to really get this right, we'd need access to
-          // a clone of the `omit` and `select` clauses from the s2q criteria, plus the `populates`
-          // query key from the s2q criteria -- probably also a clone of that)
-          // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-        }
-        // Otherwise, we know there's SOMETHING there at least.
-        else {
-
-          // Do quick, very incomplete verification that a valid timestamp was sent back.
-          var isProbablyValidTimestamp = (
+          // Do quick, incomplete verification that a valid primary key value was sent back.
+          var isProbablyValidPkValue = (
             record[attrName] !== '' &&
             record[attrName] !== 0 &&
             (
-              _.isString(record[attrName]) || _.isNumber(record[attrName]) || _.isDate(record[attrName])
+              _.isString(record[attrName]) || _.isNumber(record[attrName])
             )
           );
 
-          if (!isProbablyValidTimestamp) {
+          if (!isProbablyValidPkValue) {
             console.warn('\n'+
-              'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
-              ' a record in the result has a value with an unexpected data type for property `'+attrName+'`.\n'+
-              'The model\'s `'+attrName+'` attribute declares itself an auto timestamp with\n'+
-              '`type: \''+attrDef.type+'\'`, but instead of a valid timestamp, the actual value\n'+
-              'in the record is:\n'+
+              'Warning: Records sent back from a database adapter should always have a valid property\n'+
+              'that corresponds with the primary key attribute (`'+WLModel.primaryKey+'`).  But in this result set,\n'+
+              'after transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
+              'there is a record with a missing or invalid `'+WLModel.primaryKey+'`.\n'+
+              'Record:\n'+
               '```\n'+
-              util.inspect(record[attrName],{depth:5})+'\n'+
+              util.inspect(record, {depth:5})+'\n'+
               '```\n'+
               WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
             );
           }
 
-        }//</else>
+        }
+        //  ███████╗██╗███╗   ██╗ ██████╗ ██╗   ██╗██╗      █████╗ ██████╗
+        //  ██╔════╝██║████╗  ██║██╔════╝ ██║   ██║██║     ██╔══██╗██╔══██╗
+        //  ███████╗██║██╔██╗ ██║██║  ███╗██║   ██║██║     ███████║██████╔╝
+        //  ╚════██║██║██║╚██╗██║██║   ██║██║   ██║██║     ██╔══██║██╔══██╗
+        //  ███████║██║██║ ╚████║╚██████╔╝╚██████╔╝███████╗██║  ██║██║  ██║
+        //  ╚══════╝╚═╝╚═╝  ╚═══╝ ╚═════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝
+        //
+        else if (attrDef.model) {
 
-      }
-      //  ███╗   ███╗██╗███████╗ ██████╗        ██╗████████╗██╗   ██╗██████╗ ███████╗██╗
-      //  ████╗ ████║██║██╔════╝██╔════╝       ██╔╝╚══██╔══╝╚██╗ ██╔╝██╔══██╗██╔════╝╚██╗
-      //  ██╔████╔██║██║███████╗██║            ██║    ██║    ╚████╔╝ ██████╔╝█████╗   ██║
-      //  ██║╚██╔╝██║██║╚════██║██║            ██║    ██║     ╚██╔╝  ██╔═══╝ ██╔══╝   ██║
-      //  ██║ ╚═╝ ██║██║███████║╚██████╗██╗    ╚██╗   ██║      ██║   ██║     ███████╗██╔╝
-      //  ╚═╝     ╚═╝╚═╝╚══════╝ ╚═════╝╚═╝     ╚═╝   ╚═╝      ╚═╝   ╚═╝     ╚══════╝╚═╝
-      //
-      else {
+          assert(!attrDef.allowNull, 'Singular ("model") association attributes should never be defined with `allowNull:true` (they always allow null, by nature!).  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
 
-        // Sanity check:
-        if (attrDef.type === 'json' || attrDef.type === 'ref') {
-          assert(!attrDef.allowNull, '`type:\'json\'` and `type:\'ref\'` attributes should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
+          // If record does not define a value for a singular association, that's ok.
+          // It may have been deliberately excluded by the `select` or `omit` clause.
+          if (_.isUndefined(record[attrName])) {
+          }
+          // If the value for this singular association came back as `null`, then that
+          // might be ok too-- it could mean that the association is empty.
+          // (Note that it might also mean that it is set, and that population was attempted,
+          // but that it failed; presumably because the associated child record no longer exists)
+          else if (_.isNull(record[attrName])) {
+          }
+          // If the value came back as something that looks vaguely like a valid primary key value,
+          // then that's probably ok--  it could mean that the association was set, but not populated.
+          else if ((_.isString(record[attrName]) || _.isNumber(record[attrName])) && record[attrName] !== '' && record[attrName] !== 0 && !_.isNaN(record[attrName])) {
+          }
+          // If the value came back as a dictionary, then that might be ok-- it could mean
+          // the association was successfully populated.
+          else if (_.isObject(record[attrName]) && !_.isArray(record[attrName]) && !_.isFunction(record[attrName])) {
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            // FUTURE: we could check this more carefully in the future by providing more
+            // information to this utility-- specifically, the `populates` key from the S2Q.
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          }
+          // Otherwise, the value is invalid.
+          else {
+            console.warn('\n'+
+              'An association in a result record has an unexpected data type.  Since `'+attrName+'` is\n'+
+              'a singular (association), it should come back from Waterline as either:\n'+
+              '• `null` (if not populated and set to null explicitly, or populated but orphaned)\n'+
+              '• a dictionary (if successfully populated), or\n'+
+              '• a valid primary key value for the associated model (if set + not populated)\n'+
+              'But for this record, after converting column names back into attribute names, it\n'+
+              'wasn\'t any of those things.\n'+
+              'Record:\n'+
+              '```\n'+
+              util.inspect(record, {depth:5})+'\n'+
+              '```\n'+
+              WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+            );
+          }
+
+        }
+        //  ██████╗ ██╗     ██╗   ██╗██████╗  █████╗ ██╗
+        //  ██╔══██╗██║     ██║   ██║██╔══██╗██╔══██╗██║
+        //  ██████╔╝██║     ██║   ██║██████╔╝███████║██║
+        //  ██╔═══╝ ██║     ██║   ██║██╔══██╗██╔══██║██║
+        //  ██║     ███████╗╚██████╔╝██║  ██║██║  ██║███████╗
+        //  ╚═╝     ╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+        //
+        else if (attrDef.collection) {
+          assert(!attrDef.allowNull, 'Plural ("collection") association attributes should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
+
+          // If record does not define a value for a plural association, that's ok.
+          // That probably just means it was not populated.
+          if (_.isUndefined(record[attrName])) {
+          }
+          // If the value for this singular association came back as an array, then
+          // that might be ok too-- it probably means that the association was populated.
+          else if (_.isArray(record[attrName])) {
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            // FUTURE: we could check that it is an array of valid child records,
+            // instead of just verifying that it is an array of _some kind_.
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          }
+          // Otherwise, the value is invalid.
+          else {
+            console.warn('\n'+
+              'An association in a result record has an unexpected data type.  Since `'+attrName+'` is\n'+
+              'a plural (association), it should come back from Waterline as either:\n'+
+              '• `undefined` (if not populated), or\n'+
+              '• an array of child records (if populated)\n'+
+              'But for this record, it wasn\'t any of those things.\n'+
+              // Note that this could mean there was something else already there
+              // (imagine changing your model to use a plural association instead
+              // of an embedded array from a `type: 'json'` attribute)
+              'Record:\n'+
+              '```\n'+
+              util.inspect(record, {depth:5})+'\n'+
+              '```\n'+
+              WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+            );
+          }
+
+        }
+        //  ███████╗████████╗ █████╗ ███╗   ███╗██████╗ ███████╗
+        //  ██╔════╝╚══██╔══╝██╔══██╗████╗ ████║██╔══██╗██╔════╝
+        //  ███████╗   ██║   ███████║██╔████╔██║██████╔╝███████╗
+        //  ╚════██║   ██║   ██╔══██║██║╚██╔╝██║██╔═══╝ ╚════██║
+        //  ███████║   ██║   ██║  ██║██║ ╚═╝ ██║██║     ███████║
+        //  ╚══════╝   ╚═╝   ╚═╝  ╚═╝╚═╝     ╚═╝╚═╝     ╚══════╝
+        //
+        else if (attrDef.autoCreatedAt || attrDef.autoUpdatedAt) {
+
+          assert(!attrDef.allowNull, 'Timestamp attributes should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
+
+          // If there is no value defined on the record for this attribute...
+          if (_.isUndefined(record[attrName])) {
+
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            // FUTURE: Log a warning (but note that, to really get this right, we'd need access to
+            // a clone of the `omit` and `select` clauses from the s2q criteria, plus the `populates`
+            // query key from the s2q criteria -- probably also a clone of that)
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+          }
+          // Otherwise, we know there's SOMETHING there at least.
+          else {
+
+            // Do quick, very incomplete verification that a valid timestamp was sent back.
+            var isProbablyValidTimestamp = (
+              record[attrName] !== '' &&
+              record[attrName] !== 0 &&
+              (
+                _.isString(record[attrName]) || _.isNumber(record[attrName]) || _.isDate(record[attrName])
+              )
+            );
+
+            if (!isProbablyValidTimestamp) {
+              console.warn('\n'+
+                'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
+                ' a record in the result has a value with an unexpected data type for property `'+attrName+'`.\n'+
+                'The model\'s `'+attrName+'` attribute declares itself an auto timestamp with\n'+
+                '`type: \''+attrDef.type+'\'`, but instead of a valid timestamp, the actual value\n'+
+                'in the record is:\n'+
+                '```\n'+
+                util.inspect(record[attrName],{depth:5})+'\n'+
+                '```\n'+
+                WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+              );
+            }
+
+          }//</else>
+
+        }
+        //  ███╗   ███╗██╗███████╗ ██████╗        ██╗████████╗██╗   ██╗██████╗ ███████╗██╗
+        //  ████╗ ████║██║██╔════╝██╔════╝       ██╔╝╚══██╔══╝╚██╗ ██╔╝██╔══██╗██╔════╝╚██╗
+        //  ██╔████╔██║██║███████╗██║            ██║    ██║    ╚████╔╝ ██████╔╝█████╗   ██║
+        //  ██║╚██╔╝██║██║╚════██║██║            ██║    ██║     ╚██╔╝  ██╔═══╝ ██╔══╝   ██║
+        //  ██║ ╚═╝ ██║██║███████║╚██████╗██╗    ╚██╗   ██║      ██║   ██║     ███████╗██╔╝
+        //  ╚═╝     ╚═╝╚═╝╚══════╝ ╚═════╝╚═╝     ╚═╝   ╚═╝      ╚═╝   ╚═╝     ╚══════╝╚═╝
+        //
+        else {
+
+          // Sanity check:
+          if (attrDef.type === 'json' || attrDef.type === 'ref') {
+            assert(!attrDef.allowNull, '`type:\'json\'` and `type:\'ref\'` attributes should never be defined with `allowNull:true`.  (This should have already been caught in wl-schema during ORM initialization!  Please report this at http://sailsjs.com/bugs)');
+          }
+
+          // If there is no value defined on the record for this attribute...
+          if (_.isUndefined(record[attrName])) {
+
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            // FUTURE: Log a warning (but note that, to really get this right, we'd need access to
+            // a clone of the `omit` and `select` clauses from the s2q criteria, plus the `populates`
+            // query key from the s2q criteria -- probably also a clone of that)
+            // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+          }
+          // If the value is `null`, and the attribute has `allowNull:true`, then its ok.
+          else if (_.isNull(record[attrName]) && attrDef.allowNull === true) {
+            // Nothing to validate here.
+          }
+          // Otherwise, we'll need to validate the value.
+          else {
+
+            // Strictly validate the value vs. the attribute's `type`, and if it is
+            // obviously incorrect, then log a warning (but don't actually coerce it.)
+            try {
+              rttc.validateStrict(attrDef.type, record[attrName]);
+            } catch (e) {
+              switch (e.code) {
+                case 'E_INVALID':
+
+                  if (_.isNull(record[attrName])) {
+                    console.warn('\n'+
+                      'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
+                      ' a record in the result has a value of `null` for property `'+attrName+'`.\n'+
+                      'Since the `'+attrName+'` attribute declares `type: \''+attrDef.type+'\'`,\n'+
+                      'without ALSO declaring `allowNull: true`, this `null` value is unexpected.\n'+
+                      '(To resolve, either change this attribute to `allowNull: true` or update\n'+
+                      'existing records in the database accordingly.)\n'+
+                      WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+                    );
+                  }
+                  else {
+                    console.warn('\n'+
+                      'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
+                      ' a record in the result has a value with an unexpected data type for property `'+attrName+'`.\n'+
+                      'The corresponding attribute declares `type: \''+attrDef.type+'\'` but instead\n'+
+                      'of that, the actual value is:\n'+
+                      '```\n'+
+                      util.inspect(record[attrName],{depth:5})+'\n'+
+                      '```\n'+
+                      WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+                    );
+                  }
+                  break;
+                default: throw e;
+              }
+            }//>-•
+
+          }
+
         }
 
-        // If there is no value defined on the record for this attribute...
-        if (_.isUndefined(record[attrName])) {
+
+        //>-
+
+        //   ██████╗██╗  ██╗███████╗ ██████╗██╗  ██╗
+        //  ██╔════╝██║  ██║██╔════╝██╔════╝██║ ██╔╝
+        //  ██║     ███████║█████╗  ██║     █████╔╝
+        //  ██║     ██╔══██║██╔══╝  ██║     ██╔═██╗
+        //  ╚██████╗██║  ██║███████╗╚██████╗██║  ██╗
+        //   ╚═════╝╚═╝  ╚═╝╚══════╝ ╚═════╝╚═╝  ╚═╝
+        //
+        //  ██████╗ ███████╗ ██████╗ ██╗   ██╗██╗██████╗ ███████╗██████╗ ███╗   ██╗███████╗███████╗███████╗
+        //  ██╔══██╗██╔════╝██╔═══██╗██║   ██║██║██╔══██╗██╔════╝██╔══██╗████╗  ██║██╔════╝██╔════╝██╔════╝
+        //  ██████╔╝█████╗  ██║   ██║██║   ██║██║██████╔╝█████╗  ██║  ██║██╔██╗ ██║█████╗  ███████╗███████╗
+        //  ██╔══██╗██╔══╝  ██║▄▄ ██║██║   ██║██║██╔══██╗██╔══╝  ██║  ██║██║╚██╗██║██╔══╝  ╚════██║╚════██║
+        //  ██║  ██║███████╗╚██████╔╝╚██████╔╝██║██║  ██║███████╗██████╔╝██║ ╚████║███████╗███████║███████║
+        //  ╚═╝  ╚═╝╚══════╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚═╝  ╚═╝╚══════╝╚═════╝ ╚═╝  ╚═══╝╚══════╝╚══════╝╚══════╝
+        //
+        // If attribute is required, check that the value returned in this record
+        // is neither `null` nor empty string ('') nor `undefined`.
+        if (attrDef.required) {
 
           // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           // FUTURE: Log a warning (but note that, to really get this right, we'd need access to
           // a clone of the `omit` and `select` clauses from the s2q criteria, plus the `populates`
           // query key from the s2q criteria -- probably also a clone of that)
+          //
+          // ```
+          // if (_.isUndefined(record[attrName]) || _.isNull(record[attrName]) || record[attrName] === '') {
+          //   // (We'd also need to make sure this wasn't deliberately exluded by custom projections
+          //   //  before logging this warning.)
+          //   console.warn('\n'+
+          //     'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
+          //     'a record in the result contains an unexpected value (`'+util.inspect(record[attrName],{depth:1})+'`)`\n'+
+          //     'for its `'+attrName+'` property.  Since `'+attrName+'` is a required attribute,\n'+
+          //     'it should never be returned as `null` or empty string.  This usually means there\n'+
+          //     'is existing data that was persisted some time before the `'+attrName+'` attribute\n'+
+          //     'was set to `required: true`.  To make this warning go away, either remove\n'+
+          //     '`required: true` from this attribute, or update the existing, already-stored data\n'+
+          //     'so that the `'+attrName+'` of all records is set to some value other than null or\n'+
+          //     'empty string.\n'+
+          //     WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
+          //   );
+          // }
+          // ```
           // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         }
-        // If the value is `null`, and the attribute has `allowNull:true`, then its ok.
-        else if (_.isNull(record[attrName]) && attrDef.allowNull === true) {
-          // Nothing to validate here.
-        }
-        // Otherwise, we'll need to validate the value.
-        else {
 
-          // Strictly validate the value vs. the attribute's `type`, and if it is
-          // obviously incorrect, then log a warning (but don't actually coerce it.)
-          try {
-            rttc.validateStrict(attrDef.type, record[attrName]);
-          } catch (e) {
-            switch (e.code) {
-              case 'E_INVALID':
+      });//</_.each>
 
-                if (_.isNull(record[attrName])) {
-                  console.warn('\n'+
-                    'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
-                    ' a record in the result has a value of `null` for property `'+attrName+'`.\n'+
-                    'Since the `'+attrName+'` attribute declares `type: \''+attrDef.type+'\'`,\n'+
-                    'without ALSO declaring `allowNull: true`, this `null` value is unexpected.\n'+
-                    '(To resolve, either change this attribute to `allowNull: true` or update\n'+
-                    'existing records in the database accordingly.)\n'+
-                    WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
-                  );
-                }
-                else {
-                  console.warn('\n'+
-                    'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
-                    ' a record in the result has a value with an unexpected data type for property `'+attrName+'`.\n'+
-                    'The corresponding attribute declares `type: \''+attrDef.type+'\'` but instead\n'+
-                    'of that, the actual value is:\n'+
-                    '```\n'+
-                    util.inspect(record[attrName],{depth:5})+'\n'+
-                    '```\n'+
-                    WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
-                  );
-                }
-                break;
-              default: throw e;
-            }
-          }//>-•
-
-        }
-
-      }
-
-
-      //>-
-
-      //   ██████╗██╗  ██╗███████╗ ██████╗██╗  ██╗
-      //  ██╔════╝██║  ██║██╔════╝██╔════╝██║ ██╔╝
-      //  ██║     ███████║█████╗  ██║     █████╔╝
-      //  ██║     ██╔══██║██╔══╝  ██║     ██╔═██╗
-      //  ╚██████╗██║  ██║███████╗╚██████╗██║  ██╗
-      //   ╚═════╝╚═╝  ╚═╝╚══════╝ ╚═════╝╚═╝  ╚═╝
-      //
-      //  ██████╗ ███████╗ ██████╗ ██╗   ██╗██╗██████╗ ███████╗██████╗ ███╗   ██╗███████╗███████╗███████╗
-      //  ██╔══██╗██╔════╝██╔═══██╗██║   ██║██║██╔══██╗██╔════╝██╔══██╗████╗  ██║██╔════╝██╔════╝██╔════╝
-      //  ██████╔╝█████╗  ██║   ██║██║   ██║██║██████╔╝█████╗  ██║  ██║██╔██╗ ██║█████╗  ███████╗███████╗
-      //  ██╔══██╗██╔══╝  ██║▄▄ ██║██║   ██║██║██╔══██╗██╔══╝  ██║  ██║██║╚██╗██║██╔══╝  ╚════██║╚════██║
-      //  ██║  ██║███████╗╚██████╔╝╚██████╔╝██║██║  ██║███████╗██████╔╝██║ ╚████║███████╗███████║███████║
-      //  ╚═╝  ╚═╝╚══════╝ ╚══▀▀═╝  ╚═════╝ ╚═╝╚═╝  ╚═╝╚══════╝╚═════╝ ╚═╝  ╚═══╝╚══════╝╚══════╝╚══════╝
-      //
-      // If attribute is required, check that the value returned in this record
-      // is neither `null` nor empty string ('') nor `undefined`.
-      if (attrDef.required) {
-
-        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        // FUTURE: Log a warning (but note that, to really get this right, we'd need access to
-        // a clone of the `omit` and `select` clauses from the s2q criteria, plus the `populates`
-        // query key from the s2q criteria -- probably also a clone of that)
-        //
-        // ```
-        // if (_.isUndefined(record[attrName]) || _.isNull(record[attrName]) || record[attrName] === '') {
-        //   // (We'd also need to make sure this wasn't deliberately exluded by custom projections
-        //   //  before logging this warning.)
-        //   console.warn('\n'+
-        //     'Warning: After transforming columnNames back to attribute names for model `' + modelIdentity + '`,\n'+
-        //     'a record in the result contains an unexpected value (`'+util.inspect(record[attrName],{depth:1})+'`)`\n'+
-        //     'for its `'+attrName+'` property.  Since `'+attrName+'` is a required attribute,\n'+
-        //     'it should never be returned as `null` or empty string.  This usually means there\n'+
-        //     'is existing data that was persisted some time before the `'+attrName+'` attribute\n'+
-        //     'was set to `required: true`.  To make this warning go away, either remove\n'+
-        //     '`required: true` from this attribute, or update the existing, already-stored data\n'+
-        //     'so that the `'+attrName+'` of all records is set to some value other than null or\n'+
-        //     'empty string.\n'+
-        //     WARNING_SUFFIXES.MIGHT_BE_YOUR_FAULT
-        //   );
-        // }
-        // ```
-        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-      }
-
-    });//</_.each>
+    }//ﬁ    (verify records)
 
 
     //   █████╗ ████████╗████████╗ █████╗  ██████╗██╗  ██╗
@@ -539,7 +536,6 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
     }//>-
 
   }, false, modelIdentity, orm);//</eachRecordDeep>
-
 
 
   //

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -549,7 +549,7 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
     //  ╦╔═╗  ┬─┐┌─┐┬  ┌─┐┬  ┬┌─┐┌┐┌┌┬┐
     //  ║╠╣   ├┬┘├┤ │  ├┤ └┐┌┘├─┤│││ │
     //  ╩╚    ┴└─└─┘┴─┘└─┘ └┘ ┴ ┴┘└┘ ┴ooo
-    var skippingDecryption = meta && meta.skipDecryption;
+    var skippingDecryption = meta && meta.skipRecordDecryption;
     if (!skippingDecryption) {
       _.each(WLModel.attributes, function (attrDef, attrName){
         try {

--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -554,14 +554,19 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
       _.each(WLModel.attributes, function (attrDef, attrName){
         try {
           if (attrDef.encrypt) {
-            // Decrypt using the appropriate key from the configured DEKs.
-            record[attrName] = EA([attrName], {
-              keys: WLModel.dataEncryptionKeys
-            })
-            .decryptAttribute(undefined, record[attrName]);
+            // // Decrypt using the appropriate key from the configured DEKs.
+            // record[attrName] = EA([attrName], {
+            //   keys: WLModel.dataEncryptionKeys
+            // })
+            // .decryptAttribute(undefined, record[attrName]);
+
+            // TODO remove this hack
+            if (!record[attrName].match(/^ENCRYPTED:/)){ throw new Error('Unexpected behavior: Can\'t decrypt something already decrypted!!!'); }
+            record[attrName] = record[attrName].replace(/^ENCRYPTED:/, '');
 
           }//ﬁ
         } catch (err) {
+          console.log('•••••was attempting to decrypt this value: `'+util.inspect(record[attrName], {depth:null})+'`');
           throw flaverr({
             message: 'Decryption failed for `'+attrName+'` (in a `'+WLModel.identity+'` record)\n'+
             'Details:\n'+

--- a/lib/waterline/utils/system/transformer-builder.js
+++ b/lib/waterline/utils/system/transformer-builder.js
@@ -197,10 +197,10 @@ Transformation.prototype.unserialize = function(pRecord) {
   // Get the database columns that we'll be transforming into attribute names.
   var colsToTransform = _.values(this._transformations);
 
-  // Shallow clone the record, so that we don't lose any values in cnases where
-  // one attribute's name conflicts with another attribute's `columnName`.
+  // Shallow clone the physical record, so that we don't lose any values in cases
+  // where one attribute's name conflicts with another attribute's `columnName`.
   // (see https://github.com/balderdashy/sails/issues/4079)
-  var recordCopy = _.clone(pRecord);
+  var copyOfPhysicalRecord = _.clone(pRecord);
 
   // Remove the values from the pRecord that are set for the columns we're
   // going to transform.  This ensures that the `columnName` and the
@@ -212,16 +212,16 @@ Transformation.prototype.unserialize = function(pRecord) {
     }
   });
 
-  // Loop through the keys of the record and change them.
+  // Loop through the keys to transform of this record and reattach them.
   _.each(this._transformations, function(columnName, attrName) {
 
     // If there's no value set for this column name, continue.
-    if (!_.has(recordCopy, columnName)) {
+    if (!_.has(copyOfPhysicalRecord, columnName)) {
       return;
     }
 
     // Otherwise get the value from the cloned record.
-    pRecord[attrName] = recordCopy[columnName];
+    pRecord[attrName] = copyOfPhysicalRecord[columnName];
 
   });
 

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "@sailshq/lodash": "^3.10.2",
     "anchor": "^1.1.0",
     "async": "2.0.1",
-    "encrypted-attr": "1.0.5",
+    "encrypted-attr": "1.0.6",
     "flaverr": "^1.2.1",
     "lodash.issafeinteger": "4.0.4",
     "parley": "^3.0.0-0",
     "rttc": "^10.0.0-1",
-    "waterline-schema": "^1.0.0-7",
+    "waterline-schema": "^1.0.0-20",
     "waterline-utils": "^1.3.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@sailshq/lodash": "^3.10.2",
     "anchor": "^1.1.0",
     "async": "2.0.1",
+    "encrypted-attr": "1.0.5",
     "flaverr": "^1.2.1",
     "lodash.issafeinteger": "4.0.4",
     "parley": "^3.0.0-0",


### PR DESCRIPTION
# TODOs

1. Finish up a few straggling things in this PR
2. Update docs (meta key is already covered, just need to write quite a bit more on this subject, including documenting the new model setting)
3. Have sails-generate set up new apps' `config/models.js` file with a default DEK for use during development, and update the boilerplate `config/env/production.js` file so that it explicitly wipes out that config to prevent people accidentally using the checked-in DEK in a production setting
4. Get this working in Node 4 (see https://github.com/simonratner/node-encrypted-attr/pull/3)
5. Figure out a workable solution for Node 0.10/0.12  (possibly just do a conditional require w/ a kind (but firm) error msg if you try to get fresh and fruity with at-rest encryption while using a "mature" version of node.js)


# New things

| What it is                                        | What kind of thing it is  | Data type              | Summary
|:---------------------------------|:------------------------|:------------------|:-----------|
| `dataEncryptionKeys`                  | Model setting                 | ((dictionary))         | A set of DEKs to use when encrypting and decrypting data.  The `default` DEK is used for all new encryption.  The other DEKs are there primarily to allow for decrypting older data that was encrypted with them before a key rotation.                  |
| `encrypt`                                       | Attribute prop                | ((boolean))            | Whether to auto-encrypt and (in most cases) auto-decrypt.   |
| `decrypt`                                      | Meta key                        | ((boolean))            | Whether to automatically decrypt records returned for this particular query.  Enable this flag to automatically decrypt data (otherwise, by default it'll come back still-encrypted.)                  |
| `encryptWith`                               | Meta key                        | ((string))            | The id of a custom key to use for encryption for this particular query.  (Otherwise by default, the `default` key is used for encryption.  For decryption, the appropriate key is always used based on the data being decrypted.)                   |



# Example


```js
// config/models.js
module.exports.models = {

  // In production, you'll want to set these using environment variables.
  // (e.g. `sails_models__dataEncryptionKeys__default='tVdQbq2JptoPp4oXGT94kKqF72iV0VKY/cnp7SjL7Ik='`)
  dataEncryptionKeys: {
    default: 'tVdQbq2JptoPp4oXGT94kKqF72iV0VKY/cnp7SjL7Ik=',
    '2016': 'DZ7MslaooGub3pS/0O734yeyPTAeZtd0Lrgeswwlt0s=',
    '2015': 'C5QAkA46HD9pK0m7293V2CzEVlJeSUXgwmxBAQVj+xU='
  },

};
```


```js
// api/models/User.js
module.exports = {
  
  // `dataEncryptionKeys` overrides could also be specified here on a per-model basis,
  // but realistically you won't ever need that in most cases.
 
  attributes: {

    fullName: {
      type: 'string',
      required: true,
      example: 'Maria Rogers'
    },

    ssn: {
      description: 'Social security number (encrypted at rest).',
      type: 'string',
      encrypt: true,
      example: '555-55-5555'
    },

  }
};
```



```js
// Usage:

await User.find();
// => 
// [ { id: 4, fullName: 'Wiggly Wriggly', ssn: 'YWVzLTI1Ni1nY20kJGRlZmF1bHQ=$F4Du3CAHtmUNk1pn$hMBezK3lwJ2BhOjZ$6as+eXnJDfBS54XVJgmPsg' } ]


await User.find().decrypt();
// => 
// [ { id: 4, fullName: 'Wiggly Wriggly', ssn: '555-55-5555' } ]
```



# Nice to have

Some kind of meta setting that lets you determine which key to use.  Normally, Waterline just uses the `default` DEK for encryption, and then whatever the appropriate DEK is for decryption.  So this would tell Waterline to use a different one of your DEKs when encrypting (e.g. `'2016'`).

This is handy during key rotation.  For example, consider the following code from a key rotation script:

```js
// assuming the same DEK is configured as both 'default' and '2016'...
//…

await User.stream()
.decrypt()
.eachRecord(async (user, next)=>{
  await User.update({ id: user.id }).set({ ssn: user.ssn }).meta({ encryptWith: '2016' });
  next();
});

// All social security numbers in the database have now been re-encrypted under
// the same DEK as before, but understanding it as key id '2016' instead of 'default'.
//
// That means that they can be decrypted normally now (regardless of whether this special
// meta key is present or not) as long as keys are configured for both 'default' and '2016'
// (since Waterline automatically figures out which key to use based on the key id embedded
// in the encrypted string.)  Remember, this `meta` setting only affects which DEK is used for
// _encryption_.   For decryption, Waterline always uses the appropriate DEK no matter what.
// 
// Finally, note that, at this point, any new encryption without providing the special meta flag
// will use 'default', as usual.  So if, after running this script, you configure a different key as
// 'default', then the key rotation will be complete!
```




##### Slightly more involved example

Here's the same example as above again, this time in a transaction:

```js
await User.getDatastore().transaction(async (db, proceed)=>{
  await User.stream().usingConnection(db)
  .decrypt()
  .eachRecord(async (user, next)=>{
    await User.update().usingConnection(db)
    .where({ id: user.id })
    .set({ ssn: user.ssn })
    .meta({ encryptWith: '2016' });
    return next();
  });
  return proceed();
});
```
