### PR TITLE
Resolved 'UpdateOne: Validation of encrypted attr'

### DIFF
--- a/lib/waterline/methods/update-one.js
+++ b/lib/waterline/methods/update-one.js
@@ -111,6 +111,12 @@ module.exports = function updateOne(criteria, valuesToSet, explicitCbMaybe, meta
       // This ensures a normalized format.
 
       try {
+        // Skip encryption on first forgeStageTwoQuery
+        // call to prevent encrypted validation errors on
+        // second call: https://github.com/balderdashy/sails/issues/6939
+        query.meta = _.extend({}, query.meta || {}, {
+          skipEncryption: true
+        });
         forgeStageTwoQuery(query, orm);
       } catch (e) {
         switch (e.code) {
@@ -172,13 +178,13 @@ module.exports = function updateOne(criteria, valuesToSet, explicitCbMaybe, meta
 
         // Build a modified shallow clone of the originally-provided `meta` from
         // userland, but that also has `fetch: true` and the private/experimental
-        // flag, `skipEncryption: true`.  For context on the bit about encryption,
+        // flag, `skipEncryption: false`.  For context on the bit about encryption,
         // see: https://github.com/balderdashy/sails/issues/4302#issuecomment-363883885
         // > PLEASE DO NOT RELY ON `skipEncryption` IN YOUR OWN CODE- IT COULD CHANGE
         // > AT ANY TIME AND BREAK YOUR APP OR PLUGIN!
         var modifiedMetaForUpdate = _.extend({}, query.meta || {}, {
           fetch: true,
-          skipEncryption: true
+          skipEncryption: false
         });
 
         var modifiedCriteriaForUpdate = _.omit(query.criteria, ['select', 'omit', 'limit', 'skip', 'sort']);


### PR DESCRIPTION
- Added the skipEncryption:true to the query.meta of the first
forgeStageTwoQuery call and removed it from the second.

Fixes  balderdashy/sails#6939
