### PR TITLE
[patch] Add capitalized `globalId` to default archive model.

### DIFF
--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -268,6 +268,7 @@ function Waterline() {
 
           var newWmd = Waterline.Model.extend({
             identity: DEFAULT_ARCHIVE_MODEL_IDENTITY,
+            globalId: _.capitalize(DEFAULT_ARCHIVE_MODEL_IDENTITY),
             primaryKey: 'id',
             datastore: arbitraryArchiver.datastore,
             attributes: {

--- a/lib/waterline.js
+++ b/lib/waterline.js
@@ -268,6 +268,9 @@ function Waterline() {
 
           var newWmd = Waterline.Model.extend({
             identity: DEFAULT_ARCHIVE_MODEL_IDENTITY,
+            // > Note that we inject a "globalId" for potential use in higher-level frameworks (e.g. Sails)
+            // > that might want to globalize this model.  This way, it'd show up as "Archive" instead of "archive".
+            // > Remember: Waterline is NOT responsible for any globalization itself, this is just advisory.
             globalId: _.capitalize(DEFAULT_ARCHIVE_MODEL_IDENTITY),
             primaryKey: 'id',
             datastore: arbitraryArchiver.datastore,


### PR DESCRIPTION
For consistency with expectation that model globals are capitalized (without this, the global is `archive`).