### PR TITLE
[PATCH] Fix sails issue 4360 (PKs don't get validation rules applied)

### DIFF
--- a/lib/waterline/utils/query/private/normalize-value-to-set.js
+++ b/lib/waterline/utils/query/private/normalize-value-to-set.js
@@ -235,6 +235,10 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
   // and vs. the corresponding attribute definition's declared `type`,
   // `model`, or `collection`.
 
+  // Delcare var to flag whether or not an attribute should have validation rules applied.
+  // This will typically be the case for primary keys and generic attributes under certain conditions.
+  var doCheckForRuleViolations = false;
+
   // If this value is `undefined`, then bail early, indicating that it should be ignored.
   if (_.isUndefined(value)) {
     throw flaverr('E_SHOULD_BE_IGNORED', new Error(
@@ -277,6 +281,11 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
   //  ├┤ │ │├┬┘  ╠═╝╠╦╝║║║║╠═╣╠╦╝╚╦╝  ╠╩╗║╣ ╚╦╝  ╠═╣ ║  ║ ╠╦╝║╠╩╗║ ║ ║ ║╣
   //  └  └─┘┴└─  ╩  ╩╚═╩╩ ╩╩ ╩╩╚═ ╩   ╩ ╩╚═╝ ╩   ╩ ╩ ╩  ╩ ╩╚═╩╚═╝╚═╝ ╩ ╚═╝
   else if (WLModel.primaryKey === supposedAttrName) {
+
+    // Primary key attributes should have validation rules applied if they have any.
+    if (!_.isUndefined(correspondingAttrDef.validations)) {
+      doCheckForRuleViolations = true;
+    }
 
     try {
       value = normalizePkValue(value, correspondingAttrDef.type);
@@ -542,61 +551,63 @@ module.exports = function normalizeValueToSet(value, supposedAttrName, modelIden
     }//>-   </ if required >
 
 
-    //  ┌─┐┬ ┬┌─┐┌─┐┬┌─  ┌─┐┌─┐┬─┐  ╦═╗╦ ╦╦  ╔═╗  ╦  ╦╦╔═╗╦  ╔═╗╔╦╗╦╔═╗╔╗╔╔═╗
-    //  │  ├─┤├┤ │  ├┴┐  ├┤ │ │├┬┘  ╠╦╝║ ║║  ║╣   ╚╗╔╝║║ ║║  ╠═╣ ║ ║║ ║║║║╚═╗
-    //  └─┘┴ ┴└─┘└─┘┴ ┴  └  └─┘┴└─  ╩╚═╚═╝╩═╝╚═╝   ╚╝ ╩╚═╝╩═╝╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
-    // If appropriate, strictly enforce our (potentially-mildly-coerced) value
-    // vs. the validation ruleset defined on the corresponding attribute.
-    // Then, if there are any rule violations, stick them in an Error and throw it.
+    // Decide whether validation rules should be checked for this attribute.
     //
     // > • High-level validation rules are ALWAYS skipped for `null`.
-    // > • If there is no `validations` attribute key, then there's nothing for us to do here.
-    var ruleset = correspondingAttrDef.validations;
-    var doCheckForRuleViolations = !_.isNull(value) && !_.isUndefined(ruleset);
-    if (doCheckForRuleViolations) {
-      var isRulesetDictionary = _.isObject(ruleset) && !_.isArray(ruleset) && !_.isFunction(ruleset);
-      if (!isRulesetDictionary) {
-        throw new Error('Consistency violation: If set, an attribute\'s validations ruleset (`validations`) should always be a dictionary (plain JavaScript object).  But for the `'+modelIdentity+'` model\'s `'+supposedAttrName+'` attribute, it somehow ended up as this instead: '+util.inspect(correspondingAttrDef.validations,{depth:5})+'');
-      }
-
-      var ruleViolations;
-      try {
-        ruleViolations = anchor(value, ruleset);
-        // e.g.
-        // [ { rule: 'isEmail', message: 'Value was not a valid email address.' }, ... ]
-      } catch (e) {
-        throw new Error(
-          'Consistency violation: Unexpected error occurred when attempting to apply '+
-          'high-level validation rules from `'+modelIdentity+'` model\'s `'+supposedAttrName+'` '+
-          'attribute.  '+e.stack
-        );
-      }//</ catch >
-
-      if (ruleViolations.length > 0) {
-
-        // Format rolled-up summary for use in our error message.
-        // e.g.
-        // ```
-        //  • Value was not in the configured whitelist (delinquent, new, paid)
-        //  • Value was an empty string.
-        // ```
-        var summary = _.reduce(ruleViolations, function (memo, violation){
-          memo += '  • '+violation.message+'\n';
-          return memo;
-        }, '');
-
-        throw flaverr({
-          code: 'E_VIOLATES_RULES',
-          ruleViolations: ruleViolations
-        }, new Error(
-          'Violated one or more validation rules:\n'+
-          summary
-        ));
-      }//-•
-
-    }//>-•  </if (doCheckForRuleViolations) >
+    // > • If there is no `validations` attribute key, then there's nothing for us to check.
+    doCheckForRuleViolations = !_.isNull(value) && !_.isUndefined(correspondingAttrDef.validations);
 
   }//</else (i.e. corresponding attr def is just a normal attr--not an association or primary key)>
+
+  //  ┌─┐┬ ┬┌─┐┌─┐┬┌─  ┌─┐┌─┐┬─┐  ╦═╗╦ ╦╦  ╔═╗  ╦  ╦╦╔═╗╦  ╔═╗╔╦╗╦╔═╗╔╗╔╔═╗
+  //  │  ├─┤├┤ │  ├┴┐  ├┤ │ │├┬┘  ╠╦╝║ ║║  ║╣   ╚╗╔╝║║ ║║  ╠═╣ ║ ║║ ║║║║╚═╗
+  //  └─┘┴ ┴└─┘└─┘┴ ┴  └  └─┘┴└─  ╩╚═╚═╝╩═╝╚═╝   ╚╝ ╩╚═╝╩═╝╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
+  // If appropriate, strictly enforce our (potentially-mildly-coerced) value
+  // vs. the validation ruleset defined on the corresponding attribute.
+  // Then, if there are any rule violations, stick them in an Error and throw it.
+  if (doCheckForRuleViolations) {
+    var ruleset = correspondingAttrDef.validations;
+    var isRulesetDictionary = _.isObject(ruleset) && !_.isArray(ruleset) && !_.isFunction(ruleset);
+    if (!isRulesetDictionary) {
+      throw new Error('Consistency violation: If set, an attribute\'s validations ruleset (`validations`) should always be a dictionary (plain JavaScript object).  But for the `'+modelIdentity+'` model\'s `'+supposedAttrName+'` attribute, it somehow ended up as this instead: '+util.inspect(correspondingAttrDef.validations,{depth:5})+'');
+    }
+
+    var ruleViolations;
+    try {
+      ruleViolations = anchor(value, ruleset);
+      // e.g.
+      // [ { rule: 'isEmail', message: 'Value was not a valid email address.' }, ... ]
+    } catch (e) {
+      throw new Error(
+        'Consistency violation: Unexpected error occurred when attempting to apply '+
+        'high-level validation rules from `'+modelIdentity+'` model\'s `'+supposedAttrName+'` '+
+        'attribute.  '+e.stack
+      );
+    }//</ catch >
+
+    if (ruleViolations.length > 0) {
+
+      // Format rolled-up summary for use in our error message.
+      // e.g.
+      // ```
+      //  • Value was not in the configured whitelist (delinquent, new, paid)
+      //  • Value was an empty string.
+      // ```
+      var summary = _.reduce(ruleViolations, function (memo, violation){
+        memo += '  • '+violation.message+'\n';
+        return memo;
+      }, '');
+
+      throw flaverr({
+        code: 'E_VIOLATES_RULES',
+        ruleViolations: ruleViolations
+      }, new Error(
+        'Violated one or more validation rules:\n'+
+        summary
+      ));
+    }//-•
+
+  }//>-•  </if (doCheckForRuleViolations) >
 
 
   //  ███████╗███╗   ██╗ ██████╗██████╗ ██╗   ██╗██████╗ ████████╗    ██████╗  █████╗ ████████╗ █████╗

--- a/test/unit/collection/validations.js
+++ b/test/unit/collection/validations.js
@@ -39,12 +39,19 @@ describe('Collection Validator ::', function() {
         }
       };
 
-      waterline.initialize({ adapters: { foobar: { update: function(con, query, cb) { return cb(); } } }, datastores: datastores }, function(err, orm) {
+      waterline.initialize({ adapters: { foobar: { update: function(con, query, cb) { return cb(); }, create: function(con, query, cb) { return cb(); } } }, datastores: datastores }, function(err, orm) {
         if (err) {
           return done(err);
         }
         person = orm.collections.person;
         done();
+      });
+    });
+
+    it('should not return any errors when no validation rules are violated', function(done) {
+      person.create({ sex: 'male' }).exec(function(err) {
+        assert(!err);
+        return done();
       });
     });
 

--- a/test/unit/collection/validations.js
+++ b/test/unit/collection/validations.js
@@ -98,7 +98,7 @@ describe('Collection Validator ::', function() {
       });
     });
 
-    it('should return an Error with name `UsageError` when a required string field is set to empty string in a `create`', function(done) {
+    it('should return an Error with name `UsageError` when a required string field is set to empty string in a `update`', function(done) {
       person.update({}, { sex: '' }).exec(function(err) {
         assert(err);
         assert.equal(err.name, 'UsageError');
@@ -107,7 +107,7 @@ describe('Collection Validator ::', function() {
       });
     });
 
-    it('should return an Error with name `UsageError` when a field is set to the wrong type in a `create`', function(done) {
+    it('should return an Error with name `UsageError` when a field is set to the wrong type in a `update`', function(done) {
       person.update({}, { age: 'bar' }).exec(function(err) {
         assert(err);
         assert.equal(err.name, 'UsageError');
@@ -116,7 +116,7 @@ describe('Collection Validator ::', function() {
       });
     });
 
-    it('should return an Error with name `UsageError` when a field fails a validation rule in a `create`', function(done) {
+    it('should return an Error with name `UsageError` when a field fails a validation rule in a `update`', function(done) {
       person.update({}, { sex: 'bar' }).exec(function(err) {
         assert(err);
         assert.equal(err.name, 'UsageError');


### PR DESCRIPTION
This PR fixes the issue described here: https://github.com/balderdashy/sails/issues/4360

In essence, custom primary key definitions currently have any validation rules ignored, because they are processed separately from "generic" attributes in the "normalize value" logic.  So for a PK defined like:

```
          id: {
            type: 'string',
            required: true,
            validations: {
              minLength: 6
            }
          }
```

you can still do `.create({id: 'abc'})` and it'll pass, even though the `id` field doesn't meet the minimum length requirements.  This PR fixes that by ensuring that validation rules apply to both generic and primary key attributes.

Also fixed some existing validation tests and added new tests for the PK case.