### PR TITLE
Ilike issue 1563

### DIFF
--- a/lib/waterline/utils/query/private/normalize-constraint.js
+++ b/lib/waterline/utils/query/private/normalize-constraint.js
@@ -44,7 +44,7 @@ var MODIFIER_KINDS = {
   'in':         true,
 
   'like':       true,
-  'ilike':       true,
+  'ilike':      true,
   'contains':   true,
   'startsWith': true,
   'endsWith':   true


### PR DESCRIPTION
This small change provides postgres support for ILIKE alongside LIKE.  The "contains", "startsWith" and "endsWith" contraints only support "LIKE"  And while it appears that the direct use of  "LIKE" is supported (although undocumented) there is no equivalent pass-thru support for ILIKE. 

I'd like to see this support flow over to mySQL, but that would have to come in the form of

`COLLATE UTF8_GENERAL_CI like '%$search%'`

Or something similar. 