### PR TITLE
Allow 0 to be a valid UNIX timestamp.

### DIFF
--- a/lib/waterline/utils/query/process-all-records.js
+++ b/lib/waterline/utils/query/process-all-records.js
@@ -221,7 +221,6 @@ module.exports = function processAllRecords(records, meta, modelIdentity, orm) {
           // Do quick, incomplete verification that a valid primary key value was sent back.
           var isProbablyValidPkValue = (
             record[attrName] !== '' &&
-            record[attrName] !== 0 &&
             (
               _.isString(record[attrName]) || _.isNumber(record[attrName])
             )


### PR DESCRIPTION
Issuing console warnings for timestamp of 0 isn't necessary and are sometimes used to represent "unset" programmatically since datetimes must be type 'ref' and 'ref' cannot be null. Removing the if check will allow them to pass through in auto-migrations without spurring messages.