### PR TITLE
Fix for selecting specific fields in population for one-to-one relationship

### DIFF
--- a/lib/waterline/utils/query/forge-stage-two-query.js
+++ b/lib/waterline/utils/query/forge-stage-two-query.js
@@ -876,7 +876,7 @@ module.exports = function forgeStageTwoQuery(query, orm) {
         // Otherwise, this simply must be `true`.  Otherwise it's invalid.
         else {
 
-          if (query.populates[populateAttrName] !== true) {
+          if (query.populates[populateAttrName] !== true && (_.isUndefined(query.populates[populateAttrName].select) && _.isUndefined(query.populates[populateAttrName].omit))) {
             throw buildUsageError(
               'E_INVALID_POPULATES',
               'Could not populate `'+populateAttrName+'`.  '+
@@ -894,6 +894,12 @@ module.exports = function forgeStageTwoQuery(query, orm) {
               query.using
             );
           }//-•
+          else {
+            query.populates[populateAttrName] = {
+              select: query.populates[populateAttrName].select? query.populates[populateAttrName].select : undefined,
+              omit: query.populates[populateAttrName].omit? query.populates[populateAttrName].omit : undefined
+            };
+          }
 
         }//>-•
 


### PR DESCRIPTION
Fix for selecting specific fields in population for one-to-one relationship

If there is a population for a one-to-one relationship, we should accept only "select" and "omit" attributes.