### PR TITLE
[implements #1558] add support for suppress uniqueness warning for composite index

### DIFF
--- a/lib/waterline/utils/query/forge-adapter-error.js
+++ b/lib/waterline/utils/query/forge-adapter-error.js
@@ -214,6 +214,8 @@ module.exports = function forgeAdapterError(err, omen, adapterMethodName, modelI
             }
             // Otherwise track this as an unmatched key.
             else {
+              if (WLModel.suppressWarningForCompositeIndexUniqueness && key && key.split(', ').length > 1) { return; }
+
               unmatchedKeys.push(key);
             }
 


### PR DESCRIPTION
implements #1558, add support for suppress uniqueness warning for composite index.

Add `suppressWarningForCompositeIndexUniqueness` into models config to turn on feature.
```
module.exports.models = {
  migrate: 'alter',
  suppressWarningForCompositeIndexUniqueness: true,
};
```