### PR TITLE
PROPOSAL: Update transformer-builder

### DIFF
--- a/lib/waterline/utils/system/transformer-builder.js
+++ b/lib/waterline/utils/system/transformer-builder.js
@@ -194,37 +194,22 @@ Transformation.prototype.serializeValues = function(values) {
 
 Transformation.prototype.unserialize = function(pRecord) {
 
-  // Get the database columns that we'll be transforming into attribute names.
-  var colsToTransform = _.values(this._transformations);
-
-  // Shallow clone the physical record, so that we don't lose any values in cases
-  // where one attribute's name conflicts with another attribute's `columnName`.
-  // (see https://github.com/balderdashy/sails/issues/4079)
-  var copyOfPhysicalRecord = _.clone(pRecord);
-
-  // Remove the values from the pRecord that are set for the columns we're
-  // going to transform.  This ensures that the `columnName` and the
-  // attribute name don't both appear as properties in the final record
-  // (unless there's a conflict as described above).
-  _.each(_.keys(pRecord), function(key) {
-    if (_.contains(colsToTransform, key)) {
-      delete pRecord[key];
-    }
-  });
+  // Only unserialize fields of the pRecord that are in the _transformations
+  let unserializedRecord = {};
 
   // Loop through the keys to transform of this record and reattach them.
   _.each(this._transformations, function(columnName, attrName) {
 
     // If there's no value set for this column name, continue.
-    if (!_.has(copyOfPhysicalRecord, columnName)) {
+    if (!_.has(pRecord, columnName)) {
       return;
     }
 
-    // Otherwise get the value from the cloned record.
-    pRecord[attrName] = copyOfPhysicalRecord[columnName];
+    // Otherwise get the value from the  pRecord.
+    unserializedRecord[attrName] = pRecord[columnName];
 
   });
 
-  // Return the original, mutated record.
-  return pRecord;
+  // Return the new unserialized record.
+  return unserializedRecord;
 };


### PR DESCRIPTION
In the unserialize(), only transform pRecord's columns that match model's attributes. 
Or in other words, skip any fields available in the pRecord that don't match any attribute of the Model.