### PR TITLE
Add support for JSONB "contains"

### DIFF
--- a/lib/waterline/utils/query/private/normalize-constraint.js
+++ b/lib/waterline/utils/query/private/normalize-constraint.js
@@ -823,6 +823,20 @@ module.exports = function normalizeConstraint (constraintRhs, constraintTarget, 
       }//-•
 
     }//‡
+
+    else if (modifierKind === '@>') {
+      if (attrDef && attrDef.type !== 'json') {
+        throw flaverr('E_CONSTRAINT_NOT_USABLE', new Error(
+          'A `@>` (i.e. JSONB contains-object) modifier cannot be used with a '+
+          'non-JSON attribute (it wouldn\'t make any sense).'
+        ));
+      }
+
+      if (typeof modifier !== 'string') {
+        modifier = JSON.stringify(modifier);
+      }
+    }
+
     //  ┬ ┬┌┐┌┬─┐┌─┐┌─┐┌─┐┌─┐┌┐┌┬┌─┐┌─┐┌┬┐  ┌┬┐┌─┐┌┬┐┬┌─┐┬┌─┐┬─┐
     //  │ ││││├┬┘├┤ │  │ ││ ┬││││┌─┘├┤  ││  ││││ │ │││├┤ │├┤ ├┬┘
     //  └─┘┘└┘┴└─└─┘└─┘└─┘└─┘┘└┘┴└─┘└─┘─┴┘  ┴ ┴└─┘─┴┘┴└  ┴└─┘┴└─


### PR DESCRIPTION
It's not clear if it's currently possible to add adapter-specific modifiers to waterline, but this patch adds support for postgres's JSONB "contains" operator.

Is there a more correct place for this change to be implemented?