### PR TITLE
'_id' column fix for archiving with mongodb models and schema: true

### DIFF
--- a/lib/waterline/methods/archive.js
+++ b/lib/waterline/methods/archive.js
@@ -216,6 +216,8 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
       // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
+      var defaultWhereCriteria = query.criteria.where;
+
       //  ╔═╗═╗ ╦╔═╗╔═╗╦ ╦╔╦╗╔═╗  ┌─┐┬┌┐┌┌┬┐  ┌─┐ ┬ ┬┌─┐┬─┐┬ ┬
       //  ║╣ ╔╩╦╝║╣ ║  ║ ║ ║ ║╣   ├┤ ││││ ││  │─┼┐│ │├┤ ├┬┘└┬┘
       //  ╚═╝╩ ╚═╚═╝╚═╝╚═╝ ╩ ╚═╝  └  ┴┘└┘─┴┘  └─┘└└─┘└─┘┴└─ ┴
@@ -240,6 +242,8 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
           });
         });//∞
 
+        query.criteria.where = defaultWhereCriteria;
+
         //  ╔═╗═╗ ╦╔═╗╔═╗╦ ╦╔╦╗╔═╗  ┌─┐┬─┐┌─┐┌─┐┌┬┐┌─┐┌─┐┌─┐┌─┐┬ ┬  ┌─┐ ┬ ┬┌─┐┬─┐┬ ┬
         //  ║╣ ╔╩╦╝║╣ ║  ║ ║ ║ ║╣   │  ├┬┘├┤ ├─┤ │ ├┤ ├┤ ├─┤│  ├─┤  │─┼┐│ │├┤ ├┬┘└┬┘
         //  ╚═╝╩ ╚═╚═╝╚═╝╚═╝ ╩ ╚═╝  └─┘┴└─└─┘┴ ┴ ┴ └─┘└─┘┴ ┴└─┘┴ ┴  └─┘└└─┘└─┘┴└─ ┴
@@ -254,6 +258,8 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
           delete query.criteria.sort;
           delete query.criteria.select;
           delete query.criteria.omit;
+
+          query.criteria.where = defaultWhereCriteria;
 
           //  ╔═╗═╗ ╦╔═╗╔═╗╦ ╦╔╦╗╔═╗  ┌┬┐┌─┐┌─┐┌┬┐┬─┐┌─┐┬ ┬  ┌─┐ ┬ ┬┌─┐┬─┐┬ ┬
           //  ║╣ ╔╩╦╝║╣ ║  ║ ║ ║ ║╣    ││├┤ └─┐ │ ├┬┘│ │└┬┘  │─┼┐│ │├┤ ├┬┘└┬┘


### PR DESCRIPTION
When you try to archive record on mongodb, schema: true and 'id' field name (for default _id mongo key), there occur an error, because 'where' criteria are automatically forging to { where: { _id: 'xxxxxx' }}, what is not allowed for scheme: true, because there is no '_id' field.