### PR TITLE
Fix .archive() and .archiveOne() when using custom column names

### DIFF
--- a/lib/waterline/methods/archive.js
+++ b/lib/waterline/methods/archive.js
@@ -215,8 +215,6 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
       // Then just leverage those methods here in `.archive()`.
       // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-      console.log('before', query);
-
       //  ╔═╗═╗ ╦╔═╗╔═╗╦ ╦╔╦╗╔═╗  ┌─┐┬┌┐┌┌┬┐  ┌─┐ ┬ ┬┌─┐┬─┐┬ ┬
       //  ║╣ ╔╩╦╝║╣ ║  ║ ║ ║ ║╣   ├┤ ││││ ││  │─┼┐│ │├┤ ├┬┘└┬┘
       //  ╚═╝╩ ╚═╚═╝╚═╝╚═╝ ╩ ╚═╝  └  ┴┘└┘─┴┘  └─┘└└─┘└─┘┴└─ ┴
@@ -245,8 +243,6 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
       var s2qCriteriaForFind = _.cloneDeep(query.criteria);
       WLModel.find(s2qCriteriaForFind, function _afterFinding(err, foundRecords) {
         if (err) { return done(err); }
-
-        console.log('after', query);
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         // FUTURE: as an optimization, fetch records batch-at-a-time

--- a/lib/waterline/methods/archive.js
+++ b/lib/waterline/methods/archive.js
@@ -215,6 +215,7 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
       // Then just leverage those methods here in `.archive()`.
       // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+      console.log('before', query);
 
       //  ╔═╗═╗ ╦╔═╗╔═╗╦ ╦╔╦╗╔═╗  ┌─┐┬┌┐┌┌┬┐  ┌─┐ ┬ ┬┌─┐┬─┐┬ ┬
       //  ║╣ ╔╩╦╝║╣ ║  ║ ║ ║ ║╣   ├┤ ││││ ││  │─┼┐│ │├┤ ├┬┘└┬┘
@@ -222,8 +223,30 @@ module.exports = function archive(/* criteria, explicitCbMaybe, metaContainer */
       // Note that we pass in `meta` here, as well as in the other queries
       // below.  (This ensures we're on the same db connection, provided one
       // was explicitly passed in!)
-      WLModel.find(query.criteria, function _afterFinding(err, foundRecords) {
+      // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      // WARNING:
+      //
+      // Before proceeding with calling an additional model method that relies
+      // on criteria other than the primary .destroy(), we'll want to back up a
+      // copy of our s2q's criteria (`query.criteria`).
+      //
+      // This is important because, in an effort to improve performance,
+      // Waterline methods destructively mutate criteria when forging queries
+      // for use in the adapter(s).  Since we'll be reusing criteria, we need
+      // to insulate ourselves from those destructive changes in case there are
+      // custom column names involved.  (e.g. Mongo's `_id``)
+      //
+      // > While the criteria might contain big crazy stuff for comparing with
+      // > type:ref attributes, a deep clone is the best option we have.
+      //
+      // FUTURE: in s2q forge logic, for "archive" method, reject with an error
+      // if deep refs (non-JSON-serializable data) are discovered in criteria.
+      // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      var s2qCriteriaForFind = _.cloneDeep(query.criteria);
+      WLModel.find(s2qCriteriaForFind, function _afterFinding(err, foundRecords) {
         if (err) { return done(err); }
+
+        console.log('after', query);
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         // FUTURE: as an optimization, fetch records batch-at-a-time

--- a/lib/waterline/utils/query/help-find.js
+++ b/lib/waterline/utils/query/help-find.js
@@ -81,6 +81,8 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
     }
   }//∞
 
+  console.log('during (inside helpFind())', s2q);
+
   // Build an initial stage three query (s3q) from the incoming stage 2 query (s2q).
   var parentQuery = forgeStageThreeQuery({
     stageTwoQuery: s2q,
@@ -88,6 +90,7 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
     transformer: WLModel._transformer,
     originalModels: WLModel.waterline.collections
   });
+  console.log('during (inside helpFind(), the s2q after calling forgeStageThreeQuery)', s2q);
 
   // Expose a reference to the entire set of all WL models available
   // in the current ORM instance.

--- a/lib/waterline/utils/query/help-find.js
+++ b/lib/waterline/utils/query/help-find.js
@@ -81,8 +81,6 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
     }
   }//∞
 
-  console.log('during (inside helpFind())', s2q);
-
   // Build an initial stage three query (s3q) from the incoming stage 2 query (s2q).
   var parentQuery = forgeStageThreeQuery({
     stageTwoQuery: s2q,
@@ -90,7 +88,6 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
     transformer: WLModel._transformer,
     originalModels: WLModel.waterline.collections
   });
-  console.log('during (inside helpFind(), the s2q after calling forgeStageThreeQuery)', s2q);
 
   // Expose a reference to the entire set of all WL models available
   // in the current ORM instance.


### PR DESCRIPTION
Fix bug that was occuring in some cases when using .archive() and .archiveOne() with custom column names; including w/ sails-mongo or sails-disk in the new mongo mode