### PR TITLE
Run hooks with Model instance as this

### DIFF
--- a/lib/waterline/methods/create-each.js
+++ b/lib/waterline/methods/create-each.js
@@ -204,7 +204,7 @@ module.exports = function createEach( /* newRecords?, explicitCbMaybe?, meta? */
         }//-•
 
         // IWMIH, run the "before" lifecycle callback on each new record.
-        async.each(query.newRecords, WLModel._callbacks.beforeCreate, function(err) {
+        async.each(query.newRecords, WLModel._callbacks.beforeCreate.apply(WLModel), function(err) {
           if (err) { return proceed(err); }
           return proceed(undefined, query);
         });
@@ -429,7 +429,7 @@ module.exports = function createEach( /* newRecords?, explicitCbMaybe?, meta? */
                 return proceed(undefined, transformedRecords);
               }//-•
 
-              async.each(transformedRecords, WLModel._callbacks.afterCreate, function(err) {
+              async.each(transformedRecords, WLModel._callbacks.afterCreate.apply(WLModel), function(err) {
                 if (err) {
                   return proceed(err);
                 }

--- a/lib/waterline/methods/create-each.js
+++ b/lib/waterline/methods/create-each.js
@@ -204,7 +204,9 @@ module.exports = function createEach( /* newRecords?, explicitCbMaybe?, meta? */
         }//-•
 
         // IWMIH, run the "before" lifecycle callback on each new record.
-        async.each(query.newRecords, WLModel._callbacks.beforeCreate.apply(WLModel), function(err) {
+        async.each(query.newRecords, function(newRecord, callback) {
+          WLModel._callbacks.beforeCreate.apply(WLModel, [newRecord, callback]);
+        }, function(err) {
           if (err) { return proceed(err); }
           return proceed(undefined, query);
         });
@@ -429,11 +431,11 @@ module.exports = function createEach( /* newRecords?, explicitCbMaybe?, meta? */
                 return proceed(undefined, transformedRecords);
               }//-•
 
-              async.each(transformedRecords, WLModel._callbacks.afterCreate.apply(WLModel), function(err) {
-                if (err) {
-                  return proceed(err);
-                }
-                return proceed(undefined, transformedRecords);
+              async.each(query.newRecords, function(newRecord, callback) {
+                WLModel._callbacks.beforeCreate.apply(WLModel, [newRecord, callback]);
+              }, function(err) {
+                if (err) { return proceed(err); }
+                return proceed(undefined, query);
               });
 
             })(function _afterPotentiallyRunningAfterLC(err, transformedRecords) {

--- a/lib/waterline/methods/create-each.js
+++ b/lib/waterline/methods/create-each.js
@@ -432,7 +432,7 @@ module.exports = function createEach( /* newRecords?, explicitCbMaybe?, meta? */
               }//-•
 
               async.each(query.newRecords, function(newRecord, callback) {
-                WLModel._callbacks.beforeCreate.apply(WLModel, [newRecord, callback]);
+                WLModel._callbacks.afterCreate.apply(WLModel, [newRecord, callback]);
               }, function(err) {
                 if (err) { return proceed(err); }
                 return proceed(undefined, query);

--- a/lib/waterline/methods/create-each.js
+++ b/lib/waterline/methods/create-each.js
@@ -431,11 +431,11 @@ module.exports = function createEach( /* newRecords?, explicitCbMaybe?, meta? */
                 return proceed(undefined, transformedRecords);
               }//-•
 
-              async.each(query.newRecords, function(newRecord, callback) {
-                WLModel._callbacks.afterCreate.apply(WLModel, [newRecord, callback]);
+              async.each(transformedRecords, function(transformedRecord, callback) {
+                WLModel._callbacks.afterCreate.apply(WLModel, [transformedRecord, callback]);
               }, function(err) {
                 if (err) { return proceed(err); }
-                return proceed(undefined, query);
+                return proceed(undefined, transformedRecords);
               });
 
             })(function _afterPotentiallyRunningAfterLC(err, transformedRecords) {

--- a/lib/waterline/methods/create.js
+++ b/lib/waterline/methods/create.js
@@ -187,10 +187,10 @@ module.exports = function create(newRecord, explicitCbMaybe, metaContainer) {
         }//-•
 
         // IWMIH, run the "before" lifecycle callback.
-        WLModel._callbacks.beforeCreate(query.newRecord, function(err){
+        WLModel._callbacks.beforeCreate.apply(WLModel, [query.newRecord, function(err){
           if (err) { return proceed(err); }
           return proceed(undefined, query);
-        });
+        }]);
 
       })(function _afterPotentiallyRunningBeforeLC(err, query) {
         if (err) {
@@ -360,13 +360,13 @@ module.exports = function create(newRecord, explicitCbMaybe, metaContainer) {
               }//-•
 
               // Otherwise, run it.
-              return WLModel._callbacks.afterCreate(transformedRecord, function(err) {
+              return WLModel._callbacks.afterCreate.apply(WLModel, [transformedRecord, function(err) {
                 if (err) {
                   return proceed(err);
                 }
 
                 return proceed(undefined, transformedRecord);
-              });
+              }]);
 
             })(function _afterPotentiallyRunningAfterLC(err, transformedRecord) {
               if (err) { return done(err); }

--- a/lib/waterline/methods/destroy.js
+++ b/lib/waterline/methods/destroy.js
@@ -213,10 +213,10 @@ module.exports = function destroy(/* criteria, explicitCbMaybe, metaContainer */
         }
 
         // But otherwise, run it.
-        WLModel._callbacks.beforeDestroy(query.criteria, function (err){
+        WLModel._callbacks.beforeDestroy.apply(WLModel, [query.criteria, function (err){
           if (err) { return proceed(err); }
           return proceed(undefined, query);
-        });
+        }]);
 
       })(function _afterRunningBeforeLC(err, query) {
         if (err) {
@@ -533,13 +533,13 @@ module.exports = function destroy(/* criteria, explicitCbMaybe, metaContainer */
                   }
 
                   // Otherwise run it.
-                  WLModel._callbacks.afterDestroy(record, function _afterMaybeRunningAfterDestroyForThisRecord(err) {
+                  WLModel._callbacks.afterDestroy.apply(WLModel, [record, function _afterMaybeRunningAfterDestroyForThisRecord(err) {
                     if (err) {
                       return next(err);
                     }
 
                     return next();
-                  });
+                  }]);
 
                 },// ~∞%°
                 function _afterIteratingOverRecords(err) {

--- a/lib/waterline/methods/update.js
+++ b/lib/waterline/methods/update.js
@@ -219,10 +219,10 @@ module.exports = function update(criteria, valuesToSet, explicitCbMaybe, metaCon
           return proceed(undefined, query);
         }
 
-        WLModel._callbacks.beforeUpdate(query.valuesToSet, function(err){
+        WLModel._callbacks.beforeUpdate.apply(WLModel, [query.valuesToSet, function(err){
           if (err) { return proceed(err); }
           return proceed(undefined, query);
-        });
+        }]);
 
       })(function(err, query) {
         if (err) {
@@ -424,13 +424,13 @@ module.exports = function update(criteria, valuesToSet, explicitCbMaybe, metaCon
               }
 
               // Otherwise run it.
-              WLModel._callbacks.afterUpdate(record, function _afterMaybeRunningAfterUpdateForThisRecord(err) {
+              WLModel._callbacks.afterUpdate.apply(WLModel, [record, function _afterMaybeRunningAfterUpdateForThisRecord(err) {
                 if (err) {
                   return next(err);
                 }
 
                 return next();
-              });
+              }]);
 
             },// ~∞%°
             function _afterIteratingOverRecords(err) {


### PR DESCRIPTION
Implemented option to call hooks 'beforeUpdate', 'afterUpdate', 'beforeCreate', 'afterCreate', 'beforeDestroy', 'afterDestroy', with Model instance and make this point to model instead of a global scope.

This allows to implement common logic in single place (e.g. config/models.js in Sails).