### PR TITLE
feat: support select/omit projections on populates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Edge
 
 ##### General
+* [ENHANCEMENT] Allow `select`/`omit` projections on populated singular associations (ported from sailscastshq/waterline@414c927).
 * [BUGFIX] Fix .archive() and .archiveOne() when using custom column names  (#1616)
 * [BREAKING] Waterline attribute names must now be [ECMAScript 5.1-compatible variable names](https://github.com/mikermcneil/machinepack-javascript/blob/3786c05388cf49220a6d3b6dbbc1d80312d247ec/machines/validate-varname.js#L41).
   + Custom column names can still be configured to anything, as long as it is supported by the underlying database.

--- a/lib/waterline/utils/query/forge-stage-two-query.js
+++ b/lib/waterline/utils/query/forge-stage-two-query.js
@@ -873,21 +873,20 @@ module.exports = function forgeStageTwoQuery(query, orm) {
         if (_.isEqual(query.populates[populateAttrName], {})) {
           query.populates[populateAttrName] = true;
         }
-        // Otherwise, this simply must be `true`.  Otherwise it's invalid.
+        // Otherwise, ensure this is a supported subcriteria.
         else {
 
-          if (query.populates[populateAttrName] !== true) {
+          if (query.populates[populateAttrName] !== true && !(
+            _.isPlainObject(query.populates[populateAttrName]) &&
+            _.difference(Object.keys(query.populates[populateAttrName]), ['select', 'omit']).length === 0
+          )) {
             throw buildUsageError(
               'E_INVALID_POPULATES',
               'Could not populate `'+populateAttrName+'`.  '+
               'This is a singular ("model") association, which means it never refers to '+
               'more than _one_ associated record.  So passing in subcriteria (i.e. as '+
-              'the second argument to `.populate()`) is not supported for this association, '+
-              'since it generally wouldn\'t make any sense.  But that\'s the trouble-- it '+
-              'looks like some sort of a subcriteria (or something) _was_ provided!\n'+
-              '(Note that subcriterias consisting ONLY of `omit` or `select` are a special '+
-              'case that _does_ make sense.  This usage will be supported in a future version '+
-              'of Waterline.)\n'+
+              'the second argument to `.populate()`) is only supported when specifying `select` '+
+              'or `omit` clauses.  But something else was provided!\n'+
               '\n'+
               'Here\'s what was passed in:\n'+
               util.inspect(query.populates[populateAttrName], {depth: 5}),
@@ -895,6 +894,182 @@ module.exports = function forgeStageTwoQuery(query, orm) {
             );
           }//-•
 
+          if (_.isPlainObject(query.populates[populateAttrName])) {
+
+            if (query.populates[populateAttrName].select && query.populates[populateAttrName].omit) {
+              throw buildUsageError(
+                'E_INVALID_POPULATES',
+                'Could not populate `'+populateAttrName+'`.  '+
+                'This is a singular ("model") association, and while subcriterias consisting '+
+                'ONLY of `omit` or `select` are supported, providing both `select` AND `omit` '+
+                'at the same time is not allowed.\n'+
+                '\n'+
+                'Here\'s what was passed in:\n'+
+                util.inspect(query.populates[populateAttrName], {depth: 5}),
+                query.using
+              );
+            }//-•
+
+            var singularPopulateCriteria = query.populates[populateAttrName];
+            var AssociatedModel = getModel(otherModelIdentity, orm);
+
+            if (!_.isUndefined(singularPopulateCriteria.select)) {
+
+              if (!_.isArray(singularPopulateCriteria.select)) {
+                throw buildUsageError(
+                  'E_INVALID_POPULATES',
+                  'Could not populate `'+populateAttrName+'`.  '+
+                  'The provided subcriteria contains an invalid `select` clause.  '+
+                  'If set, `select` must be an array of attribute names (strings).  '+
+                  'But instead, got: '+util.inspect(singularPopulateCriteria.select, { depth: 5 }),
+                  query.using
+                );
+              }
+
+              if (!_.isEqual(singularPopulateCriteria.select, ['*'])) {
+
+                if (AssociatedModel.hasSchema === false) {
+                  throw buildUsageError(
+                    'E_INVALID_POPULATES',
+                    'Could not populate `'+populateAttrName+'`.  '+
+                    'The associated model (`'+otherModelIdentity+'`) is declared `schema: false`, '+
+                    'so using a custom `select` clause within a populate subcriteria is not supported.',
+                    query.using
+                  );
+                }
+
+                _.each(singularPopulateCriteria.select, function (attrNameToKeep) {
+
+                  if (!_.isString(attrNameToKeep)) {
+                    throw buildUsageError(
+                      'E_INVALID_POPULATES',
+                      'Could not populate `'+populateAttrName+'`.  '+
+                      'The `select` clause contains an item that is not a string: '+
+                      util.inspect(attrNameToKeep, { depth: 5 })+'.',
+                      query.using
+                    );
+                  }
+
+                  var referencedAttrDef;
+                  try {
+                    referencedAttrDef = getAttribute(attrNameToKeep, otherModelIdentity, orm);
+                  } catch (err) {
+                    switch (err.code) {
+                      case 'E_ATTR_NOT_REGISTERED':
+                        throw buildUsageError(
+                          'E_INVALID_POPULATES',
+                          'Could not populate `'+populateAttrName+'`.  '+
+                          'The `select` clause references `'+attrNameToKeep+'`, which is not a recognized '+
+                          'attribute in the associated model (`'+otherModelIdentity+'`).',
+                          query.using
+                        );
+                      default:
+                        throw err;
+                    }
+                  }
+
+                  if (referencedAttrDef && referencedAttrDef.collection) {
+                    throw buildUsageError(
+                      'E_INVALID_POPULATES',
+                      'Could not populate `'+populateAttrName+'`.  '+
+                      'The `select` clause references `'+attrNameToKeep+'`, but that is a plural ("collection") '+
+                      'association.  You can only populate plural associations, not explicitly `select` them.',
+                      query.using
+                    );
+                  }
+
+                });//</ each attrNameToKeep >
+
+                if (!_.contains(singularPopulateCriteria.select, AssociatedModel.primaryKey)) {
+                  singularPopulateCriteria.select.push(AssociatedModel.primaryKey);
+                }
+
+                singularPopulateCriteria.select = _.uniq(singularPopulateCriteria.select);
+
+              }//>-• (not ['*'])
+
+            }//>-• select provided
+
+            if (!_.isUndefined(singularPopulateCriteria.omit)) {
+
+              if (!_.isArray(singularPopulateCriteria.omit)) {
+                throw buildUsageError(
+                  'E_INVALID_POPULATES',
+                  'Could not populate `'+populateAttrName+'`.  '+
+                  'The provided subcriteria contains an invalid `omit` clause.  '+
+                  'If set, `omit` must be an array of attribute names (strings).  '+
+                  'But instead, got: '+util.inspect(singularPopulateCriteria.omit, { depth: 5 }),
+                  query.using
+                );
+              }
+
+              if (AssociatedModel.hasSchema === false) {
+                throw buildUsageError(
+                  'E_INVALID_POPULATES',
+                  'Could not populate `'+populateAttrName+'`.  '+
+                  'Cannot use an `omit` clause in the populate subcriteria because the associated model '+
+                  '(`'+otherModelIdentity+'`) is declared `schema: false`.',
+                  query.using
+                );
+              }
+
+              _.each(singularPopulateCriteria.omit, function (attrNameToOmit) {
+
+                if (!_.isString(attrNameToOmit)) {
+                  throw buildUsageError(
+                    'E_INVALID_POPULATES',
+                    'Could not populate `'+populateAttrName+'`.  '+
+                    'The `omit` clause contains an item that is not a string: '+
+                    util.inspect(attrNameToOmit, { depth: 5 })+'.',
+                    query.using
+                  );
+                }
+
+                if (attrNameToOmit === AssociatedModel.primaryKey) {
+                  throw buildUsageError(
+                    'E_INVALID_POPULATES',
+                    'Could not populate `'+populateAttrName+'`.  '+
+                    'The `omit` clause attempts to omit the primary key (`'+AssociatedModel.primaryKey+'`) '+
+                    'of the associated model (`'+otherModelIdentity+'`), but that is not allowed.',
+                    query.using
+                  );
+                }
+
+                var referencedAttrToOmit;
+                try {
+                  referencedAttrToOmit = getAttribute(attrNameToOmit, otherModelIdentity, orm);
+                } catch (err) {
+                  switch (err.code) {
+                    case 'E_ATTR_NOT_REGISTERED':
+                      throw buildUsageError(
+                        'E_INVALID_POPULATES',
+                        'Could not populate `'+populateAttrName+'`.  '+
+                        'The `omit` clause references `'+attrNameToOmit+'`, which is not a recognized '+
+                        'attribute in the associated model (`'+otherModelIdentity+'`).',
+                        query.using
+                      );
+                    default:
+                      throw err;
+                  }
+                }
+
+                if (referencedAttrToOmit && referencedAttrToOmit.collection) {
+                  throw buildUsageError(
+                    'E_INVALID_POPULATES',
+                    'Could not populate `'+populateAttrName+'`.  '+
+                    'The `omit` clause references `'+attrNameToOmit+'`, but that is a plural ("collection") '+
+                    'association.  Plural associations are virtual attributes and cannot be omitted this way.',
+                    query.using
+                  );
+                }
+
+              });//</ each attrNameToOmit >
+
+              singularPopulateCriteria.omit = _.uniq(singularPopulateCriteria.omit);
+
+            }//>-• omit provided
+
+          }//>-• plain object subcriteria
         }//>-•
 
       }

--- a/lib/waterline/utils/query/help-find.js
+++ b/lib/waterline/utils/query/help-find.js
@@ -67,6 +67,67 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
   // Set up a few, common local vars for convenience / familiarity.
   var orm = WLModel.waterline;
 
+  // Keep a deep copy of the original populate instructions so we can
+  // reference things like `select`/`omit` later, even after the stage
+  // three query builder mutates the stage two query in-place.
+  var originalPopulates = _.cloneDeep(s2q.populates || {});
+
+  // Helper: apply select/omit projection directives to populated records.
+  // Mutates the provided record(s) in-place.
+  function _applyPopulateProjection(populateAlias, childModel, value) {
+    if (!value || !childModel) {
+      return;
+    }
+
+    var populateInstruction = originalPopulates && originalPopulates[populateAlias];
+
+    if (!populateInstruction || !_.isPlainObject(populateInstruction)) {
+      return;
+    }
+
+    var selectClause = _.isArray(populateInstruction.select) ? populateInstruction.select : null;
+    var omitClause = _.isArray(populateInstruction.omit) ? populateInstruction.omit : null;
+
+    var hasExplicitSelect = selectClause && !_.isEqual(selectClause, ['*']);
+    var hasExplicitOmit = omitClause && omitClause.length > 0;
+
+    if (!hasExplicitSelect && !hasExplicitOmit) {
+      return;
+    }
+
+    selectClause = hasExplicitSelect ? _.clone(selectClause) : selectClause;
+    omitClause = hasExplicitOmit ? _.clone(omitClause) : omitClause;
+
+    function projectRecord(record) {
+      if (!record || !_.isPlainObject(record)) {
+        return;
+      }
+
+      var allowedAttrNames = hasExplicitSelect ? _.uniq(selectClause.concat([childModel.primaryKey])) : _.keys(record);
+
+      if (hasExplicitOmit) {
+        allowedAttrNames = _.difference(allowedAttrNames, omitClause);
+      }
+
+      var allowedAttrSet = {};
+      _.each(allowedAttrNames, function(attrName) {
+        allowedAttrSet[attrName] = true;
+      });
+
+      _.each(_.keys(record), function(attrName) {
+        if (!allowedAttrSet[attrName]) {
+          delete record[attrName];
+        }
+      });
+    }
+
+    if (_.isArray(value)) {
+      _.each(value, projectRecord);
+    } else {
+      projectRecord(value);
+    }
+  }
+
   // Keep track of any populates which were explicitly set to `false`.
   // (This is a special indicator that FS2Q adds when a particular subcriteria
   // turns out to be a no-op.  This is important so that we make sure to still
@@ -686,6 +747,7 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
             }
 
             record[key] = WLChildModel._transformer.unserialize(record[key]);
+            _applyPopulateProjection(key, WLChildModel, record[key]);
             return;
           }//-•
 
@@ -712,6 +774,8 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
           } else {
             record[key] = transformedChildRecords;
           }
+
+          _applyPopulateProjection(key, WLChildModel, record[key]);
 
           // If `undefined` is specified explicitly, use `null` instead.
           if (_.isUndefined(record[key])) {

--- a/test/unit/query/associations/populateArray.js
+++ b/test/unit/query/associations/populateArray.js
@@ -3,10 +3,11 @@ var Waterline = require('../../../../lib/waterline');
 
 describe('Collection Query ::', function() {
   describe('specific populated associations ::', function() {
+    var waterline;
     var Car;
 
     before(function(done) {
-      var waterline = new Waterline();
+      waterline = new Waterline();
       var collections = {};
 
       collections.user = Waterline.Model.extend({
@@ -68,20 +69,22 @@ describe('Collection Query ::', function() {
       waterline.registerModel(collections.car);
       waterline.registerModel(collections.ticket);
 
-      // Fixture Adapter Def
       var adapterDef = {
         identity: 'foo',
         find: function(con, query, cb) {
-          if(query.using === 'user') {
+          if (query.using === 'user') {
             return cb(null, [{ id: 1, car: 1, name: 'John Doe' }]);
           }
 
-          if(query.using === 'car') {
+          if (query.using === 'car') {
             return cb(null, [{ id: 1, foobar: 1, tickets: [1, 2]}]);
           }
 
-          if(query.using === 'ticket') {
-            return cb(null, [{ id: 1, reason: 'red light', car:1}, { id: 2, reason: 'Parking in a disabled space', car: 1 }]);
+          if (query.using === 'ticket') {
+            return cb(null, [
+              { id: 1, reason: 'red light', car: 1 },
+              { id: 2, reason: 'Parking in a disabled space', car: 1 }
+            ]);
           }
 
           return cb();
@@ -89,7 +92,7 @@ describe('Collection Query ::', function() {
       };
 
       var connections = {
-        'foo': {
+        foo: {
           adapter: 'foobar'
         }
       };
@@ -100,11 +103,20 @@ describe('Collection Query ::', function() {
         }
 
         Car = orm.collections.car;
-
         return done();
       });
     });
 
+    after(function(done) {
+      if (!waterline) {
+        return done();
+      }
+
+      waterline.teardown(function() {
+        waterline = null;
+        return done();
+      });
+    });
 
     it('should populate all related collections', function(done) {
       Car.find()
@@ -120,6 +132,407 @@ describe('Collection Query ::', function() {
         assert(car[0].tickets);
         assert(car[0].tickets[0].car);
         assert(car[0].tickets[1].car);
+        return done();
+      });
+    });
+
+    it('should allow populate with select subcriteria for singular associations', function(done) {
+      Car.find()
+      .populate('driver', {
+        select: ['name']
+      })
+      .exec(function(err, car) {
+        if (err) {
+          return done(err);
+        }
+
+        assert(car[0].driver);
+        assert.strictEqual(typeof car[0].driver.name, 'string');
+        assert.strictEqual(typeof car[0].driver.id, 'number');
+        assert.strictEqual(Object.keys(car[0].driver).length, 2);
+        return done();
+      });
+    });
+
+    it('should allow populate with omit subcriteria for singular associations', function(done) {
+      Car.find()
+      .populate('driver', {
+        omit: ['car']
+      })
+      .exec(function(err, car) {
+        if (err) {
+          return done(err);
+        }
+
+        assert(car[0].driver);
+        assert.strictEqual(typeof car[0].driver.name, 'string');
+        assert.strictEqual(typeof car[0].driver.id, 'number');
+        assert.strictEqual(car[0].driver.car, undefined);
+        return done();
+      });
+    });
+
+    it('should allow populate with empty object (converts to true)', function(done) {
+      Car.find()
+      .populate('driver', {})
+      .exec(function(err, car) {
+        if (err) {
+          return done(err);
+        }
+
+        assert(car[0].driver);
+        assert.strictEqual(typeof car[0].driver.name, 'string');
+        return done();
+      });
+    });
+
+    it('should throw error when both select and omit are provided together', function(done) {
+      Car.find()
+      .populate('driver', {
+        select: ['name'],
+        omit: ['id']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('providing both `select` AND `omit`') > -1);
+        return done();
+      });
+    });
+  });
+
+  describe('populate subcriteria validation errors ::', function() {
+    var waterline;
+    var Holder;
+
+    before(function(done) {
+      waterline = new Waterline();
+      var collections = {};
+
+      collections.pet = Waterline.Model.extend({
+        identity: 'pet',
+        datastore: 'foo',
+        primaryKey: 'id',
+        attributes: {
+          id: {
+            type: 'number'
+          },
+          name: {
+            type: 'string'
+          },
+          owner: {
+            model: 'buddy'
+          }
+        }
+      });
+
+      collections.buddy = Waterline.Model.extend({
+        identity: 'buddy',
+        datastore: 'foo',
+        primaryKey: 'id',
+        attributes: {
+          id: {
+            type: 'number'
+          },
+          name: {
+            type: 'string'
+          },
+          nickname: {
+            type: 'string'
+          },
+          pets: {
+            collection: 'pet',
+            via: 'owner'
+          }
+        }
+      });
+
+      collections.holder = Waterline.Model.extend({
+        identity: 'holder',
+        datastore: 'foo',
+        primaryKey: 'id',
+        attributes: {
+          id: {
+            type: 'number'
+          },
+          buddy: {
+            model: 'buddy'
+          }
+        }
+      });
+
+      waterline.registerModel(collections.holder);
+      waterline.registerModel(collections.buddy);
+      waterline.registerModel(collections.pet);
+
+      var adapterDef = {
+        identity: 'foo',
+        find: function(con, query, cb) {
+          if (query.using === 'holder') {
+            return cb(null, [{ id: 1, buddy: 1 }]);
+          }
+
+          if (query.using === 'buddy') {
+            return cb(null, [{ id: 1, name: 'Buddy One', nickname: 'B', pets: [] }]);
+          }
+
+          if (query.using === 'pet') {
+            return cb(null, []);
+          }
+
+          return cb();
+        }
+      };
+
+      var connections = {
+        foo: {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, datastores: connections }, function(err, orm) {
+        if (err) {
+          return done(err);
+        }
+
+        Holder = orm.collections.holder;
+        return done();
+      });
+    });
+
+    after(function(done) {
+      if (!waterline) {
+        return done();
+      }
+
+      waterline.teardown(function() {
+        waterline = null;
+        return done();
+      });
+    });
+
+    it('should error when populate select clause is not an array', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        select: 'name'
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('invalid `select` clause') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate select clause contains a non-string', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        select: ['name', 5]
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('not a string') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate select clause references an unknown attribute', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        select: ['name', 'age']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('not a recognized attribute') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate select clause references a collection attribute', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        select: ['name', 'pets']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('plural ("collection") association') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate omit clause is not an array', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        omit: 'nickname'
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('invalid `omit` clause') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate omit clause contains a non-string', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        omit: [3]
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('not a string') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate omit clause references an unknown attribute', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        omit: ['age']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('not a recognized attribute') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate omit clause references the associated model primary key', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        omit: ['id']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('primary key') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate omit clause references a collection attribute', function(done) {
+      Holder.find()
+      .populate('buddy', {
+        omit: ['pets']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('plural ("collection") association') > -1);
+        return done();
+      });
+    });
+  });
+
+  describe('populate subcriteria validation with schema false associated model ::', function() {
+    var waterline;
+    var Haunter;
+
+    before(function(done) {
+      waterline = new Waterline();
+      var collections = {};
+
+      collections.ghost = Waterline.Model.extend({
+        identity: 'ghost',
+        datastore: 'foo',
+        primaryKey: 'id',
+        schema: false,
+        attributes: {
+          id: {
+            type: 'number'
+          },
+          name: {
+            type: 'string'
+          }
+        }
+      });
+
+      collections.haunter = Waterline.Model.extend({
+        identity: 'haunter',
+        datastore: 'foo',
+        primaryKey: 'id',
+        attributes: {
+          id: {
+            type: 'number'
+          },
+          friend: {
+            model: 'ghost'
+          }
+        }
+      });
+
+      waterline.registerModel(collections.haunter);
+      waterline.registerModel(collections.ghost);
+
+      var adapterDef = {
+        identity: 'foo',
+        find: function(con, query, cb) {
+          if (query.using === 'haunter') {
+            return cb(null, [{ id: 1, friend: 1 }]);
+          }
+
+          if (query.using === 'ghost') {
+            return cb(null, [{ id: 1, name: 'Boo' }]);
+          }
+
+          return cb();
+        }
+      };
+
+      var connections = {
+        foo: {
+          adapter: 'foobar'
+        }
+      };
+
+      waterline.initialize({ adapters: { foobar: adapterDef }, datastores: connections }, function(err, orm) {
+        if (err) {
+          return done(err);
+        }
+
+        Haunter = orm.collections.haunter;
+        return done();
+      });
+    });
+
+    after(function(done) {
+      if (!waterline) {
+        return done();
+      }
+
+      waterline.teardown(function() {
+        waterline = null;
+        return done();
+      });
+    });
+
+    it('should error when populate select clause is used with schema false associated model', function(done) {
+      Haunter.find()
+      .populate('friend', {
+        select: ['name']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('declared `schema: false`') > -1);
+        return done();
+      });
+    });
+
+    it('should error when populate omit clause is used with schema false associated model', function(done) {
+      Haunter.find()
+      .populate('friend', {
+        omit: ['name']
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.code, 'E_INVALID_POPULATES');
+        assert(err.message.indexOf('declared `schema: false`') > -1);
         return done();
       });
     });


### PR DESCRIPTION
## Summary

- teach  to snapshot the original populate instructions and apply the requested  /  projection after unserializing populated child records; this keeps adapter quirks from leaking extra attributes
- allow singular () populates to specify  / ; we validate the shapes, require array syntax, auto-include the child PK, reject unknown / collection attributes, and block custom projections when the associated model is 
- build out regression coverage for the happy path and every new  error branch (bad types, unknown fields, collection / PK references, schema:false models), derived from sailscastshq/waterline@414c927590893a5eefa632f92cbed1f0b3d75d42

## Why

Waterline already supports  /  on top-level criteria, but populated singular associations silently ignored those directives. Adapters that don’t implement column-level projections returned fully hydrated child rows, so API users had no reliable way to trim sensitive attributes out of populated associations.
The validation code also rejected otherwise reasonable populate subcriteria, making it impossible to express  /  even if we applied them ourselves.

This change brings singular populates up to parity with top-level projections, keeps adapters honest, and documents the exact set of error cases developers should expect when they misuse the feature.

## How

1. Capture the original  dictionary in , then run a tiny projector over every populated child record once we’ve transformed column names back into attribute names.
2. Extend the singular-attribute normalization branch in  so that:
   - only , , or  are accepted
   - the arrays contain strings that resolve to real attributes on the associated model
   - the associated model’s primary key remains selected
   - schema:false associated models continue to forbid custom projections
3. Port the sailscastshq test additions and expand them to exercise every failure mode (non-arrays, non-strings, unknown attributes, collection attributes, schema:false usage, PK omission).

## Testing

- npm test