### PR TITLE
[patch] Allow populates to use select/omit for singular associations

### DIFF
--- a/lib/waterline/utils/query/forge-stage-two-query.js
+++ b/lib/waterline/utils/query/forge-stage-two-query.js
@@ -862,6 +862,10 @@ module.exports = function forgeStageTwoQuery(query, orm) {
       //  │  ├─┤├┤ │  ├┴┐   │ ├─┤├┤   ╠╦╝╠═╣╚═╗
       //  └─┘┴ ┴└─┘└─┘┴ ┴   ┴ ┴ ┴└─┘  ╩╚═╩ ╩╚═╝
 
+      // we perform criteria normalization for plural ("collection") associations
+      // and *SOME* singular ("model") associations (only allowing `select` or `omit`)
+      var performNormalizeCriteria = false;
+
       // If this is a singular ("model") association, then it should always have
       // an empty dictionary on the RHS.  (For this type of association, there is
       // always either exactly one associated record, or none of them.)
@@ -873,26 +877,34 @@ module.exports = function forgeStageTwoQuery(query, orm) {
         if (_.isEqual(query.populates[populateAttrName], {})) {
           query.populates[populateAttrName] = true;
         }
-        // Otherwise, this simply must be `true`.  Otherwise it's invalid.
+        // Otherwise, this simply must be `true` or the allowed `select`/`omit` clause.  Otherwise it's invalid.
         else {
 
           if (query.populates[populateAttrName] !== true) {
-            throw buildUsageError(
-              'E_INVALID_POPULATES',
-              'Could not populate `'+populateAttrName+'`.  '+
-              'This is a singular ("model") association, which means it never refers to '+
-              'more than _one_ associated record.  So passing in subcriteria (i.e. as '+
-              'the second argument to `.populate()`) is not supported for this association, '+
-              'since it generally wouldn\'t make any sense.  But that\'s the trouble-- it '+
-              'looks like some sort of a subcriteria (or something) _was_ provided!\n'+
-              '(Note that subcriterias consisting ONLY of `omit` or `select` are a special '+
-              'case that _does_ make sense.  This usage will be supported in a future version '+
-              'of Waterline.)\n'+
-              '\n'+
-              'Here\'s what was passed in:\n'+
-              util.inspect(query.populates[populateAttrName], {depth: 5}),
-              query.using
-            );
+
+            // Allow populate for singular associations to only contain a `select` or
+            // `omit` clause.
+            var p = query.populates[populateAttrName];
+            if (_.isObject(p) && !_.isArray(p) && _.size(p)===1 && (_.isArray(p.select) || _.isArray(p.omit))) {
+              // normalization performed below
+              performNormalizeCriteria = true;
+            } else {
+              throw buildUsageError(
+                'E_INVALID_POPULATES',
+                'Could not populate `'+populateAttrName+'`.  '+
+                'This is a singular ("model") association, which means it never refers to '+
+                'more than _one_ associated record.  So passing in subcriteria (i.e. as '+
+                'the second argument to `.populate()`) is not supported for this association, '+
+                'since it generally wouldn\'t make any sense.  But that\'s the trouble-- it '+
+                'looks like some sort of a subcriteria (or something) _was_ provided!\n'+
+                '(Note that subcriterias consisting ONLY of `omit` or `select` are a special '+
+                'case that _does_ make sense and is supported)\n'+
+                '\n'+
+                'Here\'s what was passed in:\n'+
+                util.inspect(query.populates[populateAttrName], {depth: 5}),
+                query.using
+              );
+            }//-•
           }//-•
 
         }//>-•
@@ -901,6 +913,13 @@ module.exports = function forgeStageTwoQuery(query, orm) {
       // Otherwise, this is a plural ("collection") association, so we'll need to
       // validate and fully-normalize the provided subcriteria.
       else {
+
+        // normalization performed below
+        performNormalizeCriteria = true;
+
+      }//</else :: this is a plural ("collection") association>
+
+      if(performNormalizeCriteria) {
 
         // For compatibility, interpet a subcriteria of `true` to mean that there
         // is really no subcriteria at all, and that we should just use the default (`{}`).
@@ -1025,7 +1044,7 @@ module.exports = function forgeStageTwoQuery(query, orm) {
 
 
 
-      }//</else :: this is a plural ("collection") association>
+      }//</else :: if(performNormalizeCriteria)
 
 
     });//</_.each() key in the `populates` dictionary>


### PR DESCRIPTION
Currently the populates clause is allowed for plural ("collection")
associations but disallowed for singular ("model") associations.

This patch allows only a select or an omit for singular associations.