### PR TITLE
handel model meta attribute

### DIFF
--- a/lib/waterline/utils/query/forge-stage-three-query.js
+++ b/lib/waterline/utils/query/forge-stage-three-query.js
@@ -79,7 +79,16 @@ module.exports = function forgeStageThreeQuery(options) {
   //   ║ ╠╦╝╠═╣║║║╚═╗╠╣ ║ ║╠╦╝║║║  │ │└─┐│││││ ┬
   //   ╩ ╩╚═╩ ╩╝╚╝╚═╝╚  ╚═╝╩╚═╩ ╩  └─┘└─┘┴┘└┘└─┘
   s3Q.using = model.tableName;
-
+  
+  if (typeof model.meta.schemaName !== 'undefined'){
+    //meta property only set if query fetch : true
+    if (typeof s3Q.meta !== 'undefined'){
+      //we have to initialize propery of meta
+      s3Q.meta.schemaName = model.meta.schemaName;
+    }else{
+      s3Q.meta = model.meta;
+    }
+  }
 
   //   ██████╗██████╗ ███████╗ █████╗ ████████╗███████╗
   //  ██╔════╝██╔══██╗██╔════╝██╔══██╗╚══██╔══╝██╔════╝


### PR DESCRIPTION
meta attribute is used for sails-postgresql adapter for setting table schemaName (like client.t_order. "client" is the schemaName and "t_order" is the table name).