### PR TITLE
[fixes #1509] Fail normalizeWhereClause() for undefined attributes configurable

### DIFF
--- a/lib/waterline/utils/query/private/normalize-where-clause.js
+++ b/lib/waterline/utils/query/private/normalize-where-clause.js
@@ -304,6 +304,12 @@ module.exports = function normalizeWhereClause(whereClause, modelIdentity, orm, 
       // Strip out any keys with undefined values.
       _.each(_.keys(branch), function (key){
         if (_.isUndefined(branch[key])) {
+          if(WLModel.failOnUndefinedAttributesInWhereClause) {
+            throw flaverr('E_WHERE_CLAUSE_UNUSABLE', new Error(
+              'When a model has a truthy `failOnUndefinedAttributesInWhereClase`, no ' +
+              '`undefined` attributes may be specified.'
+            ));
+          }
           delete branch[key];
         }
       });


### PR DESCRIPTION
If failOnUndefinedAttributesInWhereClause is set on a given Model,
then providing keys in a `where` clause with `undefined` as values
fails with E_WHERE_CLAUSE_UNUSABLE. The query.find.js test suite
has been updated to reflect this change.